### PR TITLE
feat: add Aerospike config template and update README for Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Aerospike Python Client built with PyO3 + Rust. Drop-in replacement for [aerospi
 
 - Python 3.10+
 - Rust toolchain (rustup)
-- Running Aerospike server (or Docker)
+- Running Aerospike server (or Podman/Docker)
 
 ### Install (from source)
 
@@ -40,15 +40,21 @@ pip install maturin
 maturin develop
 ```
 
-### Start Aerospike Server (Docker)
+### Start Aerospike Server (Podman)
 
 ```bash
-docker run -d --name aerospike \
+podman run -d --name aerospike \
   -p 3000:3000 -p 3001:3001 -p 3002:3002 \
+  --shm-size=1g \
   -e "NAMESPACE=test" \
-  -e "CLUSTER_NAME=docker" \
-  aerospike/aerospike-server
+  -e "DEFAULT_TTL=2592000" \
+  -v ./scripts/aerospike.template.conf:/etc/aerospike/aerospike.template.conf \
+  aerospike:ce-8.1.0.3_1
 ```
+
+> **Note**: 커스텀 template(`scripts/aerospike.template.conf`)에 `access-address 127.0.0.1`이 설정되어 있습니다.
+> Aerospike 컨테이너는 기본적으로 컨테이너 내부 IP(예: `172.17.0.2`)를 클라이언트에게 알려주는데,
+> Rust 기반 client는 이 주소로 재연결을 시도하여 실패합니다. 이 설정이 이를 방지합니다.
 
 ### Basic Usage (Sync)
 
@@ -308,6 +314,8 @@ aerospike-py/
 │   ├── exception.py        # Exception hierarchy re-exports
 │   ├── predicates.py       # Query predicate helpers
 │   └── py.typed            # PEP 561 marker
+├── scripts/
+│   └── aerospike.template.conf  # Aerospike Podman/Docker config template (access-address 포함)
 └── tests/
     ├── unit/               # No server needed
     ├── integration/        # Requires Aerospike server
@@ -331,17 +339,7 @@ maturin build --release
 
 ### Running Tests
 
-Tests require a running Aerospike server (except unit tests). Start one with Docker:
-
-```bash
-docker run -d --name aerospike \
-  -p 3000:3000 -p 3001:3001 -p 3002:3002 \
-  --shm-size=1g \
-  -e "NAMESPACE=test" \
-  -e "CLUSTER_NAME=docker" \
-  -e "DEFAULT_TTL=2592000" \
-  aerospike/aerospike-server
-```
+Tests require a running Aerospike server (except unit tests). 위의 [Start Aerospike Server (Podman)](#start-aerospike-server-podman) 섹션을 참고하여 서버를 실행하세요.
 
 #### tox (recommended)
 

--- a/scripts/aerospike.template.conf
+++ b/scripts/aerospike.template.conf
@@ -1,0 +1,43 @@
+service {
+	$([ -n "${FEATURE_KEY_FILE}" ] && echo "feature-key-file ${FEATURE_KEY_FILE}")
+	cluster-name docker
+}
+
+logging {
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address ${SERVICE_ADDRESS}
+		port ${SERVICE_PORT}
+		access-address 127.0.0.1
+	}
+
+	heartbeat {
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		address local
+		port 3001
+	}
+}
+
+namespace ${NAMESPACE} {
+	replication-factor 1
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "default-ttl ${DEFAULT_TTL}")
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "nsup-period ${NSUP_PERIOD}")
+
+	storage-engine $([ "${DATA_IN_MEMORY}" = "true" ] && echo "memory" || echo "device") {
+		file /opt/aerospike/data/${NAMESPACE}.dat
+		filesize ${STORAGE_GB}G
+		$(([ -z "${DATA_IN_MEMORY}" ] || [ "${DATA_IN_MEMORY}" = "false" ]) && echo "read-page-cache ${READ_PAGE_CACHE}")
+	}
+}


### PR DESCRIPTION
## Summary
- `scripts/aerospike.template.conf` 추가: `access-address 127.0.0.1` 설정으로 Rust client의 Docker/Podman 연결 문제 해결
- README 업데이트: Docker → Podman 가이드 전환, 커스텀 template 마운트 방식 적용, 서버 실행 가이드 중복 제거

## Test plan
- [x] `tox -e all` 231 passed, 9 skipped
- [x] `tox -e compat` 106 passed
- [x] Aerospike CE 8.1 + 커스텀 template 정상 기동 확인