### PR TITLE
fix: benchmark report side effects and timing inconsistencies

### DIFF
--- a/benchmark/bench_compare.py
+++ b/benchmark/bench_compare.py
@@ -294,7 +294,7 @@ def bench_rust_sync(
     for _ in range(rounds):
         scan = client.scan(NAMESPACE, SET_NAME)
         gc.disable()
-        elapsed = _measure_bulk(lambda: scan.results())
+        elapsed = _measure_bulk(lambda s=scan: s.results())
         gc.enable()
         scan_rounds.append(elapsed)
     results["scan"] = _bulk_median(scan_rounds, count)
@@ -418,7 +418,7 @@ def bench_c_sync(
     for _ in range(rounds):
         scan = client.scan(NAMESPACE, SET_NAME)
         gc.disable()
-        elapsed = _measure_bulk(lambda: scan.results())
+        elapsed = _measure_bulk(lambda s=scan: s.results())
         gc.enable()
         scan_rounds.append(elapsed)
     results["scan"] = _bulk_median(scan_rounds, count)
@@ -900,7 +900,7 @@ def main():
         sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
         from report_generator import generate_report
 
-        generate_report(results, json_dir, img_dir)
+        generate_report(results, json_dir, img_dir, date_slug)
         print(
             _c(Color.BOLD_CYAN, "[report]") + f" Generated: {json_dir}/{date_slug}.json"
         )

--- a/benchmark/report_generator.py
+++ b/benchmark/report_generator.py
@@ -413,10 +413,11 @@ def _update_index(json_dir: str, date_slug: str, json_filename: str) -> None:
 # ── main entry point ─────────────────────────────────────────
 
 
-def generate_report(results: BenchmarkResults, json_dir: str, img_dir: str) -> None:
+def generate_report(
+    results: BenchmarkResults, json_dir: str, img_dir: str, date_slug: str
+) -> None:
     """Generate full benchmark report: charts + JSON."""
-    now = datetime.now()
-    date_slug = now.strftime("%Y-%m-%d-%H-%M")
+    now = datetime.fromisoformat(results.timestamp)
     json_filename = f"{date_slug}.json"
 
     # img_dir already includes the date folder from caller


### PR DESCRIPTION
## Summary
- **React 렌더링 중 사이드이펙트 제거**: `TabItem` 내부의 IIFE에서 `loadReport()`를 호출하던 패턴을 `LazyReportView` wrapper 컴포넌트 + `useEffect`로 분리하여 React 렌더링 원칙 준수
- **`datetime.now()` 이중 호출 제거**: `bench_compare.py`에서 생성한 `date_slug`를 `generate_report()`에 인자로 전달하여, 이미지 디렉토리와 JSON 내부 날짜가 불일치할 수 있는 문제 해결
- **scan 객체 라운드별 격리**: `lambda: scan.results()` → `lambda s=scan: s.results()`로 변경하여 각 라운드의 scan 객체가 정확히 캡처되도록 보장

## Test plan
- [ ] `make run-benchmark-report`로 리포트 생성 후 JSON의 date 필드와 이미지 디렉토리명 일치 확인
- [ ] Docusaurus 로컬 서버에서 벤치마크 페이지 탭 전환 시 정상 로딩 확인
- [ ] 브라우저 콘솔에 React 렌더링 경고 없음 확인