### PR TITLE
ci: add workflow_dispatch to docs publish

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -1,6 +1,7 @@
 name: Publish Docs
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to `Publish Docs` workflow for manual deployment

## Test plan

- [ ] After merge, manually trigger workflow via `gh workflow run "Publish Docs"`
- [ ] `actions/deploy-pages` deploys successfully