### PR TITLE
fix: address code review issues and CI hang

### DIFF
--- a/.github/actions/wait-for-aerospike/action.yaml
+++ b/.github/actions/wait-for-aerospike/action.yaml
@@ -1,0 +1,32 @@
+name: Wait for Aerospike
+description: Poll until the Aerospike server is accepting connections
+
+inputs:
+  host:
+    description: Aerospike host
+    default: '127.0.0.1'
+  port:
+    description: Aerospike port
+    default: '3000'
+  max-attempts:
+    description: Maximum number of polling attempts
+    default: '30'
+  sleep-seconds:
+    description: Seconds to sleep between attempts
+    default: '2'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        for i in $(seq 1 ${{ inputs.max-attempts }}); do
+          if python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('${{ inputs.host }}',${{ inputs.port }})); s.close()" 2>/dev/null; then
+            echo "Aerospike is ready"
+            exit 0
+          fi
+          echo "Waiting for Aerospike... ($i/${{ inputs.max-attempts }})"
+          sleep ${{ inputs.sleep-seconds }}
+        done
+        echo "::error::Aerospike did not become ready in time"
+        exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,20 +179,12 @@ jobs:
           enable-cache: true
 
       - name: Wait for Aerospike
-        run: |
-          for i in $(seq 1 30); do
-            if python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1',3000)); s.close()" 2>/dev/null; then
-              echo "Aerospike is ready"
-              break
-            fi
-            echo "Waiting for Aerospike... ($i/30)"
-            sleep 2
-          done
+        uses: ./.github/actions/wait-for-aerospike
 
       - name: Run all tests
         run: uvx --with tox-uv tox -e all
 
-  concurrency:
+  test-concurrency:
     name: Concurrency Tests
     runs-on: ubuntu-latest
     services:
@@ -232,20 +224,12 @@ jobs:
           enable-cache: true
 
       - name: Wait for Aerospike
-        run: |
-          for i in $(seq 1 30); do
-            if python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1',3000)); s.close()" 2>/dev/null; then
-              echo "Aerospike is ready"
-              break
-            fi
-            echo "Waiting for Aerospike... ($i/30)"
-            sleep 2
-          done
+        uses: ./.github/actions/wait-for-aerospike
 
       - name: Run concurrency tests
         run: uvx --with tox-uv tox -e concurrency
 
-  concurrency-freethreaded:
+  test-concurrency-freethreaded:
     name: Concurrency Tests (Python 3.14t free-threaded)
     runs-on: ubuntu-latest
     services:
@@ -287,15 +271,7 @@ jobs:
         run: uv python install 3.14t
 
       - name: Wait for Aerospike
-        run: |
-          for i in $(seq 1 30); do
-            if python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1',3000)); s.close()" 2>/dev/null; then
-              echo "Aerospike is ready"
-              break
-            fi
-            echo "Waiting for Aerospike... ($i/30)"
-            sleep 2
-          done
+        uses: ./.github/actions/wait-for-aerospike
 
       - name: Run free-threaded concurrency tests
         run: uvx --with tox-uv tox -e freethreading
@@ -346,15 +322,7 @@ jobs:
           enable-cache: true
 
       - name: Wait for Aerospike
-        run: |
-          for i in $(seq 1 30); do
-            if python3 -c "import socket; s=socket.socket(); s.settimeout(1); s.connect(('127.0.0.1',3000)); s.close()" 2>/dev/null; then
-              echo "Aerospike is ready"
-              break
-            fi
-            echo "Waiting for Aerospike... ($i/30)"
-            sleep 2
-          done
+        uses: ./.github/actions/wait-for-aerospike
 
       - name: Run feasibility test
         run: uvx --with tox-uv tox -e ${{ matrix.test }}

--- a/tests/concurrency/test_async_concurrency.py
+++ b/tests/concurrency/test_async_concurrency.py
@@ -2,6 +2,8 @@
 
 import asyncio
 
+import pytest
+
 import aerospike_py
 
 CONFIG = {"hosts": [("127.0.0.1", 3000)], "cluster_name": "docker"}
@@ -57,9 +59,6 @@ class TestAsyncConcurrency:
             try:
                 await c.connect()
             except Exception:
-                # Server might not be available; skip rather than fail
-                import pytest
-
                 pytest.skip("Aerospike server not available")
             assert c.is_connected()
             await c.close()

--- a/tox.toml
+++ b/tox.toml
@@ -9,27 +9,11 @@ deps = [
     "pytest",
     "pytest-asyncio",
 ]
-
-# --- Python version-specific unit test environments ---
-[env.py310]
-commands = [["pytest", "tests/unit/", "-v"]]
-
-[env.py311]
-commands = [["pytest", "tests/unit/", "-v"]]
-
-[env.py312]
-commands = [["pytest", "tests/unit/", "-v"]]
-
-[env.py313]
-commands = [["pytest", "tests/unit/", "-v"]]
-
-[env.py314]
 commands = [["pytest", "tests/unit/", "-v"]]
 
 # --- Free-threaded Python 3.14t unit tests ---
 [env.py314t]
 base_python = ["python3.14t"]
-commands = [["pytest", "tests/unit/", "-v"]]
 
 # --- Integration tests (requires Aerospike server) ---
 [env.integration]


### PR DESCRIPTION
## Summary
PR #19 코드 리뷰에서 발견된 9개 이슈 수정 + CI integration 테스트 hang 문제 해결

## Fixes

### High
- **thread-safe error collection**: `errors = []` -> `queue.SimpleQueue()` (free-threaded no-GIL 환경에서 race condition 방지)

### Medium
- **CI job 이름 충돌**: `concurrency` -> `test-concurrency` (GitHub Actions 예약 키와 혼동 방지)
- **tox.toml 중복 제거**: py310~py314 동일 commands를 `env_run_base`로 통합
- **TOCTOU race 감소**: `_free_port()`에 `SO_REUSEADDR` 추가
- **deprecated API 교체**: FastAPI `on_event` -> `lifespan` context manager

### Low
- **fixture 중복 제거**: `test_freethreading.py`의 로컬 `client` fixture 제거 (conftest 사용)
- **tmpdir 미정리**: `tempfile.mkdtemp()` -> `TemporaryDirectory()` context manager
- **lazy import 제거**: `test_async_concurrency.py`에서 pytest를 모듈 상단으로 이동

### Info
- **CI 스크립트 중복 제거**: "Wait for Aerospike"를 composite action으로 추출

### CI Hang 버그 수정
- gunicorn 테스트: `subprocess.PIPE` -> `subprocess.DEVNULL` (파이프 버퍼 데드락 방지)
- FastAPI 테스트: `proc.terminate()` 후 `proc.kill()` 폴백 추가

## Test plan
- [ ] CI integration 테스트가 hang 없이 완료되는지 확인
- [ ] `uvx --with tox-uv tox -e py313` unit 테스트 통과
- [ ] free-threaded 환경에서 `queue.SimpleQueue` 정상 동작