### PR TITLE
docs: comprehensive documentation update for PR #14 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # aerospike-py
 
 [![CI](https://github.com/KimSoungRyoul/aerospike-py/actions/workflows/ci.yaml/badge.svg)](https://github.com/KimSoungRyoul/aerospike-py/actions/workflows/ci.yaml)
-[![Python](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org/)
-[![PyO3](https://img.shields.io/badge/PyO3-0.23-green.svg)](https://pyo3.rs/)
+[![PyO3](https://img.shields.io/badge/PyO3-0.28-green.svg)](https://pyo3.rs/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 Aerospike Python Client built with PyO3 + Rust. Drop-in replacement for [aerospike-client-python](https://github.com/aerospike/aerospike-client-python) powered by the [Aerospike Rust Client v2](https://github.com/aerospike/aerospike-client-rust).
@@ -12,6 +12,10 @@ Aerospike Python Client built with PyO3 + Rust. Drop-in replacement for [aerospi
 
 - Sync and Async (`AsyncClient`) API
 - CRUD, Batch, Query/Scan, UDF, Admin, Index, Truncate
+- **CDT List Operations** - 31 atomic list operations via `list_operations`
+- **CDT Map Operations** - 27 atomic map operations via `map_operations`
+- **Expression Filters** - Server-side filtering (Server 5.2+) via `exp`
+- **Context Manager** - `with` statement support for both `Client` and `AsyncClient`
 - Full type stubs (`.pyi`) for IDE autocompletion
 - 130+ tests (unit + integration + scenario)
 
@@ -19,7 +23,7 @@ Aerospike Python Client built with PyO3 + Rust. Drop-in replacement for [aerospi
 
 ### Prerequisites
 
-- Python 3.13+
+- Python 3.10+
 - Rust toolchain (rustup)
 - Running Aerospike server (or Docker)
 
@@ -51,55 +55,92 @@ docker run -d --name aerospike \
 ```python
 import aerospike_py as aerospike
 
-# Connect
-client = aerospike.client({
+# Connect (with context manager)
+with aerospike.client({
     "hosts": [("127.0.0.1", 3000)],
     "cluster_name": "docker",
-}).connect()
+}).connect() as client:
 
-# Write
-key = ("test", "demo", "user1")
-client.put(key, {"name": "Alice", "age": 30})
+    # Write
+    key = ("test", "demo", "user1")
+    client.put(key, {"name": "Alice", "age": 30})
 
-# Read
-_, meta, bins = client.get(key)
-print(bins)  # {'name': 'Alice', 'age': 30}
+    # Read
+    _, meta, bins = client.get(key)
+    print(bins)  # {'name': 'Alice', 'age': 30}
 
-# Update
-client.increment(key, "age", 1)
+    # Update
+    client.increment(key, "age", 1)
 
-# Exists
-_, meta = client.exists(key)
-print(meta)  # {'gen': 3, 'ttl': ...}
+    # Exists
+    _, meta = client.exists(key)
+    print(meta)  # {'gen': 3, 'ttl': ...}
 
-# Batch read
-keys = [("test", "demo", f"user{i}") for i in range(1, 4)]
-results = client.get_many(keys)
+    # Batch read
+    keys = [("test", "demo", f"user{i}") for i in range(1, 4)]
+    results = client.get_many(keys)
 
-# Operate (atomic multi-op)
+    # Operate (atomic multi-op)
+    ops = [
+        {"op": aerospike.OPERATOR_INCR, "bin": "age", "val": 1},
+        {"op": aerospike.OPERATOR_READ, "bin": "age", "val": None},
+    ]
+    _, _, bins = client.operate(key, ops)
+    print(bins["age"])  # 32
+
+    # Query with secondary index
+    client.index_integer_create("test", "demo", "age", "age_idx")
+
+    query = client.query("test", "demo")
+    query.where(aerospike.predicates.between("age", 25, 35))
+    records = query.results()
+
+    # Scan
+    scan = client.scan("test", "demo")
+    all_records = scan.results()
+
+    # Delete
+    client.remove(key)
+# client.close() is called automatically
+```
+
+### Expression Filters
+
+```python
+from aerospike_py import exp
+
+# Filter: age >= 21
+expr = exp.ge(exp.int_bin("age"), exp.int_val(21))
+_, _, bins = client.get(key, policy={"filter_expression": expr})
+
+# Filter: name == "Alice" AND active == True
+expr = exp.and_(
+    exp.eq(exp.string_bin("name"), exp.string_val("Alice")),
+    exp.eq(exp.bool_bin("active"), exp.bool_val(True)),
+)
+scan = client.scan("test", "demo")
+records = scan.results(policy={"filter_expression": expr})
+```
+
+### CDT List & Map Operations
+
+```python
+from aerospike_py import list_operations as list_ops
+from aerospike_py import map_operations as map_ops
+
+# List operations via operate()
 ops = [
-    {"op": aerospike.OPERATOR_INCR, "bin": "age", "val": 1},
-    {"op": aerospike.OPERATOR_READ, "bin": "age", "val": None},
+    list_ops.list_append("scores", 100),
+    list_ops.list_size("scores"),
 ]
 _, _, bins = client.operate(key, ops)
-print(bins["age"])  # 32
 
-# Query with secondary index
-client.index_integer_create("test", "demo", "age", "age_idx")
-
-query = client.query("test", "demo")
-query.where(aerospike.predicates.between("age", 25, 35))
-records = query.results()
-
-# Scan
-scan = client.scan("test", "demo")
-all_records = scan.results()
-
-# Delete
-client.remove(key)
-
-# Close
-client.close()
+# Map operations via operate()
+ops = [
+    map_ops.map_put("profile", "email", "alice@example.com"),
+    map_ops.map_size("profile"),
+]
+_, _, bins = client.operate(key, ops)
 ```
 
 ### Basic Usage (Async)
@@ -251,7 +292,8 @@ aerospike-py/
 │       ├── client.rs       # Sync Client
 │       ├── async_client.rs # Async Client
 │       ├── query.rs        # Query / Scan
-│       ├── operations.rs   # Operation mapping
+│       ├── operations.rs   # Operation mapping (incl. CDT list/map)
+│       ├── expressions.rs  # Expression filter compilation
 │       ├── errors.rs       # Error → Exception mapping
 │       ├── constants.rs    # 130+ constants
 │       ├── runtime.rs      # Global Tokio runtime
@@ -260,6 +302,9 @@ aerospike-py/
 ├── src/aerospike_py/
 │   ├── __init__.py         # Python package, re-exports, Client wrapper
 │   ├── __init__.pyi        # Type stubs
+│   ├── exp.py              # Expression filter builder
+│   ├── list_operations.py  # List CDT operation helpers (31 ops)
+│   ├── map_operations.py   # Map CDT operation helpers (27 ops)
 │   ├── exception.py        # Exception hierarchy re-exports
 │   ├── predicates.py       # Query predicate helpers
 │   └── py.typed            # PEP 561 marker
@@ -320,8 +365,10 @@ pytest tests/ -v -s
 
 ### Architecture Notes
 
-- **Sync Client**: Uses a global Tokio runtime (`runtime.rs`). All async Rust calls are wrapped with `py.allow_threads(|| RUNTIME.block_on(...))` to release the GIL.
+- **Sync Client**: Uses a global Tokio runtime (`runtime.rs`). All async Rust calls are wrapped with `py.detach(|| RUNTIME.block_on(...))` to release the GIL (PyO3 0.28+).
 - **Async Client**: Uses `pyo3_async_runtimes::tokio::future_into_py()` to return Python coroutines directly.
+- **Expression Filters**: Python expression dicts (`exp.py`) are compiled to Aerospike wire-format expressions in `expressions.rs`.
+- **CDT Operations**: List/Map operation dicts (`list_operations.py`, `map_operations.py`) are dispatched through `operations.rs`.
 - **Type conversion**: Python types are converted to/from Rust `Value` enum in `types/value.rs`. Keys, records, bins, and policies each have dedicated conversion modules.
 - **Error mapping**: Rust `aerospike_core::Error` variants are mapped to the Python exception hierarchy in `errors.rs`.
 

--- a/docs/api/async-client.md
+++ b/docs/api/async-client.md
@@ -20,6 +20,23 @@ async def main():
 asyncio.run(main())
 ```
 
+## Context Manager
+
+`AsyncClient` supports the async context manager protocol (`async with`):
+
+### `async __aenter__()` / `async __aexit__()`
+
+```python
+async def main():
+    async with AsyncClient({
+        "hosts": [("127.0.0.1", 3000)],
+        "cluster_name": "docker",
+    }) as client:
+        await client.connect()
+        # ... operations ...
+    # close() is called automatically
+```
+
 ## Connection
 
 ### `async connect(username=None, password=None)`
@@ -116,6 +133,32 @@ Increment a bin value.
 await client.increment(key, "counter", 1)
 ```
 
+## String / Numeric Operations
+
+### `async append(key, bin, val, meta=None, policy=None)`
+
+Append string to a bin.
+
+```python
+await client.append(key, "name", "_suffix")
+```
+
+### `async prepend(key, bin, val, meta=None, policy=None)`
+
+Prepend string to a bin.
+
+```python
+await client.prepend(key, "name", "prefix_")
+```
+
+### `async remove_bin(key, bin_names, meta=None, policy=None)`
+
+Remove specific bins from a record.
+
+```python
+await client.remove_bin(key, ["temp_bin", "debug_bin"])
+```
+
 ## Multi-Operation
 
 ### `async operate(key, ops, meta=None, policy=None)`
@@ -128,6 +171,15 @@ ops = [
     {"op": aerospike.OPERATOR_READ, "bin": "counter", "val": None},
 ]
 _, meta, bins = await client.operate(key, ops)
+```
+
+### `async operate_ordered(key, ops, meta=None, policy=None)`
+
+Same as `operate` but returns results as an ordered list of `(bin, value)` tuples.
+
+```python
+_, meta, results = await client.operate_ordered(key, ops)
+# results = [("counter", 2)]
 ```
 
 ## Batch Operations
@@ -147,6 +199,23 @@ Check existence of multiple records.
 
 ```python
 results = await client.exists_many(keys)
+```
+
+### `async select_many(keys, bins, policy=None)`
+
+Read specific bins from multiple records.
+
+```python
+records = await client.select_many(keys, ["name", "age"])
+```
+
+### `async batch_operate(keys, ops, policy=None)`
+
+Execute operations on multiple records.
+
+```python
+ops = [{"op": aerospike.OPERATOR_INCR, "bin": "views", "val": 1}]
+results = await client.batch_operate(keys, ops)
 ```
 
 ### `async batch_remove(keys, policy=None)`
@@ -238,3 +307,101 @@ results = await asyncio.gather(*[
     for i in range(10)
 ])
 ```
+
+## Index Management
+
+### `async index_integer_create(namespace, set_name, bin_name, index_name, policy=None)`
+
+Create a numeric secondary index.
+
+```python
+await client.index_integer_create("test", "demo", "age", "age_idx")
+```
+
+### `async index_string_create(namespace, set_name, bin_name, index_name, policy=None)`
+
+Create a string secondary index.
+
+```python
+await client.index_string_create("test", "demo", "name", "name_idx")
+```
+
+### `async index_geo2dsphere_create(namespace, set_name, bin_name, index_name, policy=None)`
+
+Create a geospatial secondary index.
+
+```python
+await client.index_geo2dsphere_create("test", "demo", "location", "geo_idx")
+```
+
+### `async index_remove(namespace, index_name, policy=None)`
+
+Remove a secondary index.
+
+```python
+await client.index_remove("test", "age_idx")
+```
+
+## Admin Operations
+
+### User Management
+
+| Method | Description |
+|--------|-------------|
+| `async admin_create_user(username, password, roles)` | Create a user |
+| `async admin_drop_user(username)` | Delete a user |
+| `async admin_change_password(username, password)` | Change password |
+| `async admin_grant_roles(username, roles)` | Grant roles |
+| `async admin_revoke_roles(username, roles)` | Revoke roles |
+| `async admin_query_user(username)` | Get user info |
+| `async admin_query_users()` | List all users |
+
+### Role Management
+
+| Method | Description |
+|--------|-------------|
+| `async admin_create_role(role, privileges, ...)` | Create a role |
+| `async admin_drop_role(role)` | Delete a role |
+| `async admin_grant_privileges(role, privileges)` | Grant privileges |
+| `async admin_revoke_privileges(role, privileges)` | Revoke privileges |
+| `async admin_query_role(role)` | Get role info |
+| `async admin_query_roles()` | List all roles |
+| `async admin_set_whitelist(role, whitelist)` | Set IP whitelist |
+| `async admin_set_quotas(role, read_quota, write_quota)` | Set quotas |
+
+```python
+# Create user
+await client.admin_create_user("new_user", "password", ["read-write"])
+
+# Grant roles
+await client.admin_grant_roles("new_user", ["sys-admin"])
+
+# Create role with privileges
+await client.admin_create_role("custom_role", [
+    {"code": aerospike.PRIV_READ, "ns": "test", "set": "demo"}
+])
+
+# Query users
+users = await client.admin_query_users()
+```
+
+## Expression Filters
+
+All read/write/batch/scan operations that accept a `policy` parameter support the `filter_expression` key for server-side filtering:
+
+```python
+from aerospike_py import exp
+
+expr = exp.ge(exp.int_bin("age"), exp.int_val(21))
+
+# Get with filter
+_, _, bins = await client.get(key, policy={"filter_expression": expr})
+
+# Scan with filter
+records = await client.scan("test", "demo", policy={"filter_expression": expr})
+
+# Batch with filter
+records = await client.get_many(keys, policy={"filter_expression": expr})
+```
+
+See the [Expression Filters Guide](../guides/expression-filters.md) for detailed documentation.

--- a/docs/guides/cdt-list.md
+++ b/docs/guides/cdt-list.md
@@ -1,0 +1,422 @@
+# List CDT Operations
+
+List CDT (Collection Data Type) operations provide 31 atomic operations on list bins. These are executed server-side as part of `client.operate()`, enabling atomic multi-operation transactions on list data.
+
+## Import
+
+```python
+from aerospike_py import list_operations as list_ops
+import aerospike_py as aerospike
+```
+
+## Overview
+
+Each `list_ops.*` function returns an operation dict that you pass to `client.operate()` or `client.operate_ordered()`:
+
+```python
+ops = [
+    list_ops.list_append("scores", 100),
+    list_ops.list_size("scores"),
+]
+_, _, bins = client.operate(key, ops)
+```
+
+## Basic Write Operations
+
+### `list_append(bin, val, policy=None)`
+
+Append a value to the end of a list.
+
+```python
+ops = [list_ops.list_append("colors", "red")]
+client.operate(key, ops)
+```
+
+### `list_append_items(bin, values, policy=None)`
+
+Append multiple values to a list.
+
+```python
+ops = [list_ops.list_append_items("colors", ["green", "blue"])]
+client.operate(key, ops)
+```
+
+### `list_insert(bin, index, val, policy=None)`
+
+Insert a value at the given index.
+
+```python
+ops = [list_ops.list_insert("colors", 0, "yellow")]
+client.operate(key, ops)
+```
+
+### `list_insert_items(bin, index, values, policy=None)`
+
+Insert multiple values at the given index.
+
+```python
+ops = [list_ops.list_insert_items("colors", 1, ["cyan", "magenta"])]
+client.operate(key, ops)
+```
+
+### `list_set(bin, index, val)`
+
+Set the value at a specific index.
+
+```python
+ops = [list_ops.list_set("colors", 0, "orange")]
+client.operate(key, ops)
+```
+
+### `list_increment(bin, index, val, policy=None)`
+
+Increment the numeric value at a given index.
+
+```python
+ops = [list_ops.list_increment("scores", 0, 10)]
+client.operate(key, ops)
+```
+
+## Basic Read Operations
+
+### `list_get(bin, index)`
+
+Get the item at a specific index.
+
+```python
+ops = [list_ops.list_get("scores", 0)]
+_, _, bins = client.operate(key, ops)
+print(bins["scores"])  # first element
+```
+
+### `list_get_range(bin, index, count)`
+
+Get `count` items starting at `index`.
+
+```python
+ops = [list_ops.list_get_range("scores", 0, 3)]
+_, _, bins = client.operate(key, ops)
+print(bins["scores"])  # first 3 elements
+```
+
+### `list_size(bin)`
+
+Return the number of items in a list.
+
+```python
+ops = [list_ops.list_size("scores")]
+_, _, bins = client.operate(key, ops)
+print(bins["scores"])  # e.g., 5
+```
+
+## Remove Operations
+
+### `list_remove(bin, index)`
+
+Remove the item at the given index.
+
+```python
+ops = [list_ops.list_remove("colors", 0)]
+client.operate(key, ops)
+```
+
+### `list_remove_range(bin, index, count)`
+
+Remove `count` items starting at `index`.
+
+```python
+ops = [list_ops.list_remove_range("colors", 1, 2)]
+client.operate(key, ops)
+```
+
+### `list_pop(bin, index)`
+
+Remove and return the item at the given index.
+
+```python
+ops = [list_ops.list_pop("colors", 0)]
+_, _, bins = client.operate(key, ops)
+print(bins["colors"])  # the removed item
+```
+
+### `list_pop_range(bin, index, count)`
+
+Remove and return `count` items starting at `index`.
+
+```python
+ops = [list_ops.list_pop_range("colors", 0, 2)]
+_, _, bins = client.operate(key, ops)
+print(bins["colors"])  # list of removed items
+```
+
+### `list_trim(bin, index, count)`
+
+Remove items outside the specified range `[index, index+count)`.
+
+```python
+# Keep only items at index 1..3
+ops = [list_ops.list_trim("scores", 1, 3)]
+client.operate(key, ops)
+```
+
+### `list_clear(bin)`
+
+Remove all items from a list.
+
+```python
+ops = [list_ops.list_clear("scores")]
+client.operate(key, ops)
+```
+
+## Sort Operations
+
+### `list_sort(bin, sort_flags=0)`
+
+Sort the list in place.
+
+```python
+ops = [list_ops.list_sort("scores")]
+client.operate(key, ops)
+
+# Drop duplicates while sorting
+ops = [list_ops.list_sort("scores", aerospike.LIST_SORT_DROP_DUPLICATES)]
+client.operate(key, ops)
+```
+
+### `list_set_order(bin, list_order=0)`
+
+Set the list ordering type.
+
+```python
+# Set to ordered (maintains sort order on future writes)
+ops = [list_ops.list_set_order("scores", aerospike.LIST_ORDERED)]
+client.operate(key, ops)
+```
+
+## Advanced Read Operations (by Value/Index/Rank)
+
+These operations require a `return_type` parameter that controls what is returned.
+
+### `list_get_by_value(bin, val, return_type)`
+
+Get items matching the given value.
+
+```python
+ops = [list_ops.list_get_by_value("tags", "urgent", aerospike.LIST_RETURN_INDEX)]
+_, _, bins = client.operate(key, ops)
+# Returns indices of all "urgent" items
+```
+
+### `list_get_by_value_list(bin, values, return_type)`
+
+Get items matching any of the given values.
+
+```python
+ops = [list_ops.list_get_by_value_list(
+    "tags", ["urgent", "important"], aerospike.LIST_RETURN_COUNT
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_get_by_value_range(bin, begin, end, return_type)`
+
+Get items with values in the range `[begin, end)`.
+
+```python
+ops = [list_ops.list_get_by_value_range(
+    "scores", 80, 100, aerospike.LIST_RETURN_VALUE
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_get_by_index(bin, index, return_type)`
+
+Get item by index with specified return type.
+
+```python
+ops = [list_ops.list_get_by_index("scores", 0, aerospike.LIST_RETURN_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_get_by_index_range(bin, index, return_type, count=None)`
+
+Get items by index range.
+
+```python
+# Get 3 items starting at index 2
+ops = [list_ops.list_get_by_index_range(
+    "scores", 2, aerospike.LIST_RETURN_VALUE, count=3
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_get_by_rank(bin, rank, return_type)`
+
+Get item by rank (0 = smallest).
+
+```python
+# Get the smallest value
+ops = [list_ops.list_get_by_rank("scores", 0, aerospike.LIST_RETURN_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_get_by_rank_range(bin, rank, return_type, count=None)`
+
+Get items by rank range.
+
+```python
+# Get top 3 values (highest rank)
+ops = [list_ops.list_get_by_rank_range(
+    "scores", -3, aerospike.LIST_RETURN_VALUE, count=3
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+## Advanced Remove Operations (by Value/Index/Rank)
+
+### `list_remove_by_value(bin, val, return_type)`
+
+Remove items matching the given value.
+
+```python
+ops = [list_ops.list_remove_by_value("tags", "temp", aerospike.LIST_RETURN_COUNT)]
+_, _, bins = client.operate(key, ops)
+print(f"Removed {bins['tags']} items")
+```
+
+### `list_remove_by_value_list(bin, values, return_type)`
+
+Remove items matching any of the given values.
+
+```python
+ops = [list_ops.list_remove_by_value_list(
+    "tags", ["temp", "debug"], aerospike.LIST_RETURN_NONE
+)]
+client.operate(key, ops)
+```
+
+### `list_remove_by_value_range(bin, begin, end, return_type)`
+
+Remove items with values in the range `[begin, end)`.
+
+```python
+ops = [list_ops.list_remove_by_value_range(
+    "scores", 0, 50, aerospike.LIST_RETURN_COUNT
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_remove_by_index(bin, index, return_type)`
+
+Remove item by index.
+
+```python
+ops = [list_ops.list_remove_by_index("scores", 0, aerospike.LIST_RETURN_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_remove_by_index_range(bin, index, return_type, count=None)`
+
+Remove items by index range.
+
+```python
+ops = [list_ops.list_remove_by_index_range(
+    "scores", 0, aerospike.LIST_RETURN_NONE, count=2
+)]
+client.operate(key, ops)
+```
+
+### `list_remove_by_rank(bin, rank, return_type)`
+
+Remove item by rank.
+
+```python
+# Remove smallest value
+ops = [list_ops.list_remove_by_rank("scores", 0, aerospike.LIST_RETURN_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `list_remove_by_rank_range(bin, rank, return_type, count=None)`
+
+Remove items by rank range.
+
+```python
+# Remove 2 smallest values
+ops = [list_ops.list_remove_by_rank_range(
+    "scores", 0, aerospike.LIST_RETURN_NONE, count=2
+)]
+client.operate(key, ops)
+```
+
+## Return Type Constants
+
+Use these constants from `aerospike_py` to control what the server returns:
+
+| Constant | Description |
+|----------|-------------|
+| `LIST_RETURN_NONE` | Return nothing |
+| `LIST_RETURN_INDEX` | Return index(es) |
+| `LIST_RETURN_REVERSE_INDEX` | Return reverse index(es) |
+| `LIST_RETURN_RANK` | Return rank(s) |
+| `LIST_RETURN_REVERSE_RANK` | Return reverse rank(s) |
+| `LIST_RETURN_COUNT` | Return count of matched items |
+| `LIST_RETURN_VALUE` | Return value(s) |
+| `LIST_RETURN_EXISTS` | Return boolean existence |
+
+## List Order Constants
+
+| Constant | Description |
+|----------|-------------|
+| `LIST_UNORDERED` | Unordered list (default) |
+| `LIST_ORDERED` | Ordered list (maintains sort order) |
+
+## List Sort Flags
+
+| Constant | Description |
+|----------|-------------|
+| `LIST_SORT_DEFAULT` | Default sort |
+| `LIST_SORT_DROP_DUPLICATES` | Drop duplicates during sort |
+
+## Complete Example
+
+```python
+import aerospike_py as aerospike
+from aerospike_py import list_operations as list_ops
+
+with aerospike.client({
+    "hosts": [("127.0.0.1", 3000)],
+    "cluster_name": "docker",
+}).connect() as client:
+
+    key = ("test", "demo", "player1")
+
+    # Initialize a scores list
+    client.put(key, {"scores": [85, 92, 78, 95, 88]})
+
+    # Atomic: sort, get top 3, and get size
+    ops = [
+        list_ops.list_sort("scores"),
+        list_ops.list_get_by_rank_range(
+            "scores", -3, aerospike.LIST_RETURN_VALUE, count=3
+        ),
+    ]
+    _, _, bins = client.operate(key, ops)
+    print(f"Top 3 scores: {bins['scores']}")
+
+    # Remove scores below 80
+    ops = [
+        list_ops.list_remove_by_value_range(
+            "scores", 0, 80, aerospike.LIST_RETURN_COUNT
+        ),
+    ]
+    _, _, bins = client.operate(key, ops)
+    print(f"Removed {bins['scores']} low scores")
+
+    # Append a new score and get updated size
+    ops = [
+        list_ops.list_append("scores", 97),
+        list_ops.list_size("scores"),
+    ]
+    _, _, bins = client.operate(key, ops)
+    print(f"Total scores: {bins['scores']}")
+```

--- a/docs/guides/cdt-map.md
+++ b/docs/guides/cdt-map.md
@@ -1,0 +1,391 @@
+# Map CDT Operations
+
+Map CDT (Collection Data Type) operations provide 27 atomic operations on map bins. These are executed server-side as part of `client.operate()`, enabling atomic multi-operation transactions on map data.
+
+## Import
+
+```python
+from aerospike_py import map_operations as map_ops
+import aerospike_py as aerospike
+```
+
+## Overview
+
+Each `map_ops.*` function returns an operation dict that you pass to `client.operate()` or `client.operate_ordered()`:
+
+```python
+ops = [
+    map_ops.map_put("profile", "email", "alice@example.com"),
+    map_ops.map_size("profile"),
+]
+_, _, bins = client.operate(key, ops)
+```
+
+## Basic Write Operations
+
+### `map_put(bin, key, val, policy=None)`
+
+Put a key/value pair into a map.
+
+```python
+ops = [map_ops.map_put("profile", "name", "Alice")]
+client.operate(key, ops)
+```
+
+### `map_put_items(bin, items, policy=None)`
+
+Put multiple key/value pairs into a map.
+
+```python
+ops = [map_ops.map_put_items("profile", {
+    "name": "Alice",
+    "email": "alice@example.com",
+    "age": 30,
+})]
+client.operate(key, ops)
+```
+
+### `map_increment(bin, key, incr, policy=None)`
+
+Increment a numeric value in a map by key.
+
+```python
+ops = [map_ops.map_increment("counters", "views", 1)]
+client.operate(key, ops)
+```
+
+### `map_decrement(bin, key, decr, policy=None)`
+
+Decrement a numeric value in a map by key.
+
+```python
+ops = [map_ops.map_decrement("counters", "stock", 1)]
+client.operate(key, ops)
+```
+
+## Map Settings
+
+### `map_set_order(bin, map_order)`
+
+Set the map ordering type.
+
+```python
+# Set map to key-ordered
+ops = [map_ops.map_set_order("profile", aerospike.MAP_KEY_ORDERED)]
+client.operate(key, ops)
+```
+
+### `map_clear(bin)`
+
+Remove all items from a map.
+
+```python
+ops = [map_ops.map_clear("profile")]
+client.operate(key, ops)
+```
+
+## Basic Read Operations
+
+### `map_size(bin)`
+
+Return the number of entries in a map.
+
+```python
+ops = [map_ops.map_size("profile")]
+_, _, bins = client.operate(key, ops)
+print(bins["profile"])  # e.g., 3
+```
+
+### `map_get_by_key(bin, key, return_type)`
+
+Get an entry by key.
+
+```python
+ops = [map_ops.map_get_by_key("profile", "name", aerospike.MAP_RETURN_VALUE)]
+_, _, bins = client.operate(key, ops)
+print(bins["profile"])  # "Alice"
+```
+
+## Advanced Read Operations
+
+### `map_get_by_key_range(bin, begin, end, return_type)`
+
+Get entries with keys in the range `[begin, end)`.
+
+```python
+ops = [map_ops.map_get_by_key_range(
+    "profile", "a", "n", aerospike.MAP_RETURN_KEY_VALUE
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_get_by_key_list(bin, keys, return_type)`
+
+Get entries matching any of the given keys.
+
+```python
+ops = [map_ops.map_get_by_key_list(
+    "profile", ["name", "email"], aerospike.MAP_RETURN_VALUE
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_get_by_value(bin, val, return_type)`
+
+Get entries by value.
+
+```python
+ops = [map_ops.map_get_by_value("scores", 100, aerospike.MAP_RETURN_KEY)]
+_, _, bins = client.operate(key, ops)
+# Returns keys of entries with value 100
+```
+
+### `map_get_by_value_range(bin, begin, end, return_type)`
+
+Get entries with values in the range `[begin, end)`.
+
+```python
+ops = [map_ops.map_get_by_value_range(
+    "scores", 90, 100, aerospike.MAP_RETURN_KEY_VALUE
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_get_by_value_list(bin, values, return_type)`
+
+Get entries matching any of the given values.
+
+```python
+ops = [map_ops.map_get_by_value_list(
+    "scores", [100, 95], aerospike.MAP_RETURN_KEY
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_get_by_index(bin, index, return_type)`
+
+Get entry by index (key-ordered position).
+
+```python
+# Get first entry (by key order)
+ops = [map_ops.map_get_by_index("profile", 0, aerospike.MAP_RETURN_KEY_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_get_by_index_range(bin, index, return_type, count=None)`
+
+Get entries by index range.
+
+```python
+# Get first 3 entries by key order
+ops = [map_ops.map_get_by_index_range(
+    "profile", 0, aerospike.MAP_RETURN_KEY_VALUE, count=3
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_get_by_rank(bin, rank, return_type)`
+
+Get entry by rank (0 = smallest value).
+
+```python
+# Get entry with smallest value
+ops = [map_ops.map_get_by_rank("scores", 0, aerospike.MAP_RETURN_KEY_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_get_by_rank_range(bin, rank, return_type, count=None)`
+
+Get entries by rank range.
+
+```python
+# Get top 3 entries by value
+ops = [map_ops.map_get_by_rank_range(
+    "scores", -3, aerospike.MAP_RETURN_KEY_VALUE, count=3
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+## Remove Operations
+
+### `map_remove_by_key(bin, key, return_type)`
+
+Remove entry by key.
+
+```python
+ops = [map_ops.map_remove_by_key("profile", "temp", aerospike.MAP_RETURN_NONE)]
+client.operate(key, ops)
+```
+
+### `map_remove_by_key_list(bin, keys, return_type)`
+
+Remove entries matching any of the given keys.
+
+```python
+ops = [map_ops.map_remove_by_key_list(
+    "profile", ["temp", "debug"], aerospike.MAP_RETURN_COUNT
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_remove_by_key_range(bin, begin, end, return_type)`
+
+Remove entries with keys in the range `[begin, end)`.
+
+```python
+ops = [map_ops.map_remove_by_key_range(
+    "cache", "tmp_a", "tmp_z", aerospike.MAP_RETURN_NONE
+)]
+client.operate(key, ops)
+```
+
+### `map_remove_by_value(bin, val, return_type)`
+
+Remove entries by value.
+
+```python
+ops = [map_ops.map_remove_by_value("scores", 0, aerospike.MAP_RETURN_KEY)]
+_, _, bins = client.operate(key, ops)
+# Returns keys of removed entries
+```
+
+### `map_remove_by_value_list(bin, values, return_type)`
+
+Remove entries matching any of the given values.
+
+```python
+ops = [map_ops.map_remove_by_value_list(
+    "tags", ["deprecated", "old"], aerospike.MAP_RETURN_NONE
+)]
+client.operate(key, ops)
+```
+
+### `map_remove_by_value_range(bin, begin, end, return_type)`
+
+Remove entries with values in the range `[begin, end)`.
+
+```python
+ops = [map_ops.map_remove_by_value_range(
+    "scores", 0, 50, aerospike.MAP_RETURN_COUNT
+)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_remove_by_index(bin, index, return_type)`
+
+Remove entry by index.
+
+```python
+ops = [map_ops.map_remove_by_index("profile", 0, aerospike.MAP_RETURN_KEY_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_remove_by_index_range(bin, index, return_type, count=None)`
+
+Remove entries by index range.
+
+```python
+ops = [map_ops.map_remove_by_index_range(
+    "cache", 0, aerospike.MAP_RETURN_NONE, count=5
+)]
+client.operate(key, ops)
+```
+
+### `map_remove_by_rank(bin, rank, return_type)`
+
+Remove entry by rank.
+
+```python
+# Remove entry with smallest value
+ops = [map_ops.map_remove_by_rank("scores", 0, aerospike.MAP_RETURN_VALUE)]
+_, _, bins = client.operate(key, ops)
+```
+
+### `map_remove_by_rank_range(bin, rank, return_type, count=None)`
+
+Remove entries by rank range.
+
+```python
+# Remove 2 entries with smallest values
+ops = [map_ops.map_remove_by_rank_range(
+    "scores", 0, aerospike.MAP_RETURN_NONE, count=2
+)]
+client.operate(key, ops)
+```
+
+## Return Type Constants
+
+| Constant | Description |
+|----------|-------------|
+| `MAP_RETURN_NONE` | Return nothing |
+| `MAP_RETURN_INDEX` | Return index(es) |
+| `MAP_RETURN_REVERSE_INDEX` | Return reverse index(es) |
+| `MAP_RETURN_RANK` | Return rank(s) |
+| `MAP_RETURN_REVERSE_RANK` | Return reverse rank(s) |
+| `MAP_RETURN_COUNT` | Return count of matched entries |
+| `MAP_RETURN_KEY` | Return key(s) |
+| `MAP_RETURN_VALUE` | Return value(s) |
+| `MAP_RETURN_KEY_VALUE` | Return key-value pair(s) |
+| `MAP_RETURN_EXISTS` | Return boolean existence |
+
+## Map Order Constants
+
+| Constant | Description |
+|----------|-------------|
+| `MAP_UNORDERED` | Unordered map (default) |
+| `MAP_KEY_ORDERED` | Ordered by key |
+| `MAP_KEY_VALUE_ORDERED` | Ordered by key and value |
+
+## Map Write Flag Constants
+
+| Constant | Description |
+|----------|-------------|
+| `MAP_WRITE_FLAGS_DEFAULT` | Default behavior |
+| `MAP_WRITE_FLAGS_CREATE_ONLY` | Only create new entries |
+| `MAP_WRITE_FLAGS_UPDATE_ONLY` | Only update existing entries |
+| `MAP_WRITE_FLAGS_NO_FAIL` | Do not raise error on policy violation |
+| `MAP_WRITE_FLAGS_PARTIAL` | Allow partial success for multi-item ops |
+
+## Complete Example
+
+```python
+import aerospike_py as aerospike
+from aerospike_py import map_operations as map_ops
+
+with aerospike.client({
+    "hosts": [("127.0.0.1", 3000)],
+    "cluster_name": "docker",
+}).connect() as client:
+
+    key = ("test", "demo", "player1")
+
+    # Initialize a scores map
+    client.put(key, {"scores": {"math": 92, "science": 88, "english": 75, "art": 95}})
+
+    # Atomic: get top 2 scores and total count
+    ops = [
+        map_ops.map_get_by_rank_range(
+            "scores", -2, aerospike.MAP_RETURN_KEY_VALUE, count=2
+        ),
+    ]
+    _, _, bins = client.operate(key, ops)
+    print(f"Top 2 scores: {bins['scores']}")
+
+    # Remove scores below 80
+    ops = [
+        map_ops.map_remove_by_value_range(
+            "scores", 0, 80, aerospike.MAP_RETURN_KEY
+        ),
+    ]
+    _, _, bins = client.operate(key, ops)
+    print(f"Removed subjects: {bins['scores']}")
+
+    # Add a new score and increment an existing one
+    ops = [
+        map_ops.map_put("scores", "history", 90),
+        map_ops.map_increment("scores", "math", 5),
+        map_ops.map_size("scores"),
+    ]
+    _, _, bins = client.operate(key, ops)
+    print(f"Total subjects: {bins['scores']}")
+```

--- a/docs/guides/expression-filters.md
+++ b/docs/guides/expression-filters.md
@@ -1,0 +1,325 @@
+# Expression Filters
+
+Expression Filters allow server-side filtering of records during read, write, query, and scan operations. The server evaluates the expression and only returns (or modifies) records that match.
+
+!!! note "Server Requirement"
+    Expression filters require Aerospike Server **5.2+**.
+
+## Import
+
+```python
+from aerospike_py import exp
+```
+
+## Overview
+
+Expressions are built by composing function calls that return dict nodes. These dicts are passed to the Rust layer via the `filter_expression` policy key, where they are compiled into the Aerospike wire-format.
+
+```python
+# Build expression: age >= 21
+expr = exp.ge(exp.int_bin("age"), exp.int_val(21))
+
+# Use in policy
+policy = {"filter_expression": expr}
+_, _, bins = client.get(key, policy=policy)
+```
+
+## Value Constructors
+
+Create literal value expressions:
+
+| Function | Description |
+|----------|-------------|
+| `exp.int_val(val)` | 64-bit integer |
+| `exp.float_val(val)` | 64-bit float |
+| `exp.string_val(val)` | String |
+| `exp.bool_val(val)` | Boolean |
+| `exp.blob_val(val)` | Bytes |
+| `exp.list_val(val)` | List |
+| `exp.map_val(val)` | Map/dict |
+| `exp.geo_val(val)` | GeoJSON string |
+| `exp.nil()` | Nil value |
+| `exp.infinity()` | Infinity (for unbounded ranges) |
+| `exp.wildcard()` | Wildcard (matches any value) |
+
+```python
+exp.int_val(42)
+exp.string_val("hello")
+exp.bool_val(True)
+exp.list_val([1, 2, 3])
+exp.map_val({"key": "value"})
+```
+
+## Bin Accessors
+
+Read bin values by type:
+
+| Function | Description |
+|----------|-------------|
+| `exp.int_bin(name)` | Read integer bin |
+| `exp.float_bin(name)` | Read float bin |
+| `exp.string_bin(name)` | Read string bin |
+| `exp.bool_bin(name)` | Read boolean bin |
+| `exp.blob_bin(name)` | Read blob bin |
+| `exp.list_bin(name)` | Read list bin |
+| `exp.map_bin(name)` | Read map bin |
+| `exp.geo_bin(name)` | Read geospatial bin |
+| `exp.hll_bin(name)` | Read HyperLogLog bin |
+| `exp.bin_exists(name)` | True if bin exists |
+| `exp.bin_type(name)` | Bin particle type |
+
+```python
+exp.int_bin("age")
+exp.string_bin("name")
+exp.bin_exists("optional_field")
+```
+
+## Comparison Operations
+
+| Function | Description |
+|----------|-------------|
+| `exp.eq(left, right)` | Equal (`==`) |
+| `exp.ne(left, right)` | Not equal (`!=`) |
+| `exp.gt(left, right)` | Greater than (`>`) |
+| `exp.ge(left, right)` | Greater or equal (`>=`) |
+| `exp.lt(left, right)` | Less than (`<`) |
+| `exp.le(left, right)` | Less or equal (`<=`) |
+
+```python
+# age == 30
+exp.eq(exp.int_bin("age"), exp.int_val(30))
+
+# score > 100.5
+exp.gt(exp.float_bin("score"), exp.float_val(100.5))
+
+# name != "admin"
+exp.ne(exp.string_bin("name"), exp.string_val("admin"))
+```
+
+## Logical Operations
+
+| Function | Description |
+|----------|-------------|
+| `exp.and_(*exprs)` | Logical AND |
+| `exp.or_(*exprs)` | Logical OR |
+| `exp.not_(expr)` | Logical NOT |
+| `exp.xor_(*exprs)` | Logical XOR |
+
+```python
+# age >= 18 AND active == true
+exp.and_(
+    exp.ge(exp.int_bin("age"), exp.int_val(18)),
+    exp.eq(exp.bool_bin("active"), exp.bool_val(True)),
+)
+
+# status == "gold" OR status == "platinum"
+exp.or_(
+    exp.eq(exp.string_bin("status"), exp.string_val("gold")),
+    exp.eq(exp.string_bin("status"), exp.string_val("platinum")),
+)
+
+# NOT deleted
+exp.not_(exp.eq(exp.bool_bin("deleted"), exp.bool_val(True)))
+```
+
+## Numeric Operations
+
+| Function | Description |
+|----------|-------------|
+| `exp.num_add(*exprs)` | Addition |
+| `exp.num_sub(*exprs)` | Subtraction |
+| `exp.num_mul(*exprs)` | Multiplication |
+| `exp.num_div(*exprs)` | Division |
+| `exp.num_mod(num, denom)` | Modulo |
+| `exp.num_pow(base, exponent)` | Power |
+| `exp.num_log(num, base)` | Logarithm |
+| `exp.num_abs(value)` | Absolute value |
+| `exp.num_floor(num)` | Floor |
+| `exp.num_ceil(num)` | Ceiling |
+| `exp.to_int(num)` | Convert to integer |
+| `exp.to_float(num)` | Convert to float |
+| `exp.min_(*exprs)` | Minimum value |
+| `exp.max_(*exprs)` | Maximum value |
+
+```python
+# (price * quantity) > 1000
+exp.gt(
+    exp.num_mul(exp.int_bin("price"), exp.int_bin("quantity")),
+    exp.int_val(1000),
+)
+```
+
+## Integer Bitwise Operations
+
+| Function | Description |
+|----------|-------------|
+| `exp.int_and(*exprs)` | Bitwise AND |
+| `exp.int_or(*exprs)` | Bitwise OR |
+| `exp.int_xor(*exprs)` | Bitwise XOR |
+| `exp.int_not(expr)` | Bitwise NOT |
+| `exp.int_lshift(value, shift)` | Left shift |
+| `exp.int_rshift(value, shift)` | Logical right shift |
+| `exp.int_arshift(value, shift)` | Arithmetic right shift |
+| `exp.int_count(expr)` | Bit count |
+| `exp.int_lscan(value, search)` | Scan from MSB |
+| `exp.int_rscan(value, search)` | Scan from LSB |
+
+## Record Metadata
+
+| Function | Description |
+|----------|-------------|
+| `exp.key(exp_type)` | Record primary key |
+| `exp.key_exists()` | True if key stored in metadata |
+| `exp.set_name()` | Record set name |
+| `exp.record_size()` | Record size in bytes (Server 7.0+) |
+| `exp.last_update()` | Last update time (ns since epoch) |
+| `exp.since_update()` | Milliseconds since last update |
+| `exp.void_time()` | Expiration time (ns since epoch) |
+| `exp.ttl()` | Record TTL in seconds |
+| `exp.is_tombstone()` | True if tombstone record |
+| `exp.digest_modulo(mod)` | Digest modulo (for sampling) |
+
+```python
+# TTL < 3600 (expiring within an hour)
+exp.lt(exp.ttl(), exp.int_val(3600))
+
+# Record updated within last 24 hours (86400000 ms)
+exp.lt(exp.since_update(), exp.int_val(86_400_000))
+
+# Sample ~10% of records
+exp.eq(exp.digest_modulo(10), exp.int_val(0))
+```
+
+## Pattern Matching
+
+### Regex
+
+```python
+# name matches pattern (case insensitive: flags=2)
+exp.regex_compare("^alice.*", 2, exp.string_bin("name"))
+```
+
+### Geospatial
+
+```python
+# point within region
+region = '{"type":"AeroCircle","coordinates":[[-122.0, 37.5], 1000]}'
+exp.geo_compare(exp.geo_bin("location"), exp.geo_val(region))
+```
+
+## Variables and Control Flow
+
+### Conditional (`cond`)
+
+```python
+# if age < 18: "minor", elif age < 65: "adult", else: "senior"
+exp.cond(
+    exp.lt(exp.int_bin("age"), exp.int_val(18)), exp.string_val("minor"),
+    exp.lt(exp.int_bin("age"), exp.int_val(65)), exp.string_val("adult"),
+    exp.string_val("senior"),
+)
+```
+
+### Let Bindings (`let_` / `def_` / `var`)
+
+```python
+# let total = price * qty in total > 1000
+exp.let_(
+    exp.def_("total", exp.num_mul(exp.int_bin("price"), exp.int_bin("qty"))),
+    exp.gt(exp.var("total"), exp.int_val(1000)),
+)
+```
+
+## Using with Operations
+
+Expression filters can be applied to any operation via the `filter_expression` policy key.
+
+### Get with Filter
+
+```python
+expr = exp.ge(exp.int_bin("age"), exp.int_val(21))
+try:
+    _, _, bins = client.get(key, policy={"filter_expression": expr})
+except aerospike.FilteredOut:
+    print("Record does not match filter")
+```
+
+### Put with Filter
+
+```python
+# Only update if status == "active"
+expr = exp.eq(exp.string_bin("status"), exp.string_val("active"))
+client.put(key, {"visits": 1}, policy={"filter_expression": expr})
+```
+
+### Query with Filter
+
+```python
+# Secondary index query + expression filter
+query = client.query("test", "demo")
+query.where(aerospike.predicates.between("age", 20, 50))
+
+expr = exp.eq(exp.string_bin("region"), exp.string_val("US"))
+records = query.results(policy={"filter_expression": expr})
+```
+
+### Scan with Filter
+
+```python
+# Scan with filter: only active users with TTL > 1 hour
+expr = exp.and_(
+    exp.eq(exp.bool_bin("active"), exp.bool_val(True)),
+    exp.gt(exp.ttl(), exp.int_val(3600)),
+)
+scan = client.scan("test", "demo")
+records = scan.results(policy={"filter_expression": expr})
+```
+
+### Batch with Filter
+
+```python
+expr = exp.ge(exp.int_bin("score"), exp.int_val(100))
+records = client.get_many(keys, policy={"filter_expression": expr})
+```
+
+## Practical Examples
+
+### Active Premium Users
+
+```python
+expr = exp.and_(
+    exp.eq(exp.bool_bin("active"), exp.bool_val(True)),
+    exp.or_(
+        exp.eq(exp.string_bin("tier"), exp.string_val("gold")),
+        exp.eq(exp.string_bin("tier"), exp.string_val("platinum")),
+    ),
+    exp.ge(exp.int_bin("age"), exp.int_val(18)),
+)
+
+scan = client.scan("test", "users")
+records = scan.results(policy={"filter_expression": expr})
+```
+
+### Records Expiring Soon
+
+```python
+# Records with TTL < 1 hour
+expr = exp.and_(
+    exp.gt(exp.ttl(), exp.int_val(0)),       # not immortal
+    exp.lt(exp.ttl(), exp.int_val(3600)),     # expiring within 1hr
+)
+scan = client.scan("test", "cache")
+expiring = scan.results(policy={"filter_expression": expr})
+```
+
+### High-Value Transactions
+
+```python
+# amount * quantity > 10000
+expr = exp.gt(
+    exp.num_mul(exp.float_bin("amount"), exp.int_bin("quantity")),
+    exp.float_val(10000.0),
+)
+scan = client.scan("test", "transactions")
+records = scan.results(policy={"filter_expression": expr})
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,15 @@ Aerospike Python Client built with **PyO3 + Rust**. Drop-in replacement for [aer
 - **Full CRUD** - put, get, select, exists, remove, touch, increment, append, prepend
 - **Batch Operations** - get_many, exists_many, select_many, batch_operate, batch_remove
 - **Query & Scan** - Secondary index queries with predicates, full namespace scans
+- **Expression Filters** - Server-side filtering with 50+ expression builders (Server 5.2+)
+- **List CDT Operations** - 31 atomic list operations (append, insert, get/remove by value/index/rank, sort, etc.)
+- **Map CDT Operations** - 27 atomic map operations (put, get/remove by key/value/index/rank, etc.)
+- **Context Manager** - `with` statement support for both `Client` and `AsyncClient`
 - **UDF** - Register, execute, and remove Lua User Defined Functions
 - **Admin** - User/role CRUD, privileges, whitelist, quotas
 - **Index Management** - Create/remove integer, string, geo2dsphere indexes
 - **Truncate** - Namespace/set truncation
-- **130+ Constants** - Policy, operator, index, status code constants
+- **130+ Constants** - Policy, operator, index, CDT, status code constants
 - **18 Exception Classes** - Full exception hierarchy matching the original client
 - **Type Stubs** - Complete `.pyi` files for IDE autocompletion
 
@@ -33,7 +37,7 @@ maturin develop
 
 ### Requirements
 
-- Python 3.13+
+- Python 3.10+
 - Rust toolchain (install via [rustup](https://rustup.rs/))
 - Running Aerospike server for integration use
 
@@ -59,20 +63,24 @@ client.close()
 
 ```
 aerospike-py/
-├── rust/src/          # PyO3 Rust bindings
-│   ├── client.rs      # Sync Client
-│   ├── async_client.rs# Async Client
-│   ├── query.rs       # Query / Scan
-│   ├── operations.rs  # Operation mapping
-│   ├── errors.rs      # Error → Exception mapping
-│   ├── constants.rs   # 130+ constants
-│   ├── types/         # Type converters
-│   └── policy/        # Policy parsers
-├── src/aerospike_py/  # Python package
-│   ├── __init__.py    # Re-exports, Client wrapper
-│   ├── exception.py   # Exception hierarchy
-│   └── predicates.py  # Query predicates
-└── tests/             # Unit + Integration tests
+├── rust/src/              # PyO3 Rust bindings
+│   ├── client.rs          # Sync Client
+│   ├── async_client.rs    # Async Client
+│   ├── query.rs           # Query / Scan
+│   ├── operations.rs      # Operation mapping (incl. CDT list/map)
+│   ├── expressions.rs     # Expression filter compilation
+│   ├── errors.rs          # Error → Exception mapping
+│   ├── constants.rs       # 130+ constants
+│   ├── types/             # Type converters
+│   └── policy/            # Policy parsers
+├── src/aerospike_py/      # Python package
+│   ├── __init__.py        # Re-exports, Client wrapper
+│   ├── exp.py             # Expression filter builder
+│   ├── list_operations.py # List CDT operation helpers
+│   ├── map_operations.py  # Map CDT operation helpers
+│   ├── exception.py       # Exception hierarchy
+│   └── predicates.py      # Query predicates
+└── tests/                 # Unit + Integration tests
 ```
 
 ## License

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,9 @@ nav:
       - CRUD: guides/crud.md
       - Batch: guides/batch.md
       - Query & Scan: guides/query-scan.md
+      - Expression Filters: guides/expression-filters.md
+      - List CDT Operations: guides/cdt-list.md
+      - Map CDT Operations: guides/cdt-map.md
       - UDF: guides/udf.md
       - Admin: guides/admin.md
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary

- Add **Expression Filters** guide (`docs/guides/expression-filters.md`) - 50+ expression builders with practical examples
- Add **List CDT Operations** guide (`docs/guides/cdt-list.md`) - 31 atomic list operations
- Add **Map CDT Operations** guide (`docs/guides/cdt-map.md`) - 27 atomic map operations
- Update **AsyncClient API** docs with 27 new methods (append, prepend, remove_bin, operate_ordered, select_many, batch_operate, 4 index ops, 15 admin ops)
- Add **Context Manager** documentation for both `Client` and `AsyncClient`
- Add **Expression Filter** (`filter_expression` policy) sections to Client and AsyncClient API docs
- Update badges: Python `3.13+` → `3.10+`, PyO3 `0.23` → `0.28`
- Update Project Structure and Architecture Notes (`py.detach`, `expressions.rs`, new Python modules)
- Update `mkdocs.yml` navigation with 3 new guide entries
- Verified: `mkdocs build --strict` passes with no errors

## Test plan

- [x] `mkdocs build --strict` passes without errors or warnings
- [x] All code examples match actual API signatures from source and type stubs
- [x] Version numbers (Python 3.10+, PyO3 0.28) verified against `pyproject.toml` and `Cargo.toml`
- [x] Internal links are consistent with mkdocs navigation structure