### PR TITLE
fix: resolve maturin build failure in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,10 +66,10 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --no-install-project
 
       - name: Build
-        run: uv run maturin develop
+        run: uv run maturin develop --uv
 
       - name: Unit tests
         run: uv run pytest tests/unit/ -v
@@ -112,10 +112,10 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --no-install-project
 
       - name: Build
-        run: uv run maturin develop
+        run: uv run maturin develop --uv
 
       - name: Wait for Aerospike
         run: |


### PR DESCRIPTION
## Summary
- `uv sync --dev`에 `--no-install-project` 추가하여 maturin 순환 의존 문제 해결
- `maturin develop`에 `--uv` 플래그 추가하여 uv 기반 wheel 설치 사용
- build, integration job 모두 동일하게 수정

## Test plan
- [ ] CI build job 성공 확인
- [ ] CI integration job 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)