### PR TITLE
refactor: extract shared helpers and replace once_cell with std LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,6 @@ dependencies = [
  "aerospike",
  "aerospike-core",
  "futures",
- "once_cell",
  "pyo3",
  "pyo3-async-runtimes",
  "tokio",
@@ -1289,18 +1288,18 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,4 +14,3 @@ aerospike = { git = "https://github.com/aerospike/aerospike-client-rust.git", ta
 aerospike-core = { git = "https://github.com/aerospike/aerospike-client-rust.git", tag = "v2.0.0-alpha.9" }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-once_cell = "1"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,7 @@ mod errors;
 mod operations;
 mod policy;
 pub mod query;
+mod record_helpers;
 mod runtime;
 mod types;
 

--- a/rust/src/record_helpers.rs
+++ b/rust/src/record_helpers.rs
@@ -1,0 +1,50 @@
+use aerospike_core::BatchRecord;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyTuple};
+
+use crate::types::key::key_to_py;
+use crate::types::value::value_to_py;
+
+/// Convert Vec<BatchRecord> to Python list of (key, meta, bins) tuples.
+pub fn batch_records_to_py(py: Python<'_>, results: &[BatchRecord]) -> PyResult<PyObject> {
+    let py_list = PyList::empty(py);
+    for br in results {
+        let key_py = key_to_py(py, &br.key)?;
+        match &br.record {
+            Some(record) => {
+                let meta = record_to_meta(py, record)?;
+                let bins = PyDict::new(py);
+                for (name, value) in &record.bins {
+                    bins.set_item(name, value_to_py(py, value)?)?;
+                }
+                let tuple = PyTuple::new(py, [key_py, meta, bins.into_any().unbind()])?;
+                py_list.append(tuple)?;
+            }
+            None => {
+                let tuple = PyTuple::new(py, [key_py, py.None(), py.None()])?;
+                py_list.append(tuple)?;
+            }
+        }
+    }
+    Ok(py_list.into_any().unbind())
+}
+
+/// Extract meta dict from a Record.
+pub fn record_to_meta(py: Python<'_>, record: &aerospike_core::Record) -> PyResult<PyObject> {
+    let meta = PyDict::new(py);
+    meta.set_item("gen", record.generation)?;
+    let ttl: u32 = record
+        .time_to_live()
+        .map(|d| d.as_secs() as u32)
+        .unwrap_or(0xFFFFFFFF_u32);
+    meta.set_item("ttl", ttl)?;
+    Ok(meta.into_any().unbind())
+}
+
+/// Extract meta dict from a BatchRecord (for exists_many).
+pub fn batch_record_meta(py: Python<'_>, br: &BatchRecord) -> PyObject {
+    match &br.record {
+        Some(record) => record_to_meta(py, record).unwrap_or_else(|_| py.None()),
+        None => py.None(),
+    }
+}

--- a/rust/src/runtime.rs
+++ b/rust/src/runtime.rs
@@ -1,6 +1,6 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-pub static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
## Summary
- **DRY 개선**: `client.rs`와 `async_client.rs`에 중복되어 있던 `batch_records_to_py`, `record_to_meta`, `batch_record_meta` 헬퍼 함수를 새로운 `record_helpers.rs` 모듈로 추출
- **의존성 감소**: `once_cell::sync::Lazy`를 Rust 1.80에서 stable된 `std::sync::LazyLock`으로 교체하고 `once_cell` 직접 의존성 제거
- **중복 제거**: `client.rs`의 `exists()`와 `operate_ordered()` 메서드에서 TTL/meta 계산 로직이 인라인으로 중복되어 있던 것을 공유 함수로 통합

## Changes
| File | Change |
|------|--------|
| `rust/src/record_helpers.rs` | **NEW** - 공유 record/batch 헬퍼 모듈 |
| `rust/src/client.rs` | 중복 헬퍼 제거, 공유 모듈 사용 (-55 lines) |
| `rust/src/async_client.rs` | 중복 헬퍼 제거, 공유 모듈 사용 (-43 lines) |
| `rust/src/runtime.rs` | `once_cell::Lazy` → `std::sync::LazyLock` |
| `rust/Cargo.toml` | `once_cell` 의존성 제거 |
| `rust/src/lib.rs` | `record_helpers` 모듈 등록 |

**Net: -52 lines** (69 additions, 121 deletions)

## Test plan
- [x] `maturin develop` 빌드 성공
- [x] `pytest tests/unit/ -v` 7개 테스트 전부 통과
- [ ] CI 통합 테스트 확인