### PR TITLE
fix: add --no-project to uv run to prevent auto project sync

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --no-install-project
 
       - name: Run pre-commit
         run: uvx pre-commit run --all-files
@@ -69,10 +69,10 @@ jobs:
         run: uv sync --dev --no-install-project
 
       - name: Build
-        run: uv run maturin develop --uv
+        run: uv run --no-project maturin develop --uv
 
       - name: Unit tests
-        run: uv run pytest tests/unit/ -v
+        run: uv run --no-project pytest tests/unit/ -v
 
   integration:
     name: Integration Tests
@@ -115,12 +115,12 @@ jobs:
         run: uv sync --dev --no-install-project
 
       - name: Build
-        run: uv run maturin develop --uv
+        run: uv run --no-project maturin develop --uv
 
       - name: Wait for Aerospike
         run: |
           for i in $(seq 1 30); do
-            if uv run python -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1',3000)); s.close()"; then
+            if uv run --no-project python -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1',3000)); s.close()"; then
               echo "Aerospike is ready"
               break
             fi
@@ -129,4 +129,4 @@ jobs:
           done
 
       - name: Run all tests
-        run: uv run pytest tests/ -v
+        run: uv run --no-project pytest tests/ -v


### PR DESCRIPTION
## Summary
- 모든 `uv run` 호출에 `--no-project` 플래그 추가
- `uv run`은 명령 실행 전 자동으로 프로젝트를 sync하는데, 이때 build-system의 maturin을 spawn하려다 `No such file or directory` 에러 발생
- `--no-project`로 auto-sync를 비활성화하여 `maturin develop`가 별도로 빌드를 처리하도록 함
- lint job의 `uv sync`에도 `--no-install-project` 추가 (동일 문제 예방)

## Test plan
- [ ] CI build job 성공 확인
- [ ] CI integration job 성공 확인
- [ ] CI lint job 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)