### PR TITLE
fix: use in-process ASGI transport for FastAPI, fix gunicorn PID flake

### DIFF
--- a/tox.toml
+++ b/tox.toml
@@ -33,7 +33,6 @@ deps = [
     "pytest",
     "pytest-asyncio",
     "fastapi",
-    "uvicorn",
     "httpx",
 ]
 commands = [["pytest", "tests/feasibility/test_fastapi.py", "-v"]]
@@ -54,7 +53,6 @@ deps = [
     "pytest",
     "pytest-asyncio",
     "fastapi",
-    "uvicorn",
     "httpx",
     "gunicorn",
 ]


### PR DESCRIPTION
## Summary
feasibility 테스트에서 subprocess/fork 관련 문제를 근본적으로 해결

## Changes

### FastAPI test — subprocess 완전 제거
- `multiprocessing.Process` + uvicorn 서버 기동 방식 제거
- `httpx.ASGITransport`로 **in-process** ASGI 테스트
- fork deadlock, spawn timeout, 포트 충돌 문제가 모두 사라짐
- uvicorn 의존성 불필요 → tox fastapi/all 환경에서 제거

### Gunicorn test — keep-alive로 인한 flaky assertion 수정
- `httpx.Client` (keep-alive session)가 모든 요청을 같은 워커로 보내서 PID가 1개만 수집됨
- `httpx.get()` 개별 호출로 변경 → 매 요청마다 새 연결 → 워커 분산 보장

## Test plan
- [ ] CI `tox -e all` integration 테스트 통과
- [ ] CI `tox -e fastapi` 테스트 통과
- [ ] CI `tox -e gunicorn` 테스트에서 PID >= 2 확인