### PR TITLE
fix: remove UV_SYSTEM_PYTHON=1 causing maturin --uv to fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  UV_SYSTEM_PYTHON: 1
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- 전역 `UV_SYSTEM_PYTHON=1` 환경변수 제거
- **원인**: `maturin develop --uv`가 내부적으로 uv를 호출할 때 `UV_SYSTEM_PYTHON=1`로 인해 `--system` 플래그가 활성화되어, uv 관리 Python(externally managed)에 wheel 설치를 시도하다 실패
- `setup-uv` + `uv sync`가 자동으로 venv을 생성/사용하므로 `UV_SYSTEM_PYTHON`은 불필요

## Test plan
- [ ] CI build job 성공 확인
- [ ] CI integration job 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)