### PR TITLE
ci: switch docs deployment to actions/deploy-pages

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -8,11 +8,16 @@ on:
       - "mkdocs.yml"
 
 permissions:
-  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: Deploy docs
+  build:
+    name: Build docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,5 +30,22 @@ jobs:
       - name: Install mkdocs-material
         run: pip install mkdocs-material
 
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy docs
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Replace legacy `mkdocs gh-deploy --force` (direct push to `gh-pages` branch) with the official GitHub Pages deployment workflow
- Use `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`
- Add `mkdocs build --strict` for build-time validation
- Add `concurrency` group to prevent overlapping deployments
- GitHub Pages `build_type` changed to `workflow` via API

## Why

The previous approach pushed built HTML directly to `gh-pages` branch, which triggered a secondary `pages-build-deployment` Jekyll build that always failed (since this is a mkdocs project). The `actions/deploy-pages` approach is the recommended method and avoids the unnecessary Jekyll build step entirely.

## Test plan

- [ ] Merge triggers `Publish Docs` workflow
- [ ] `actions/deploy-pages` deploys successfully
- [ ] https://kimsoungryoul.github.io/aerospike-py/ serves the updated docs