### PR TITLE
ci: unify lint with pre-commit action and add caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,25 +24,24 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          shared-key: "rust-lint"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --dev
 
-      - name: Ruff check
-        run: uv run ruff check src/ tests/
-
-      - name: Ruff format check
-        run: uv run ruff format --check src/ tests/
-
-      - name: Cargo fmt check
-        run: cargo fmt --manifest-path rust/Cargo.toml --check
-
-      - name: Cargo clippy
-        run: cargo clippy --manifest-path rust/Cargo.toml -- -D warnings
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
 
   build:
     name: Build & Unit Tests
@@ -53,10 +52,18 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          shared-key: "rust-build"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --dev
@@ -91,10 +98,18 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          shared-key: "rust-build"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,10 @@ repos:
         language: system
         types: [rust]
         pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --manifest-path rust/Cargo.toml -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -918,6 +918,7 @@ impl PyClient {
     }
 
     /// Create a new role with the given privileges.
+    #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (role, privileges, policy=None, whitelist=None, read_quota=0, write_quota=0))]
     fn admin_create_role(
         &self,
@@ -1333,6 +1334,7 @@ impl PyClient {
     }
 
     /// Internal helper for index creation
+    #[allow(clippy::too_many_arguments)]
     fn create_index(
         &self,
         py: Python<'_>,

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -37,16 +37,19 @@ enum Predicate {
         val: i64,
         col_type: i32,
     },
+    #[allow(dead_code)]
     GeoWithinRegion {
         bin: String,
         geojson: String,
     },
+    #[allow(dead_code)]
     GeoWithinRadius {
         bin: String,
         lat: f64,
         lng: f64,
         radius: f64,
     },
+    #[allow(dead_code)]
     GeoContainsPoint {
         bin: String,
         geojson: String,


### PR DESCRIPTION
## Summary
- pre-commit에 cargo-clippy 훅 추가하여 로컬/CI 린트 검사 일치
- CI lint job을 `pre-commit/action@v3.0.1`로 통합 (개별 스텝 4개 제거)
- 전체 job에 Rust 컴파일 캐시(`Swatinem/rust-cache@v2`) 및 uv 패키지 캐시 추가
- clippy 경고 수정 (dead_code, too_many_arguments)

## Test plan
- [x] `pre-commit run --all-files` 로컬 통과 확인
- [ ] CI 파이프라인에서 pre-commit/action 정상 실행 확인
- [ ] 두 번째 CI 실행부터 Rust cache hit 확인