### PR TITLE
refactor: use pytest-asyncio instead of manual asyncio.run() wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ bench = ["aerospike"]
 [dependency-groups]
 dev = ["pytest", "pytest-asyncio", "ruff", "maturin>=1.9,<2"]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [build-system]
 requires = ["maturin>=1.9,<2"]
 build-backend = "maturin"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for async integration tests."""
+
+import pytest
+
+import aerospike_py
+
+CONFIG = {"hosts": [("127.0.0.1", 3000)], "cluster_name": "docker"}
+
+
+@pytest.fixture
+async def async_client():
+    """Create and connect an AsyncClient, skip if server is unavailable."""
+    try:
+        c = aerospike_py.AsyncClient(CONFIG)
+        await c.connect()
+    except Exception as e:
+        if "connect" in str(e).lower() or "cluster" in str(e).lower():
+            pytest.skip(f"Aerospike server not available: {e}")
+        raise
+    yield c
+    await c.close()

--- a/tests/integration/test_async.py
+++ b/tests/integration/test_async.py
@@ -1,176 +1,97 @@
-"""Integration tests for AsyncClient (requires Aerospike server).
-
-pyo3_async_runtimes requires a running event loop when async methods are called,
-so all AsyncClient method calls must happen inside an async context.
-We use asyncio.run() for each test to ensure this.
-"""
-
-import asyncio
-
-import pytest
+"""Integration tests for AsyncClient (requires Aerospike server)."""
 
 import aerospike_py
 
-CONFIG = {"hosts": [("127.0.0.1", 3000)], "cluster_name": "docker"}
-
-
-def _run(coro):
-    """Run an async test, skipping if server is unavailable."""
-    try:
-        return asyncio.run(coro)
-    except Exception as e:
-        if "connect" in str(e).lower() or "cluster" in str(e).lower():
-            pytest.skip(f"Aerospike server not available: {e}")
-        raise
-
 
 class TestAsyncConnection:
-    def test_is_connected(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            assert c.is_connected()
-            await c.close()
+    async def test_is_connected(self, async_client):
+        assert async_client.is_connected()
 
-        _run(_test())
-
-    def test_close(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            assert c.is_connected()
-            await c.close()
-            assert not c.is_connected()
-
-        _run(_test())
+    async def test_close(self, async_client):
+        assert async_client.is_connected()
+        await async_client.close()
+        assert not async_client.is_connected()
 
 
 class TestAsyncCRUD:
-    def test_put_and_get(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            key = ("test", "demo", "async_key1")
-            await c.put(key, {"name": "async", "val": 42})
-            record = await c.get(key)
-            _, meta, bins = record
-            assert bins["name"] == "async"
-            assert bins["val"] == 42
-            assert meta["gen"] >= 1
-            await c.remove(key)
-            await c.close()
+    async def test_put_and_get(self, async_client):
+        key = ("test", "demo", "async_key1")
+        await async_client.put(key, {"name": "async", "val": 42})
+        _, meta, bins = await async_client.get(key)
+        assert bins["name"] == "async"
+        assert bins["val"] == 42
+        assert meta["gen"] >= 1
+        await async_client.remove(key)
 
-        _run(_test())
+    async def test_exists(self, async_client):
+        key = ("test", "demo", "async_exists")
+        await async_client.put(key, {"a": 1})
+        k, meta = await async_client.exists(key)
+        assert meta is not None
 
-    def test_exists(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            key = ("test", "demo", "async_exists")
-            await c.put(key, {"a": 1})
-            result = await c.exists(key)
-            k, meta = result
-            assert meta is not None
+        await async_client.remove(key)
+        k, meta = await async_client.exists(key)
+        assert meta is None
 
-            await c.remove(key)
-            result = await c.exists(key)
-            k, meta = result
-            assert meta is None
-            await c.close()
+    async def test_touch_and_increment(self, async_client):
+        key = ("test", "demo", "async_touch")
+        await async_client.put(key, {"counter": 10})
+        await async_client.touch(key)
+        await async_client.increment(key, "counter", 5)
+        _, _, bins = await async_client.get(key)
+        assert bins["counter"] == 15
+        await async_client.remove(key)
 
-        _run(_test())
-
-    def test_touch_and_increment(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            key = ("test", "demo", "async_touch")
-            await c.put(key, {"counter": 10})
-            await c.touch(key)
-            await c.increment(key, "counter", 5)
-            record = await c.get(key)
-            _, _, bins = record
-            assert bins["counter"] == 15
-            await c.remove(key)
-            await c.close()
-
-        _run(_test())
-
-    def test_operate(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            key = ("test", "demo", "async_operate")
-            await c.put(key, {"a": 1, "b": "hello"})
-            ops = [
-                {"op": aerospike_py.OPERATOR_INCR, "bin": "a", "val": 10},
-                {"op": aerospike_py.OPERATOR_READ, "bin": "a", "val": None},
-            ]
-            record = await c.operate(key, ops)
-            _, _, bins = record
-            val = bins["a"]
-            if isinstance(val, list):
-                assert val[-1] == 11
-            else:
-                assert val == 11
-            await c.remove(key)
-            await c.close()
-
-        _run(_test())
+    async def test_operate(self, async_client):
+        key = ("test", "demo", "async_operate")
+        await async_client.put(key, {"a": 1, "b": "hello"})
+        ops = [
+            {"op": aerospike_py.OPERATOR_INCR, "bin": "a", "val": 10},
+            {"op": aerospike_py.OPERATOR_READ, "bin": "a", "val": None},
+        ]
+        _, _, bins = await async_client.operate(key, ops)
+        val = bins["a"]
+        if isinstance(val, list):
+            assert val[-1] == 11
+        else:
+            assert val == 11
+        await async_client.remove(key)
 
 
 class TestAsyncBatch:
-    def test_get_many(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            keys = [
-                ("test", "demo", "async_batch_1"),
-                ("test", "demo", "async_batch_2"),
-            ]
-            await c.put(keys[0], {"v": 1})
-            await c.put(keys[1], {"v": 2})
-            results = await c.get_many(keys)
-            assert len(results) == 2
-            for _, meta, bins in results:
-                assert meta is not None
-                assert "v" in bins
-            await c.batch_remove(keys)
-            await c.close()
+    async def test_get_many(self, async_client):
+        keys = [
+            ("test", "demo", "async_batch_1"),
+            ("test", "demo", "async_batch_2"),
+        ]
+        await async_client.put(keys[0], {"v": 1})
+        await async_client.put(keys[1], {"v": 2})
+        results = await async_client.get_many(keys)
+        assert len(results) == 2
+        for _, meta, bins in results:
+            assert meta is not None
+            assert "v" in bins
+        await async_client.batch_remove(keys)
 
-        _run(_test())
-
-    def test_exists_many(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            keys = [
-                ("test", "demo", "async_em_1"),
-                ("test", "demo", "async_em_missing"),
-            ]
-            await c.put(keys[0], {"v": 1})
-            results = await c.exists_many(keys)
-            assert len(results) == 2
-            _, meta0 = results[0]
-            _, meta1 = results[1]
-            assert meta0 is not None
-            assert meta1 is None
-            await c.remove(keys[0])
-            await c.close()
-
-        _run(_test())
+    async def test_exists_many(self, async_client):
+        keys = [
+            ("test", "demo", "async_em_1"),
+            ("test", "demo", "async_em_missing"),
+        ]
+        await async_client.put(keys[0], {"v": 1})
+        results = await async_client.exists_many(keys)
+        assert len(results) == 2
+        _, meta0 = results[0]
+        _, meta1 = results[1]
+        assert meta0 is not None
+        assert meta1 is None
+        await async_client.remove(keys[0])
 
 
 class TestAsyncScan:
-    def test_scan(self):
-        async def _test():
-            c = aerospike_py.AsyncClient(CONFIG)
-            await c.connect()
-            key = ("test", "demo", "async_scan_1")
-            await c.put(key, {"s": "data"})
-            results = await c.scan("test", "demo")
-            assert len(results) >= 1
-            await c.remove(key)
-            await c.close()
-
-        _run(_test())
+    async def test_scan(self, async_client):
+        key = ("test", "demo", "async_scan_1")
+        await async_client.put(key, {"s": "data"})
+        results = await async_client.scan("test", "demo")
+        assert len(results) >= 1
+        await async_client.remove(key)


### PR DESCRIPTION
## Summary
- `asyncio_mode = "auto"` 설정을 `pyproject.toml`에 추가하여 `@pytest.mark.asyncio` 없이 async 테스트 자동 인식
- `tests/integration/conftest.py`에 공통 `async_client` fixture 추가 (연결/정리/서버 미가용 시 skip 처리)
- `test_async.py`, `test_async_scenarios.py`에서 `_run(asyncio.run(coro))` 보일러플레이트 패턴 제거
- 테스트당 ~5줄의 중복 코드 제거 (474줄 → 319줄)

## Test plan
- [x] 25개 async integration 테스트 전부 통과 확인