### PR TITLE
fix: move dev deps to [dependency-groups] so uv sync --dev works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = []
 [project.optional-dependencies]
 docs = ["mkdocs-material"]
 bench = ["aerospike"]
+
+[dependency-groups]
 dev = ["pytest", "pytest-asyncio", "ruff", "maturin>=1.9,<2"]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -28,26 +28,32 @@ source = { editable = "." }
 bench = [
     { name = "aerospike" },
 ]
+docs = [
+    { name = "mkdocs-material" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "maturin" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
-docs = [
-    { name = "mkdocs-material" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "aerospike", marker = "extra == 'bench'" },
-    { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.9,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "ruff", marker = "extra == 'dev'" },
 ]
-provides-extras = ["bench", "dev", "docs"]
+provides-extras = ["bench", "docs"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "maturin", specifier = ">=1.9,<2" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
 
 [[package]]
 name = "babel"


### PR DESCRIPTION
## Summary
- `[project.optional-dependencies].dev` → `[dependency-groups].dev`로 이전
- **근본 원인**: `uv sync --dev`는 `[dependency-groups].dev`를 참조하지만, dev 패키지가 `[project.optional-dependencies].dev`에 선언되어 있어서 maturin이 venv에 설치되지 않았음
- 로컬 검증 완료: `uv sync --dev --no-install-project` → maturin 설치됨 → `uv run --no-project maturin develop --uv` 성공 → unit tests 통과

## Test plan
- [x] 로컬: `uv sync --dev --no-install-project` 후 `.venv/bin/maturin` 존재 확인
- [x] 로컬: `uv run --no-project maturin develop --uv` 빌드 성공
- [x] 로컬: `uv run --no-project pytest tests/unit/ -v` 7 passed
- [ ] CI build job 성공 확인
- [ ] CI integration job 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)