### PR TITLE
fix: use uvx for pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        run: uvx pre-commit run --all-files
 
   build:
     name: Build & Unit Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = []
 [project.optional-dependencies]
 docs = ["mkdocs-material"]
 bench = ["aerospike"]
-dev = ["pytest", "pytest-asyncio", "ruff", "pre-commit", "maturin>=1.9,<2"]
+dev = ["pytest", "pytest-asyncio", "ruff", "maturin>=1.9,<2"]
 
 [build-system]
 requires = ["maturin>=1.9,<2"]


### PR DESCRIPTION
## Summary
- CI lint job에서 `pre-commit/action@v3.0.1` → `uvx pre-commit run --all-files`로 변경
  - uv venv에 pip이 없어서 action이 실패하는 문제 해결
- dev 의존성에서 `pre-commit` 제거 (system/uvx로 사용)