### PR TITLE
feat: add batch_read vs batch_read_numpy benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ BENCH_ROUNDS ?= 20
 BENCH_CONCURRENCY ?= 50
 BENCH_BATCH_GROUPS ?= 10
 
+NUMPY_BENCH_ROUNDS ?= 10
+NUMPY_BENCH_CONCURRENCY ?= 50
+NUMPY_BENCH_BATCH_GROUPS ?= 10
+
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
@@ -76,6 +80,24 @@ run-benchmark-report: build run-aerospike-ce ## Run benchmark and generate docs 
 		--host $(AEROSPIKE_HOST) \
 		--port $(AEROSPIKE_PORT) \
 		--report; \
+	$(MAKE) stop-aerospike-ce
+
+.PHONY: run-numpy-benchmark
+run-numpy-benchmark: build run-aerospike-ce ## Run numpy batch benchmark (dict vs numpy comparison)
+	uv run python benchmark/bench_batch_numpy.py \
+		--scenario all --rounds $(NUMPY_BENCH_ROUNDS) \
+		--concurrency $(NUMPY_BENCH_CONCURRENCY) \
+		--batch-groups $(NUMPY_BENCH_BATCH_GROUPS) \
+		--host $(AEROSPIKE_HOST) --port $(AEROSPIKE_PORT); \
+	$(MAKE) stop-aerospike-ce
+
+.PHONY: run-numpy-benchmark-report
+run-numpy-benchmark-report: build run-aerospike-ce ## Run numpy batch benchmark and generate report
+	uv run python benchmark/bench_batch_numpy.py \
+		--scenario all --rounds $(NUMPY_BENCH_ROUNDS) \
+		--concurrency $(NUMPY_BENCH_CONCURRENCY) \
+		--batch-groups $(NUMPY_BENCH_BATCH_GROUPS) \
+		--host $(AEROSPIKE_HOST) --port $(AEROSPIKE_PORT) --report; \
 	$(MAKE) stop-aerospike-ce
 
 # ---------------------------------------------------------------------------

--- a/benchmark/bench_batch_numpy.py
+++ b/benchmark/bench_batch_numpy.py
@@ -1,0 +1,1031 @@
+"""Benchmark: batch_read (dict) vs batch_read_numpy (numpy structured array).
+
+Four scenarios comparing aerospike-py's batch_read return formats:
+  1. Record Count Scaling   – varying record counts
+  2. Bin Count Scaling      – varying bin counts
+  3. Post-Processing        – raw read → column access → filter → aggregation
+  4. Memory Usage           – peak memory via tracemalloc
+
+Usage:
+    python benchmark/bench_batch_numpy.py \
+        --scenario all|record_scaling|bin_scaling|post_processing|memory \
+        --rounds 10 --warmup 200 --concurrency 50 --batch-groups 10 \
+        --host 127.0.0.1 --port 3000 \
+        --report --report-dir DIR --no-color
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import gc
+import os
+import platform
+import sys
+import time
+import tracemalloc
+from dataclasses import dataclass, field
+from datetime import datetime
+
+import numpy as np
+
+# Re-use helpers from bench_compare
+from bench_compare import (
+    Color,
+    _bulk_median,
+    _c,
+    _log,
+    _measure_bulk,
+    _settle,
+)
+
+NAMESPACE = "test"
+SET_NAME = "bench_np"
+WARMUP_COUNT = 200
+
+RECORD_COUNTS = [100, 500, 1000, 5000, 10000]
+BIN_COUNTS = [1, 3, 5, 10, 20]
+POST_STAGES = [
+    ("raw_read", "Raw Read"),
+    ("read_column_access", "Read + Column Access"),
+    ("read_filter", "Read + Filter"),
+    ("read_aggregation", "Read + Aggregation"),
+]
+
+_use_color = True
+
+
+# ── data helpers ──────────────────────────────────────────────
+
+
+def _make_bins(num_bins: int, i: int) -> dict:
+    """Create bin data for record i with num_bins bins."""
+    return {f"bin{b}": float(i * num_bins + b) * 0.1 for b in range(num_bins)}
+
+
+def _make_dtype(num_bins: int) -> np.dtype:
+    """Create numpy dtype for num_bins float bins."""
+    return np.dtype([(f"bin{b}", "f8") for b in range(num_bins)])
+
+
+def _seed_data(client, prefix: str, count: int, num_bins: int):
+    """Seed count records with num_bins bins using sync client."""
+    for i in range(count):
+        client.put(
+            (NAMESPACE, SET_NAME, f"{prefix}{i}"),
+            _make_bins(num_bins, i),
+        )
+
+
+def _cleanup_data(client, prefix: str, count: int):
+    """Remove seeded records."""
+    for i in range(count):
+        try:
+            client.remove((NAMESPACE, SET_NAME, f"{prefix}{i}"))
+        except Exception:
+            pass
+
+
+async def _seed_data_async(
+    client, prefix: str, count: int, num_bins: int, concurrency: int
+):
+    """Seed count records async."""
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _p(i):
+        async with sem:
+            await client.put(
+                (NAMESPACE, SET_NAME, f"{prefix}{i}"),
+                _make_bins(num_bins, i),
+            )
+
+    await asyncio.gather(*[_p(i) for i in range(count)])
+
+
+async def _cleanup_data_async(client, prefix: str, count: int):
+    """Remove seeded records async."""
+    keys = [(NAMESPACE, SET_NAME, f"{prefix}{i}") for i in range(count)]
+    await client.batch_remove(keys)
+
+
+# ── warmup ────────────────────────────────────────────────────
+
+
+def _warmup_sync(client, warmup: int):
+    _log(f"warmup {warmup} ops ...")
+    for i in range(warmup):
+        key = (NAMESPACE, SET_NAME, f"_warm_np_{i}")
+        try:
+            client.put(key, {"w": i})
+            client.get(key)
+            client.remove(key)
+        except Exception:
+            pass
+
+
+async def _warmup_async(client, warmup: int):
+    _log(f"warmup {warmup} ops ...")
+    for i in range(warmup):
+        key = (NAMESPACE, SET_NAME, f"_warm_npa_{i}")
+        try:
+            await client.put(key, {"w": i})
+            await client.get(key)
+            await client.remove(key)
+        except Exception:
+            pass
+
+
+# ── formatting helpers ────────────────────────────────────────
+
+
+def _visible_len(s: str) -> int:
+    import re
+
+    return len(re.sub(r"\033\[[0-9;]*m", "", s))
+
+
+def _lpad(s: str, width: int) -> str:
+    pad = width - _visible_len(s)
+    return " " * max(0, pad) + s
+
+
+def _rpad(s: str, width: int) -> str:
+    pad = width - _visible_len(s)
+    return s + " " * max(0, pad)
+
+
+def _fmt_ms(val: float | None) -> str:
+    if val is None:
+        return "-"
+    return f"{val:.3f}ms"
+
+
+def _speedup(target: float | None, baseline: float | None) -> str:
+    if target is None or baseline is None or target <= 0 or baseline <= 0:
+        return "-"
+    ratio = baseline / target
+    if ratio >= 1.0:
+        text = f"{ratio:.1f}x faster"
+        return _c(Color.GREEN, text) if _use_color else text
+    text = f"{1 / ratio:.1f}x slower"
+    return _c(Color.RED, text) if _use_color else text
+
+
+# ── Scenario 1: Record Count Scaling ─────────────────────────
+
+
+def _run_record_scaling(
+    host: str,
+    port: int,
+    rounds: int,
+    warmup: int,
+    concurrency: int,
+    batch_groups: int,
+) -> dict:
+    import aerospike_py
+    from aerospike_py import AsyncClient
+
+    fixed_bins = 5
+    dtype = _make_dtype(fixed_bins)
+    data = []
+
+    # Sync client
+    client = aerospike_py.client(
+        {"hosts": [(host, port)], "cluster_name": "docker"}
+    ).connect()
+    _warmup_sync(client, warmup)
+
+    for rc in RECORD_COUNTS:
+        prefix = f"rs_{rc}_"
+        _log(f"Record Scaling: seeding {rc} records (bins={fixed_bins}) ...")
+        _seed_data(client, prefix, rc, fixed_bins)
+        _settle()
+
+        keys = [(NAMESPACE, SET_NAME, f"{prefix}{i}") for i in range(rc)]
+        groups = [keys[i::batch_groups] for i in range(batch_groups)]
+
+        # batch_read sync
+        _log(f"  batch_read(Sync) {rc} records x {rounds} rounds")
+        br_rounds = []
+        for _ in range(rounds):
+            gc.disable()
+            elapsed = _measure_bulk(lambda: [client.batch_read(g) for g in groups])
+            gc.enable()
+            br_rounds.append(elapsed)
+        br_sync = _bulk_median(br_rounds, rc)
+
+        # batch_read_numpy sync
+        _log(f"  batch_read_numpy(Sync) {rc} records x {rounds} rounds")
+        np_rounds = []
+        for _ in range(rounds):
+            gc.disable()
+            elapsed = _measure_bulk(
+                lambda: [client.batch_read(g, _dtype=dtype) for g in groups]
+            )
+            gc.enable()
+            np_rounds.append(elapsed)
+        np_sync = _bulk_median(np_rounds, rc)
+
+        _cleanup_data(client, prefix, rc)
+        _settle()
+
+        data.append(
+            {
+                "record_count": rc,
+                "batch_read_sync": br_sync,
+                "batch_read_numpy_sync": np_sync,
+            }
+        )
+
+    client.close()
+
+    # Async client
+    async def _async_part():
+        aclient = AsyncClient({"hosts": [(host, port)], "cluster_name": "docker"})
+        await aclient.connect()
+        await _warmup_async(aclient, warmup)
+
+        for entry in data:
+            rc = entry["record_count"]
+            prefix = f"ra_{rc}_"
+            _log(
+                f"Record Scaling (Async): seeding {rc} records (bins={fixed_bins}) ..."
+            )
+            await _seed_data_async(aclient, prefix, rc, fixed_bins, concurrency)
+            _settle()
+
+            keys = [(NAMESPACE, SET_NAME, f"{prefix}{i}") for i in range(rc)]
+            groups = [keys[i::batch_groups] for i in range(batch_groups)]
+
+            # batch_read async
+            _log(f"  batch_read(Async) {rc} records x {rounds} rounds")
+            br_rounds = []
+            for _ in range(rounds):
+                gc.disable()
+                t0 = time.perf_counter()
+                await asyncio.gather(*[aclient.batch_read(g) for g in groups])
+                elapsed = time.perf_counter() - t0
+                gc.enable()
+                br_rounds.append(elapsed)
+            entry["batch_read_async"] = _bulk_median(br_rounds, rc)
+
+            # batch_read_numpy async
+            _log(f"  batch_read_numpy(Async) {rc} records x {rounds} rounds")
+            np_rounds = []
+            for _ in range(rounds):
+                gc.disable()
+                t0 = time.perf_counter()
+                await asyncio.gather(
+                    *[aclient.batch_read(g, _dtype=dtype) for g in groups]
+                )
+                elapsed = time.perf_counter() - t0
+                gc.enable()
+                np_rounds.append(elapsed)
+            entry["batch_read_numpy_async"] = _bulk_median(np_rounds, rc)
+
+            await _cleanup_data_async(aclient, prefix, rc)
+            _settle()
+
+        await aclient.close()
+
+    asyncio.run(_async_part())
+
+    return {"fixed_bins": fixed_bins, "data": data}
+
+
+# ── Scenario 2: Bin Count Scaling ────────────────────────────
+
+
+def _run_bin_scaling(
+    host: str,
+    port: int,
+    rounds: int,
+    warmup: int,
+    concurrency: int,
+    batch_groups: int,
+) -> dict:
+    import aerospike_py
+    from aerospike_py import AsyncClient
+
+    fixed_records = 1000
+    data = []
+
+    client = aerospike_py.client(
+        {"hosts": [(host, port)], "cluster_name": "docker"}
+    ).connect()
+    _warmup_sync(client, warmup)
+
+    for bc in BIN_COUNTS:
+        prefix = f"bs_{bc}_"
+        dtype = _make_dtype(bc)
+        _log(f"Bin Scaling: seeding {fixed_records} records (bins={bc}) ...")
+        _seed_data(client, prefix, fixed_records, bc)
+        _settle()
+
+        keys = [(NAMESPACE, SET_NAME, f"{prefix}{i}") for i in range(fixed_records)]
+        groups = [keys[i::batch_groups] for i in range(batch_groups)]
+
+        # batch_read sync
+        _log(f"  batch_read(Sync) bins={bc} x {rounds} rounds")
+        br_rounds = []
+        for _ in range(rounds):
+            gc.disable()
+            elapsed = _measure_bulk(lambda: [client.batch_read(g) for g in groups])
+            gc.enable()
+            br_rounds.append(elapsed)
+        br_sync = _bulk_median(br_rounds, fixed_records)
+
+        # batch_read_numpy sync
+        _log(f"  batch_read_numpy(Sync) bins={bc} x {rounds} rounds")
+        np_rounds = []
+        for _ in range(rounds):
+            gc.disable()
+            elapsed = _measure_bulk(
+                lambda: [client.batch_read(g, _dtype=dtype) for g in groups]
+            )
+            gc.enable()
+            np_rounds.append(elapsed)
+        np_sync = _bulk_median(np_rounds, fixed_records)
+
+        _cleanup_data(client, prefix, fixed_records)
+        _settle()
+
+        data.append(
+            {
+                "bin_count": bc,
+                "batch_read_sync": br_sync,
+                "batch_read_numpy_sync": np_sync,
+            }
+        )
+
+    client.close()
+
+    # Async part
+    async def _async_part():
+        aclient = AsyncClient({"hosts": [(host, port)], "cluster_name": "docker"})
+        await aclient.connect()
+        await _warmup_async(aclient, warmup)
+
+        for entry in data:
+            bc = entry["bin_count"]
+            prefix = f"ba_{bc}_"
+            dtype = _make_dtype(bc)
+            _log(
+                f"Bin Scaling (Async): seeding {fixed_records} records (bins={bc}) ..."
+            )
+            await _seed_data_async(aclient, prefix, fixed_records, bc, concurrency)
+            _settle()
+
+            keys = [(NAMESPACE, SET_NAME, f"{prefix}{i}") for i in range(fixed_records)]
+            groups = [keys[i::batch_groups] for i in range(batch_groups)]
+
+            _log(f"  batch_read(Async) bins={bc} x {rounds} rounds")
+            br_rounds = []
+            for _ in range(rounds):
+                gc.disable()
+                t0 = time.perf_counter()
+                await asyncio.gather(*[aclient.batch_read(g) for g in groups])
+                elapsed = time.perf_counter() - t0
+                gc.enable()
+                br_rounds.append(elapsed)
+            entry["batch_read_async"] = _bulk_median(br_rounds, fixed_records)
+
+            _log(f"  batch_read_numpy(Async) bins={bc} x {rounds} rounds")
+            np_rounds = []
+            for _ in range(rounds):
+                gc.disable()
+                t0 = time.perf_counter()
+                await asyncio.gather(
+                    *[aclient.batch_read(g, _dtype=dtype) for g in groups]
+                )
+                elapsed = time.perf_counter() - t0
+                gc.enable()
+                np_rounds.append(elapsed)
+            entry["batch_read_numpy_async"] = _bulk_median(np_rounds, fixed_records)
+
+            await _cleanup_data_async(aclient, prefix, fixed_records)
+            _settle()
+
+        await aclient.close()
+
+    asyncio.run(_async_part())
+
+    return {"fixed_records": fixed_records, "data": data}
+
+
+# ── Scenario 3: Post-Processing ──────────────────────────────
+
+
+def _run_post_processing(
+    host: str,
+    port: int,
+    rounds: int,
+    warmup: int,
+    concurrency: int,
+    batch_groups: int,
+) -> dict:
+    import aerospike_py
+    from aerospike_py import AsyncClient
+
+    record_count = 1000
+    num_bins = 5
+    dtype = _make_dtype(num_bins)
+    prefix = "pp_"
+    data = []
+
+    client = aerospike_py.client(
+        {"hosts": [(host, port)], "cluster_name": "docker"}
+    ).connect()
+    _warmup_sync(client, warmup)
+
+    _log(f"Post-Processing: seeding {record_count} records (bins={num_bins}) ...")
+    _seed_data(client, prefix, record_count, num_bins)
+    _settle()
+
+    keys = [(NAMESPACE, SET_NAME, f"{prefix}{i}") for i in range(record_count)]
+    groups = [keys[i::batch_groups] for i in range(batch_groups)]
+
+    # Define stage functions for dict (sync)
+    def _dict_raw_read():
+        for g in groups:
+            client.batch_read(g)
+
+    def _dict_column_access():
+        for g in groups:
+            results = client.batch_read(g)
+            _ = [
+                br.record[2]["bin0"]
+                for br in results.batch_records
+                if br.record is not None
+            ]
+
+    def _dict_filter():
+        for g in groups:
+            results = client.batch_read(g)
+            _ = [
+                br
+                for br in results.batch_records
+                if br.record is not None and br.record[2].get("bin0", 0) > 50.0
+            ]
+
+    def _dict_aggregation():
+        for g in groups:
+            results = client.batch_read(g)
+            _ = sum(
+                br.record[2]["bin0"]
+                for br in results.batch_records
+                if br.record is not None
+            )
+
+    # Define stage functions for numpy (sync)
+    def _numpy_raw_read():
+        for g in groups:
+            client.batch_read(g, _dtype=dtype)
+
+    def _numpy_column_access():
+        for g in groups:
+            result = client.batch_read(g, _dtype=dtype)
+            _ = result.batch_records["bin0"]
+
+    def _numpy_filter():
+        for g in groups:
+            result = client.batch_read(g, _dtype=dtype)
+            arr = result.batch_records
+            _ = arr[arr["bin0"] > 50.0]
+
+    def _numpy_aggregation():
+        for g in groups:
+            result = client.batch_read(g, _dtype=dtype)
+            _ = result.batch_records["bin0"].sum()
+
+    dict_fns = [_dict_raw_read, _dict_column_access, _dict_filter, _dict_aggregation]
+    numpy_fns = [
+        _numpy_raw_read,
+        _numpy_column_access,
+        _numpy_filter,
+        _numpy_aggregation,
+    ]
+
+    for (stage_key, stage_label), dict_fn, numpy_fn in zip(
+        POST_STAGES, dict_fns, numpy_fns
+    ):
+        _log(f"  Post-Processing: {stage_label} (Sync)")
+
+        # batch_read sync
+        br_rounds = []
+        for _ in range(rounds):
+            gc.disable()
+            elapsed = _measure_bulk(dict_fn)
+            gc.enable()
+            br_rounds.append(elapsed)
+        br_sync = _bulk_median(br_rounds, record_count)
+
+        # batch_read_numpy sync
+        np_rounds = []
+        for _ in range(rounds):
+            gc.disable()
+            elapsed = _measure_bulk(numpy_fn)
+            gc.enable()
+            np_rounds.append(elapsed)
+        np_sync = _bulk_median(np_rounds, record_count)
+
+        data.append(
+            {
+                "stage": stage_key,
+                "stage_label": stage_label,
+                "batch_read_sync": br_sync,
+                "batch_read_numpy_sync": np_sync,
+            }
+        )
+
+    _cleanup_data(client, prefix, record_count)
+    client.close()
+
+    # Async part
+    async def _async_part():
+        aclient = AsyncClient({"hosts": [(host, port)], "cluster_name": "docker"})
+        await aclient.connect()
+        await _warmup_async(aclient, warmup)
+
+        a_prefix = "ppa_"
+        _log(
+            f"Post-Processing (Async): seeding {record_count} records (bins={num_bins}) ..."
+        )
+        await _seed_data_async(aclient, a_prefix, record_count, num_bins, concurrency)
+        _settle()
+
+        a_keys = [(NAMESPACE, SET_NAME, f"{a_prefix}{i}") for i in range(record_count)]
+        a_groups = [a_keys[i::batch_groups] for i in range(batch_groups)]
+
+        # Async stage functions for dict
+        async def _adict_raw_read():
+            await asyncio.gather(*[aclient.batch_read(g) for g in a_groups])
+
+        async def _adict_column_access():
+            all_results = await asyncio.gather(
+                *[aclient.batch_read(g) for g in a_groups]
+            )
+            for results in all_results:
+                _ = [
+                    br.record[2]["bin0"]
+                    for br in results.batch_records
+                    if br.record is not None
+                ]
+
+        async def _adict_filter():
+            all_results = await asyncio.gather(
+                *[aclient.batch_read(g) for g in a_groups]
+            )
+            for results in all_results:
+                _ = [
+                    br
+                    for br in results.batch_records
+                    if br.record is not None and br.record[2].get("bin0", 0) > 50.0
+                ]
+
+        async def _adict_aggregation():
+            all_results = await asyncio.gather(
+                *[aclient.batch_read(g) for g in a_groups]
+            )
+            for results in all_results:
+                _ = sum(
+                    br.record[2]["bin0"]
+                    for br in results.batch_records
+                    if br.record is not None
+                )
+
+        # Async stage functions for numpy
+        async def _anumpy_raw_read():
+            await asyncio.gather(
+                *[aclient.batch_read(g, _dtype=dtype) for g in a_groups]
+            )
+
+        async def _anumpy_column_access():
+            all_results = await asyncio.gather(
+                *[aclient.batch_read(g, _dtype=dtype) for g in a_groups]
+            )
+            for result in all_results:
+                _ = result.batch_records["bin0"]
+
+        async def _anumpy_filter():
+            all_results = await asyncio.gather(
+                *[aclient.batch_read(g, _dtype=dtype) for g in a_groups]
+            )
+            for result in all_results:
+                arr = result.batch_records
+                _ = arr[arr["bin0"] > 50.0]
+
+        async def _anumpy_aggregation():
+            all_results = await asyncio.gather(
+                *[aclient.batch_read(g, _dtype=dtype) for g in a_groups]
+            )
+            for result in all_results:
+                _ = result.batch_records["bin0"].sum()
+
+        adict_fns = [
+            _adict_raw_read,
+            _adict_column_access,
+            _adict_filter,
+            _adict_aggregation,
+        ]
+        anumpy_fns = [
+            _anumpy_raw_read,
+            _anumpy_column_access,
+            _anumpy_filter,
+            _anumpy_aggregation,
+        ]
+
+        for entry, adict_fn, anumpy_fn in zip(data, adict_fns, anumpy_fns):
+            _log(f"  Post-Processing: {entry['stage_label']} (Async)")
+
+            br_rounds = []
+            for _ in range(rounds):
+                gc.disable()
+                t0 = time.perf_counter()
+                await adict_fn()
+                elapsed = time.perf_counter() - t0
+                gc.enable()
+                br_rounds.append(elapsed)
+            entry["batch_read_async"] = _bulk_median(br_rounds, record_count)
+
+            np_rounds = []
+            for _ in range(rounds):
+                gc.disable()
+                t0 = time.perf_counter()
+                await anumpy_fn()
+                elapsed = time.perf_counter() - t0
+                gc.enable()
+                np_rounds.append(elapsed)
+            entry["batch_read_numpy_async"] = _bulk_median(np_rounds, record_count)
+
+        await _cleanup_data_async(aclient, a_prefix, record_count)
+        await aclient.close()
+
+    asyncio.run(_async_part())
+    _settle()
+
+    return {"record_count": record_count, "bin_count": num_bins, "data": data}
+
+
+# ── Scenario 4: Memory Usage ─────────────────────────────────
+
+
+def _run_memory(
+    host: str,
+    port: int,
+    rounds: int,
+    warmup: int,
+    batch_groups: int,
+) -> dict:
+    import aerospike_py
+
+    num_bins = 5
+    dtype = _make_dtype(num_bins)
+    data = []
+
+    client = aerospike_py.client(
+        {"hosts": [(host, port)], "cluster_name": "docker"}
+    ).connect()
+    _warmup_sync(client, warmup)
+
+    for rc in RECORD_COUNTS:
+        prefix = f"mem_{rc}_"
+        _log(f"Memory: seeding {rc} records (bins={num_bins}) ...")
+        _seed_data(client, prefix, rc, num_bins)
+        _settle()
+
+        keys = [(NAMESPACE, SET_NAME, f"{prefix}{i}") for i in range(rc)]
+        groups = [keys[i::batch_groups] for i in range(batch_groups)]
+
+        # Measure dict peak memory
+        _log(f"  dict peak memory ({rc} records)")
+        gc.collect()
+        tracemalloc.start()
+        for _ in range(rounds):
+            _ = [client.batch_read(g) for g in groups]
+        _, dict_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        dict_peak_kb = dict_peak / 1024
+
+        # Measure numpy peak memory
+        _log(f"  numpy peak memory ({rc} records)")
+        gc.collect()
+        tracemalloc.start()
+        for _ in range(rounds):
+            _ = [client.batch_read(g, _dtype=dtype) for g in groups]
+        _, numpy_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        numpy_peak_kb = numpy_peak / 1024
+
+        savings_pct = (
+            ((dict_peak_kb - numpy_peak_kb) / dict_peak_kb * 100)
+            if dict_peak_kb > 0
+            else 0
+        )
+
+        _cleanup_data(client, prefix, rc)
+        _settle()
+
+        data.append(
+            {
+                "record_count": rc,
+                "dict_peak_kb": round(dict_peak_kb, 1),
+                "numpy_peak_kb": round(numpy_peak_kb, 1),
+                "savings_pct": round(savings_pct, 1),
+            }
+        )
+
+    client.close()
+    return {"bin_count": num_bins, "data": data}
+
+
+# ── terminal output ──────────────────────────────────────────
+
+
+COL_W = 18
+
+
+def _print_scaling_table(
+    title: str, x_label: str, x_key: str, result: dict, rounds: int
+):
+    data = result["data"]
+    fixed_info = ""
+    if "fixed_bins" in result:
+        fixed_info = f"bins={result['fixed_bins']}"
+    elif "fixed_records" in result:
+        fixed_info = f"records={result['fixed_records']}"
+
+    header = f"{title} ({fixed_info}, rounds={rounds})"
+    print(f"\n  {_c(Color.BOLD_CYAN, header) if _use_color else header}")
+    w = 10 + COL_W * 4 + COL_W * 2 + 20
+    sep = "─" * w
+    print(f"  {_c(Color.DIM, sep) if _use_color else sep}")
+
+    h = f"  {x_label:>8}"
+    h += f" | {'batch_read(Sync)':>{COL_W}}"
+    h += f" | {'numpy(Sync)':>{COL_W}}"
+    h += f" | {'batch_read(Async)':>{COL_W}}"
+    h += f" | {'numpy(Async)':>{COL_W}}"
+    h += f" | {'Speedup(Sync)':>{COL_W}}"
+    h += f" | {'Speedup(Async)':>{COL_W}}"
+    print(h)
+    print(f"  {_c(Color.DIM, sep) if _use_color else sep}")
+
+    for entry in data:
+        x_val = entry[x_key]
+        br_s = entry["batch_read_sync"]["avg_ms"]
+        np_s = entry["batch_read_numpy_sync"]["avg_ms"]
+        br_a = entry.get("batch_read_async", {}).get("avg_ms")
+        np_a = entry.get("batch_read_numpy_async", {}).get("avg_ms")
+
+        sp_s = _speedup(np_s, br_s)
+        sp_a = _speedup(np_a, br_a)
+
+        line = f"  {x_val:>8,}"
+        line += f" | {_fmt_ms(br_s):>{COL_W}}"
+        line += f" | {_fmt_ms(np_s):>{COL_W}}"
+        line += f" | {_fmt_ms(br_a):>{COL_W}}"
+        line += f" | {_fmt_ms(np_a):>{COL_W}}"
+        line += f" | {_lpad(sp_s, COL_W)}"
+        line += f" | {_lpad(sp_a, COL_W)}"
+        print(line)
+
+
+def _print_post_processing_table(result: dict, rounds: int):
+    data = result["data"]
+    header = f"Post-Processing (records={result['record_count']}, bins={result['bin_count']}, rounds={rounds})"
+    print(f"\n  {_c(Color.BOLD_CYAN, header) if _use_color else header}")
+    w = 24 + COL_W * 4 + COL_W * 2 + 20
+    sep = "─" * w
+    print(f"  {_c(Color.DIM, sep) if _use_color else sep}")
+
+    h = f"  {'Stage':<22}"
+    h += f" | {'batch_read(Sync)':>{COL_W}}"
+    h += f" | {'numpy(Sync)':>{COL_W}}"
+    h += f" | {'batch_read(Async)':>{COL_W}}"
+    h += f" | {'numpy(Async)':>{COL_W}}"
+    h += f" | {'Speedup(Sync)':>{COL_W}}"
+    h += f" | {'Speedup(Async)':>{COL_W}}"
+    print(h)
+    print(f"  {_c(Color.DIM, sep) if _use_color else sep}")
+
+    for entry in data:
+        label = entry["stage_label"]
+        br_s = entry["batch_read_sync"]["avg_ms"]
+        np_s = entry["batch_read_numpy_sync"]["avg_ms"]
+        br_a = entry.get("batch_read_async", {}).get("avg_ms")
+        np_a = entry.get("batch_read_numpy_async", {}).get("avg_ms")
+
+        sp_s = _speedup(np_s, br_s)
+        sp_a = _speedup(np_a, br_a)
+
+        line = f"  {label:<22}"
+        line += f" | {_fmt_ms(br_s):>{COL_W}}"
+        line += f" | {_fmt_ms(np_s):>{COL_W}}"
+        line += f" | {_fmt_ms(br_a):>{COL_W}}"
+        line += f" | {_fmt_ms(np_a):>{COL_W}}"
+        line += f" | {_lpad(sp_s, COL_W)}"
+        line += f" | {_lpad(sp_a, COL_W)}"
+        print(line)
+
+
+def _print_memory_table(result: dict, rounds: int):
+    data = result["data"]
+    header = f"Memory Usage (bins={result['bin_count']}, rounds={rounds}, Sync only)"
+    print(f"\n  {_c(Color.BOLD_CYAN, header) if _use_color else header}")
+    w = 10 + 16 * 3 + 10
+    sep = "─" * w
+    print(f"  {_c(Color.DIM, sep) if _use_color else sep}")
+
+    h = f"  {'Records':>8}"
+    h += f" | {'dict peak (KB)':>14}"
+    h += f" | {'numpy peak (KB)':>15}"
+    h += f" | {'Savings':>10}"
+    print(h)
+    print(f"  {_c(Color.DIM, sep) if _use_color else sep}")
+
+    for entry in data:
+        savings = f"{entry['savings_pct']:.1f}%"
+        if entry["savings_pct"] > 0:
+            savings = _c(Color.GREEN, savings) if _use_color else savings
+        elif entry["savings_pct"] < 0:
+            savings = _c(Color.RED, savings) if _use_color else savings
+
+        line = f"  {entry['record_count']:>8,}"
+        line += f" | {entry['dict_peak_kb']:>14,.1f}"
+        line += f" | {entry['numpy_peak_kb']:>15,.1f}"
+        line += f" | {_lpad(savings, 10)}"
+        print(line)
+
+
+# ── main ──────────────────────────────────────────────────────
+
+
+@dataclass
+class NumpyBenchmarkResults:
+    record_scaling: dict | None = None
+    bin_scaling: dict | None = None
+    post_processing: dict | None = None
+    memory: dict | None = None
+    rounds: int = 10
+    warmup: int = 200
+    concurrency: int = 50
+    batch_groups: int = 10
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    python_version: str = field(default_factory=platform.python_version)
+    platform_info: str = field(
+        default_factory=lambda: f"{platform.system()} {platform.machine()}"
+    )
+
+
+def main():
+    global _use_color
+
+    parser = argparse.ArgumentParser(
+        description="Benchmark: batch_read (dict) vs batch_read_numpy (numpy)"
+    )
+    parser.add_argument(
+        "--scenario",
+        default="all",
+        choices=["all", "record_scaling", "bin_scaling", "post_processing", "memory"],
+        help="Scenario to run (default: all)",
+    )
+    parser.add_argument("--rounds", type=int, default=10, help="Rounds per measurement")
+    parser.add_argument("--warmup", type=int, default=WARMUP_COUNT, help="Warmup ops")
+    parser.add_argument("--concurrency", type=int, default=50, help="Async concurrency")
+    parser.add_argument(
+        "--batch-groups",
+        type=int,
+        default=10,
+        help="Number of groups for batch_read",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=3000)
+    parser.add_argument(
+        "--no-color", action="store_true", help="Disable colored output"
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Generate benchmark report (JSON)",
+    )
+    parser.add_argument(
+        "--report-dir",
+        default=None,
+        help="Report JSON output directory",
+    )
+    args = parser.parse_args()
+
+    if args.no_color or not sys.stdout.isatty():
+        _use_color = False
+
+    scenarios = (
+        ["record_scaling", "bin_scaling", "post_processing", "memory"]
+        if args.scenario == "all"
+        else [args.scenario]
+    )
+
+    print("NumPy Batch Benchmark config:")
+    print(f"  scenarios    = {', '.join(scenarios)}")
+    print(f"  rounds       = {args.rounds}")
+    print(f"  warmup       = {args.warmup}")
+    print(f"  concurrency  = {args.concurrency}")
+    print(f"  batch_groups = {args.batch_groups}")
+    print(f"  server       = {args.host}:{args.port}")
+    print()
+
+    results = NumpyBenchmarkResults(
+        rounds=args.rounds,
+        warmup=args.warmup,
+        concurrency=args.concurrency,
+        batch_groups=args.batch_groups,
+    )
+
+    step = 0
+    total = len(scenarios)
+
+    if "record_scaling" in scenarios:
+        step += 1
+        print(_c(Color.BOLD_CYAN, f"[{step}/{total}]") + " Record Count Scaling ...")
+        results.record_scaling = _run_record_scaling(
+            args.host,
+            args.port,
+            args.rounds,
+            args.warmup,
+            args.concurrency,
+            args.batch_groups,
+        )
+        _print_scaling_table(
+            "Record Count Scaling",
+            "Records",
+            "record_count",
+            results.record_scaling,
+            args.rounds,
+        )
+        print()
+
+    if "bin_scaling" in scenarios:
+        step += 1
+        print(_c(Color.BOLD_CYAN, f"[{step}/{total}]") + " Bin Count Scaling ...")
+        results.bin_scaling = _run_bin_scaling(
+            args.host,
+            args.port,
+            args.rounds,
+            args.warmup,
+            args.concurrency,
+            args.batch_groups,
+        )
+        _print_scaling_table(
+            "Bin Count Scaling",
+            "Bins",
+            "bin_count",
+            results.bin_scaling,
+            args.rounds,
+        )
+        print()
+
+    if "post_processing" in scenarios:
+        step += 1
+        print(_c(Color.BOLD_CYAN, f"[{step}/{total}]") + " Post-Processing ...")
+        results.post_processing = _run_post_processing(
+            args.host,
+            args.port,
+            args.rounds,
+            args.warmup,
+            args.concurrency,
+            args.batch_groups,
+        )
+        _print_post_processing_table(results.post_processing, args.rounds)
+        print()
+
+    if "memory" in scenarios:
+        step += 1
+        print(_c(Color.BOLD_CYAN, f"[{step}/{total}]") + " Memory Usage ...")
+        results.memory = _run_memory(
+            args.host,
+            args.port,
+            args.rounds,
+            args.warmup,
+            args.batch_groups,
+        )
+        _print_memory_table(results.memory, args.rounds)
+        print()
+
+    if args.report:
+        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        date_slug = datetime.now().strftime("%Y-%m-%d_%H:%M")
+        json_dir = args.report_dir or os.path.join(
+            project_root, "docs", "static", "benchmark", "numpy-results"
+        )
+
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from report_generator import generate_numpy_report
+
+        generate_numpy_report(results, json_dir, date_slug)
+        print(
+            _c(Color.BOLD_CYAN, "[report]") + f" Generated: {json_dir}/{date_slug}.json"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/report_generator.py
+++ b/benchmark/report_generator.py
@@ -15,11 +15,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from bench_compare import BenchmarkResults
 
-OPERATIONS = ["put", "get", "batch_read", "batch_write", "scan"]
+OPERATIONS = ["put", "get", "batch_read", "batch_read_numpy", "batch_write", "scan"]
 OP_LABELS = {
     "put": "PUT",
     "get": "GET",
     "batch_read": "BATCH_READ",
+    "batch_read_numpy": "BATCH_READ_NUMPY",
     "batch_write": "BATCH_WRITE",
     "scan": "SCAN",
 }
@@ -67,6 +68,38 @@ def _generate_takeaways(results: BenchmarkResults) -> list[str]:
                 f"AsyncClient shows **{best_async_ratio:.1f}x** faster latency "
                 f"than the official client in {OP_LABELS[best_async_op]} operations"
             )
+
+    # batch_read_numpy (Sync/Async) vs Official batch_read comparison
+    if has_c:
+        numpy_sync = results.rust_sync.get("batch_read_numpy", {}).get("avg_ms", 0)
+        numpy_async = results.rust_async.get("batch_read_numpy", {}).get("avg_ms", 0)
+        official_br = results.c_sync.get("batch_read", {}).get("avg_ms", 0)
+        if numpy_sync and official_br and numpy_sync > 0 and official_br > 0:
+            ratio = official_br / numpy_sync
+            if ratio >= 1.0:
+                takeaways.append(
+                    f"BATCH_READ_NUMPY (SyncClient) is **{ratio:.1f}x** faster than "
+                    f"official BATCH_READ (returns numpy structured array vs Python dict)"
+                )
+            else:
+                inv = 1 / ratio
+                takeaways.append(
+                    f"BATCH_READ_NUMPY (SyncClient) is **{inv:.1f}x** slower than "
+                    f"official BATCH_READ (returns numpy structured array vs Python dict)"
+                )
+        if numpy_async and official_br and numpy_async > 0 and official_br > 0:
+            ratio = official_br / numpy_async
+            if ratio >= 1.0:
+                takeaways.append(
+                    f"BATCH_READ_NUMPY (AsyncClient) is **{ratio:.1f}x** faster than "
+                    f"official BATCH_READ (returns numpy structured array vs Python dict)"
+                )
+            else:
+                inv = 1 / ratio
+                takeaways.append(
+                    f"BATCH_READ_NUMPY (AsyncClient) is **{inv:.1f}x** slower than "
+                    f"official BATCH_READ (returns numpy structured array vs Python dict)"
+                )
 
     # Async vs sync advantage
     best_async_sync_op = None
@@ -136,6 +169,174 @@ def _update_index(json_dir: str, date_slug: str, json_filename: str) -> None:
     with open(index_path, "w") as f:
         json.dump(index, f, indent=2, ensure_ascii=False)
         f.write("\n")
+
+
+# ── numpy batch report ────────────────────────────────────────
+
+
+def _numpy_takeaways(results) -> list[str]:
+    """Generate key insights from numpy batch benchmark results."""
+    takeaways = []
+
+    # Record scaling insight
+    if results.record_scaling:
+        data = results.record_scaling["data"]
+        if len(data) >= 2:
+            last = data[-1]
+            sync_ratio = (
+                last["batch_read_sync"]["avg_ms"]
+                / last["batch_read_numpy_sync"]["avg_ms"]
+                if last["batch_read_numpy_sync"]["avg_ms"] > 0
+                else 0
+            )
+            if sync_ratio > 1:
+                takeaways.append(
+                    f"At {last['record_count']:,} records, batch_read_numpy is "
+                    f"**{sync_ratio:.1f}x** faster than batch_read (Sync)"
+                )
+
+    # Post-processing insight
+    if results.post_processing:
+        data = results.post_processing["data"]
+        agg = next((d for d in data if d["stage"] == "read_aggregation"), None)
+        if agg:
+            sync_ratio = (
+                agg["batch_read_sync"]["avg_ms"]
+                / agg["batch_read_numpy_sync"]["avg_ms"]
+                if agg["batch_read_numpy_sync"]["avg_ms"] > 0
+                else 0
+            )
+            if sync_ratio > 1:
+                takeaways.append(
+                    f"Aggregation with numpy is **{sync_ratio:.1f}x** faster than dict-based processing"
+                )
+
+    # Memory insight
+    if results.memory:
+        data = results.memory["data"]
+        if data:
+            last = data[-1]
+            if last["savings_pct"] > 0:
+                takeaways.append(
+                    f"At {last['record_count']:,} records, numpy uses "
+                    f"**{last['savings_pct']:.0f}%** less memory than dict"
+                )
+
+    if not takeaways:
+        takeaways.append("Benchmark results collected successfully")
+
+    return takeaways
+
+
+def _metrics_dict(d: dict) -> dict:
+    """Extract avg_ms, ops_per_sec, stdev_ms from a bulk_median result."""
+    return {
+        "avg_ms": d.get("avg_ms"),
+        "ops_per_sec": d.get("ops_per_sec"),
+        "stdev_ms": d.get("stdev_ms"),
+    }
+
+
+def generate_numpy_report(results, json_dir: str, date_slug: str) -> None:
+    """Generate numpy batch benchmark report JSON."""
+    now = datetime.fromisoformat(results.timestamp)
+    json_filename = f"{date_slug}.json"
+
+    os.makedirs(json_dir, exist_ok=True)
+
+    print("\n  Generating numpy batch benchmark report...")
+    print(f"    JSON dir: {json_dir}")
+
+    report: dict = {
+        "timestamp": now.isoformat(),
+        "date": date_slug,
+        "report_type": "numpy_batch",
+        "environment": {
+            "platform": results.platform_info,
+            "python_version": results.python_version,
+            "rounds": results.rounds,
+            "warmup": results.warmup,
+            "concurrency": results.concurrency,
+            "batch_groups": results.batch_groups,
+        },
+    }
+
+    # Record scaling
+    if results.record_scaling:
+        report["record_scaling"] = {
+            "fixed_bins": results.record_scaling["fixed_bins"],
+            "data": [
+                {
+                    "record_count": d["record_count"],
+                    "batch_read_sync": _metrics_dict(d["batch_read_sync"]),
+                    "batch_read_numpy_sync": _metrics_dict(d["batch_read_numpy_sync"]),
+                    "batch_read_async": _metrics_dict(d.get("batch_read_async", {})),
+                    "batch_read_numpy_async": _metrics_dict(
+                        d.get("batch_read_numpy_async", {})
+                    ),
+                }
+                for d in results.record_scaling["data"]
+            ],
+        }
+
+    # Bin scaling
+    if results.bin_scaling:
+        report["bin_scaling"] = {
+            "fixed_records": results.bin_scaling["fixed_records"],
+            "data": [
+                {
+                    "bin_count": d["bin_count"],
+                    "batch_read_sync": _metrics_dict(d["batch_read_sync"]),
+                    "batch_read_numpy_sync": _metrics_dict(d["batch_read_numpy_sync"]),
+                    "batch_read_async": _metrics_dict(d.get("batch_read_async", {})),
+                    "batch_read_numpy_async": _metrics_dict(
+                        d.get("batch_read_numpy_async", {})
+                    ),
+                }
+                for d in results.bin_scaling["data"]
+            ],
+        }
+
+    # Post-processing
+    if results.post_processing:
+        report["post_processing"] = {
+            "record_count": results.post_processing["record_count"],
+            "bin_count": results.post_processing["bin_count"],
+            "data": [
+                {
+                    "stage": d["stage"],
+                    "stage_label": d["stage_label"],
+                    "batch_read_sync": _metrics_dict(d["batch_read_sync"]),
+                    "batch_read_numpy_sync": _metrics_dict(d["batch_read_numpy_sync"]),
+                    "batch_read_async": _metrics_dict(d.get("batch_read_async", {})),
+                    "batch_read_numpy_async": _metrics_dict(
+                        d.get("batch_read_numpy_async", {})
+                    ),
+                }
+                for d in results.post_processing["data"]
+            ],
+        }
+
+    # Memory
+    if results.memory:
+        report["memory"] = {
+            "bin_count": results.memory["bin_count"],
+            "data": results.memory["data"],
+        }
+
+    report["takeaways"] = _numpy_takeaways(results)
+
+    # Write JSON
+    json_path = os.path.join(json_dir, json_filename)
+    with open(json_path, "w") as f:
+        json.dump(report, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print(f"    JSON: {json_filename}")
+
+    # Update index.json
+    _update_index(json_dir, date_slug, json_filename)
+    print("    Index: index.json updated")
+    print("  Done.\n")
 
 
 # ── main entry point ─────────────────────────────────────────

--- a/docs/docs/performance/numpy-benchmark-results.mdx
+++ b/docs/docs/performance/numpy-benchmark-results.mdx
@@ -1,0 +1,9 @@
+---
+title: NumPy Batch Benchmark
+sidebar_label: NumPy Batch Benchmark
+sidebar_position: 3
+---
+
+import NumpyBenchmarkReport from '@site/src/components/NumpyBenchmarkReport';
+
+<NumpyBenchmarkReport />

--- a/docs/docs/performance/overview.md
+++ b/docs/docs/performance/overview.md
@@ -74,3 +74,5 @@ make run-benchmark BENCH_COUNT=10000 BENCH_ROUNDS=30 BENCH_CONCURRENCY=100
 ## Latest Results
 
 See the [Benchmark Results](./benchmark-results) page for the latest benchmark results.
+
+See the [NumPy Batch Benchmark](./numpy-benchmark-results) page for dict vs numpy batch_read comparison.

--- a/docs/src/components/NumpyBenchmarkReport/NumpyBenchmarkReport.module.css
+++ b/docs/src/components/NumpyBenchmarkReport/NumpyBenchmarkReport.module.css
@@ -1,0 +1,64 @@
+.container {
+  padding: 1rem 0;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  margin: 1rem 0 2rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.table th,
+.table td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  text-align: left;
+}
+
+.table th {
+  background: var(--ifm-color-emphasis-100);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.table tbody tr:hover {
+  background: var(--ifm-color-emphasis-50);
+}
+
+.numCell {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.faster {
+  color: var(--ifm-color-success-darkest, #2e7d32);
+  font-weight: 700;
+}
+
+.slower {
+  color: var(--ifm-color-danger-darkest, #c62828);
+  font-style: italic;
+}
+
+.chartWrap {
+  min-height: 400px;
+  margin: 1rem 0 2rem;
+}
+
+.errorBox {
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  border: 1px solid var(--ifm-color-danger);
+  background: var(--ifm-color-danger-contrast-background);
+  margin: 1rem 0;
+}
+
+.errorBox pre {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+}

--- a/docs/src/components/NumpyBenchmarkReport/charts.tsx
+++ b/docs/src/components/NumpyBenchmarkReport/charts.tsx
@@ -1,0 +1,310 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+
+// ── Types ───────────────────────────────────────────────────
+
+interface MetricsEntry {
+  avg_ms: number | null;
+  ops_per_sec: number | null;
+  stdev_ms: number | null;
+}
+
+interface RecordScalingEntry {
+  record_count: number;
+  batch_read_sync: MetricsEntry;
+  batch_read_numpy_sync: MetricsEntry;
+  batch_read_async: MetricsEntry;
+  batch_read_numpy_async: MetricsEntry;
+}
+
+interface BinScalingEntry {
+  bin_count: number;
+  batch_read_sync: MetricsEntry;
+  batch_read_numpy_sync: MetricsEntry;
+  batch_read_async: MetricsEntry;
+  batch_read_numpy_async: MetricsEntry;
+}
+
+interface PostProcessingEntry {
+  stage: string;
+  stage_label: string;
+  batch_read_sync: MetricsEntry;
+  batch_read_numpy_sync: MetricsEntry;
+  batch_read_async: MetricsEntry;
+  batch_read_numpy_async: MetricsEntry;
+}
+
+interface MemoryEntry {
+  record_count: number;
+  dict_peak_kb: number;
+  numpy_peak_kb: number;
+  savings_pct: number;
+}
+
+export interface NumpyBenchmarkData {
+  timestamp: string;
+  date: string;
+  report_type: string;
+  environment: {
+    platform: string;
+    python_version: string;
+    rounds: number;
+    warmup: number;
+    concurrency: number;
+    batch_groups: number;
+  };
+  record_scaling?: {
+    fixed_bins: number;
+    data: RecordScalingEntry[];
+  };
+  bin_scaling?: {
+    fixed_records: number;
+    data: BinScalingEntry[];
+  };
+  post_processing?: {
+    record_count: number;
+    bin_count: number;
+    data: PostProcessingEntry[];
+  };
+  memory?: {
+    bin_count: number;
+    data: MemoryEntry[];
+  };
+  takeaways: string[];
+}
+
+type ColorMode = 'light' | 'dark';
+
+// ── Constants ───────────────────────────────────────────────
+
+const COLOR_DICT_SYNC = '#673ab7';   // purple
+const COLOR_NUMPY_SYNC = '#e91e63';  // pink
+const COLOR_DICT_ASYNC = '#4caf50';  // green
+const COLOR_NUMPY_ASYNC = '#2196f3'; // blue
+
+function themeColors(colorMode: ColorMode) {
+  const isDark = colorMode === 'dark';
+  return {
+    text: isDark ? '#e0e0e0' : '#333333',
+    grid: isDark ? '#444444' : '#cccccc',
+    tooltipBg: isDark ? '#1e1e1e' : '#ffffff',
+    tooltipBorder: isDark ? '#555555' : '#cccccc',
+  };
+}
+
+// ── Custom Tooltip ──────────────────────────────────────────
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  colorMode,
+  unit,
+}: {
+  active?: boolean;
+  payload?: Array<{name: string; value: number; color: string}>;
+  label?: string;
+  colorMode: ColorMode;
+  unit: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const theme = themeColors(colorMode);
+  return (
+    <div
+      style={{
+        background: theme.tooltipBg,
+        border: `1px solid ${theme.tooltipBorder}`,
+        borderRadius: 6,
+        padding: '8px 12px',
+        fontSize: 13,
+      }}
+    >
+      <p style={{margin: 0, fontWeight: 600, color: theme.text}}>{label}</p>
+      {payload.map((entry, i) => (
+        <p key={i} style={{margin: '4px 0 0', color: entry.color}}>
+          {entry.name}:{' '}
+          {unit === 'ms'
+            ? `${entry.value.toFixed(3)}ms`
+            : unit === 'kb'
+              ? `${entry.value.toLocaleString()} KB`
+              : `${entry.value.toLocaleString()}/s`}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+// ── Record Scaling Chart ────────────────────────────────────
+
+export function RecordScalingChart({
+  data,
+  colorMode,
+}: {
+  data: NumpyBenchmarkData;
+  colorMode: ColorMode;
+}) {
+  if (!data.record_scaling) return null;
+  const theme = themeColors(colorMode);
+
+  const chartData = data.record_scaling.data.map((d) => ({
+    records: d.record_count.toLocaleString(),
+    'batch_read (Sync)': d.batch_read_sync.avg_ms ?? 0,
+    'numpy (Sync)': d.batch_read_numpy_sync.avg_ms ?? 0,
+    'batch_read (Async)': d.batch_read_async.avg_ms ?? 0,
+    'numpy (Async)': d.batch_read_numpy_async.avg_ms ?? 0,
+  }));
+
+  return (
+    <div style={{width: '100%', minHeight: 400, margin: '1rem 0'}}>
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart data={chartData} margin={{top: 20, right: 30, left: 20, bottom: 5}}>
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />
+          <XAxis dataKey="records" tick={{fill: theme.text}} />
+          <YAxis
+            tick={{fill: theme.text}}
+            label={{value: 'Latency (ms)', angle: -90, position: 'insideLeft', fill: theme.text}}
+          />
+          <Tooltip content={<ChartTooltip colorMode={colorMode} unit="ms" />} />
+          <Legend wrapperStyle={{color: theme.text}} />
+          <Line type="monotone" dataKey="batch_read (Sync)" stroke={COLOR_DICT_SYNC} strokeWidth={2} dot={{r: 4}} />
+          <Line type="monotone" dataKey="numpy (Sync)" stroke={COLOR_NUMPY_SYNC} strokeWidth={2} dot={{r: 4}} />
+          <Line type="monotone" dataKey="batch_read (Async)" stroke={COLOR_DICT_ASYNC} strokeWidth={2} dot={{r: 4}} />
+          <Line type="monotone" dataKey="numpy (Async)" stroke={COLOR_NUMPY_ASYNC} strokeWidth={2} dot={{r: 4}} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ── Bin Scaling Chart ───────────────────────────────────────
+
+export function BinScalingChart({
+  data,
+  colorMode,
+}: {
+  data: NumpyBenchmarkData;
+  colorMode: ColorMode;
+}) {
+  if (!data.bin_scaling) return null;
+  const theme = themeColors(colorMode);
+
+  const chartData = data.bin_scaling.data.map((d) => ({
+    bins: d.bin_count.toString(),
+    'batch_read (Sync)': d.batch_read_sync.avg_ms ?? 0,
+    'numpy (Sync)': d.batch_read_numpy_sync.avg_ms ?? 0,
+    'batch_read (Async)': d.batch_read_async.avg_ms ?? 0,
+    'numpy (Async)': d.batch_read_numpy_async.avg_ms ?? 0,
+  }));
+
+  return (
+    <div style={{width: '100%', minHeight: 400, margin: '1rem 0'}}>
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart data={chartData} margin={{top: 20, right: 30, left: 20, bottom: 5}}>
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />
+          <XAxis dataKey="bins" tick={{fill: theme.text}} />
+          <YAxis
+            tick={{fill: theme.text}}
+            label={{value: 'Latency (ms)', angle: -90, position: 'insideLeft', fill: theme.text}}
+          />
+          <Tooltip content={<ChartTooltip colorMode={colorMode} unit="ms" />} />
+          <Legend wrapperStyle={{color: theme.text}} />
+          <Line type="monotone" dataKey="batch_read (Sync)" stroke={COLOR_DICT_SYNC} strokeWidth={2} dot={{r: 4}} />
+          <Line type="monotone" dataKey="numpy (Sync)" stroke={COLOR_NUMPY_SYNC} strokeWidth={2} dot={{r: 4}} />
+          <Line type="monotone" dataKey="batch_read (Async)" stroke={COLOR_DICT_ASYNC} strokeWidth={2} dot={{r: 4}} />
+          <Line type="monotone" dataKey="numpy (Async)" stroke={COLOR_NUMPY_ASYNC} strokeWidth={2} dot={{r: 4}} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ── Post-Processing Chart ───────────────────────────────────
+
+export function PostProcessingChart({
+  data,
+  colorMode,
+}: {
+  data: NumpyBenchmarkData;
+  colorMode: ColorMode;
+}) {
+  if (!data.post_processing) return null;
+  const theme = themeColors(colorMode);
+
+  const chartData = data.post_processing.data.map((d) => ({
+    stage: d.stage_label,
+    'batch_read (Sync)': d.batch_read_sync.avg_ms ?? 0,
+    'numpy (Sync)': d.batch_read_numpy_sync.avg_ms ?? 0,
+    'batch_read (Async)': d.batch_read_async.avg_ms ?? 0,
+    'numpy (Async)': d.batch_read_numpy_async.avg_ms ?? 0,
+  }));
+
+  return (
+    <div style={{width: '100%', minHeight: 400, margin: '1rem 0'}}>
+      <ResponsiveContainer width="100%" height={400}>
+        <BarChart data={chartData} margin={{top: 20, right: 30, left: 20, bottom: 5}}>
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />
+          <XAxis dataKey="stage" tick={{fill: theme.text}} />
+          <YAxis
+            tick={{fill: theme.text}}
+            label={{value: 'Latency (ms)', angle: -90, position: 'insideLeft', fill: theme.text}}
+          />
+          <Tooltip content={<ChartTooltip colorMode={colorMode} unit="ms" />} />
+          <Legend wrapperStyle={{color: theme.text}} />
+          <Bar dataKey="batch_read (Sync)" fill={COLOR_DICT_SYNC} />
+          <Bar dataKey="numpy (Sync)" fill={COLOR_NUMPY_SYNC} />
+          <Bar dataKey="batch_read (Async)" fill={COLOR_DICT_ASYNC} />
+          <Bar dataKey="numpy (Async)" fill={COLOR_NUMPY_ASYNC} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ── Memory Chart ────────────────────────────────────────────
+
+export function MemoryChart({
+  data,
+  colorMode,
+}: {
+  data: NumpyBenchmarkData;
+  colorMode: ColorMode;
+}) {
+  if (!data.memory) return null;
+  const theme = themeColors(colorMode);
+
+  const chartData = data.memory.data.map((d) => ({
+    records: d.record_count.toLocaleString(),
+    'dict (KB)': d.dict_peak_kb,
+    'numpy (KB)': d.numpy_peak_kb,
+  }));
+
+  return (
+    <div style={{width: '100%', minHeight: 400, margin: '1rem 0'}}>
+      <ResponsiveContainer width="100%" height={400}>
+        <BarChart data={chartData} margin={{top: 20, right: 30, left: 20, bottom: 5}}>
+          <CartesianGrid strokeDasharray="3 3" stroke={theme.grid} />
+          <XAxis dataKey="records" tick={{fill: theme.text}} />
+          <YAxis
+            tick={{fill: theme.text}}
+            label={{value: 'Peak Memory (KB)', angle: -90, position: 'insideLeft', fill: theme.text}}
+          />
+          <Tooltip content={<ChartTooltip colorMode={colorMode} unit="kb" />} />
+          <Legend wrapperStyle={{color: theme.text}} />
+          <Bar dataKey="dict (KB)" fill={COLOR_DICT_SYNC} />
+          <Bar dataKey="numpy (KB)" fill={COLOR_NUMPY_SYNC} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/docs/src/components/NumpyBenchmarkReport/index.tsx
+++ b/docs/src/components/NumpyBenchmarkReport/index.tsx
@@ -1,0 +1,400 @@
+import React, {useEffect, useState} from 'react';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import {useColorMode} from '@docusaurus/theme-common';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from './NumpyBenchmarkReport.module.css';
+import type {NumpyBenchmarkData} from './charts';
+
+// ── Types ───────────────────────────────────────────────────
+
+interface IndexData {
+  reports: {date: string; file: string}[];
+}
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function fmtMs(val: number | null): string {
+  if (val == null) return '-';
+  return `${val.toFixed(3)}ms`;
+}
+
+function fmtOps(val: number | null): string {
+  if (val == null) return '-';
+  return `${val.toLocaleString('en-US', {maximumFractionDigits: 0})}/s`;
+}
+
+interface SpeedupResult {
+  text: string;
+  className: string;
+}
+
+function calcSpeedup(
+  numpyMs: number | null,
+  dictMs: number | null,
+): SpeedupResult {
+  if (numpyMs == null || dictMs == null || numpyMs <= 0 || dictMs <= 0) {
+    return {text: '-', className: ''};
+  }
+  const ratio = dictMs / numpyMs;
+  if (ratio >= 1.0) {
+    return {
+      text: `${ratio.toFixed(1)}x faster`,
+      className: styles.faster,
+    };
+  }
+  const inv = 1 / ratio;
+  return {
+    text: `${inv.toFixed(1)}x slower`,
+    className: styles.slower,
+  };
+}
+
+// ── Sub-components ──────────────────────────────────────────
+
+function EnvironmentTable({env}: {env: NumpyBenchmarkData['environment']}) {
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Platform</td><td>{env.platform}</td></tr>
+          <tr><td>Python</td><td>{env.python_version}</td></tr>
+          <tr><td>Rounds</td><td>{env.rounds}</td></tr>
+          <tr><td>Warmup</td><td>{env.warmup}</td></tr>
+          <tr><td>Async concurrency</td><td>{env.concurrency}</td></tr>
+          <tr><td>Batch groups</td><td>{env.batch_groups}</td></tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ScalingTable({
+  data,
+  xLabel,
+  xKey,
+}: {
+  data: NumpyBenchmarkData;
+  xLabel: string;
+  xKey: 'record_scaling' | 'bin_scaling';
+}) {
+  const section = data[xKey];
+  if (!section) return null;
+  const valueKey = xKey === 'record_scaling' ? 'record_count' : 'bin_count';
+
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>{xLabel}</th>
+            <th>batch_read (Sync)</th>
+            <th>numpy (Sync)</th>
+            <th>batch_read (Async)</th>
+            <th>numpy (Async)</th>
+            <th>Speedup (Sync)</th>
+            <th>Speedup (Async)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {section.data.map((entry: any) => {
+            const brSync = entry.batch_read_sync?.avg_ms ?? null;
+            const npSync = entry.batch_read_numpy_sync?.avg_ms ?? null;
+            const brAsync = entry.batch_read_async?.avg_ms ?? null;
+            const npAsync = entry.batch_read_numpy_async?.avg_ms ?? null;
+            const spSync = calcSpeedup(npSync, brSync);
+            const spAsync = calcSpeedup(npAsync, brAsync);
+
+            return (
+              <tr key={entry[valueKey]}>
+                <td>{entry[valueKey].toLocaleString()}</td>
+                <td className={styles.numCell}>{fmtMs(brSync)}</td>
+                <td className={styles.numCell}>{fmtMs(npSync)}</td>
+                <td className={styles.numCell}>{fmtMs(brAsync)}</td>
+                <td className={styles.numCell}>{fmtMs(npAsync)}</td>
+                <td className={`${styles.numCell} ${spSync.className}`}>{spSync.text}</td>
+                <td className={`${styles.numCell} ${spAsync.className}`}>{spAsync.text}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PostProcessingTable({data}: {data: NumpyBenchmarkData}) {
+  if (!data.post_processing) return null;
+
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Stage</th>
+            <th>batch_read (Sync)</th>
+            <th>numpy (Sync)</th>
+            <th>batch_read (Async)</th>
+            <th>numpy (Async)</th>
+            <th>Speedup (Sync)</th>
+            <th>Speedup (Async)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.post_processing.data.map((entry) => {
+            const brSync = entry.batch_read_sync?.avg_ms ?? null;
+            const npSync = entry.batch_read_numpy_sync?.avg_ms ?? null;
+            const brAsync = entry.batch_read_async?.avg_ms ?? null;
+            const npAsync = entry.batch_read_numpy_async?.avg_ms ?? null;
+            const spSync = calcSpeedup(npSync, brSync);
+            const spAsync = calcSpeedup(npAsync, brAsync);
+
+            return (
+              <tr key={entry.stage}>
+                <td>{entry.stage_label}</td>
+                <td className={styles.numCell}>{fmtMs(brSync)}</td>
+                <td className={styles.numCell}>{fmtMs(npSync)}</td>
+                <td className={styles.numCell}>{fmtMs(brAsync)}</td>
+                <td className={styles.numCell}>{fmtMs(npAsync)}</td>
+                <td className={`${styles.numCell} ${spSync.className}`}>{spSync.text}</td>
+                <td className={`${styles.numCell} ${spAsync.className}`}>{spAsync.text}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MemoryTable({data}: {data: NumpyBenchmarkData}) {
+  if (!data.memory) return null;
+
+  return (
+    <div className={styles.tableWrap}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Records</th>
+            <th>dict peak (KB)</th>
+            <th>numpy peak (KB)</th>
+            <th>Savings</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.memory.data.map((entry) => {
+            const savingsClass = entry.savings_pct > 0 ? styles.faster : entry.savings_pct < 0 ? styles.slower : '';
+            return (
+              <tr key={entry.record_count}>
+                <td>{entry.record_count.toLocaleString()}</td>
+                <td className={styles.numCell}>{entry.dict_peak_kb.toLocaleString()} KB</td>
+                <td className={styles.numCell}>{entry.numpy_peak_kb.toLocaleString()} KB</td>
+                <td className={`${styles.numCell} ${savingsClass}`}>{entry.savings_pct.toFixed(1)}%</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Report View ─────────────────────────────────────────────
+
+function ReportView({data}: {data: NumpyBenchmarkData}) {
+  const {colorMode} = useColorMode();
+
+  return (
+    <div>
+      <h2>Environment</h2>
+      <EnvironmentTable env={data.environment} />
+
+      {data.record_scaling && (
+        <>
+          <h2>Record Count Scaling</h2>
+          <p>Fixed bins: {data.record_scaling.fixed_bins}. Measures how numpy advantage scales with record count.</p>
+          <BrowserOnly fallback={<div style={{height: 400}}>Loading chart...</div>}>
+            {() => {
+              const {RecordScalingChart} = require('./charts');
+              return <RecordScalingChart data={data} colorMode={colorMode} />;
+            }}
+          </BrowserOnly>
+          <ScalingTable data={data} xLabel="Records" xKey="record_scaling" />
+        </>
+      )}
+
+      {data.bin_scaling && (
+        <>
+          <h2>Bin Count Scaling</h2>
+          <p>Fixed records: {data.bin_scaling.fixed_records}. Measures how bin (column) count affects numpy performance.</p>
+          <BrowserOnly fallback={<div style={{height: 400}}>Loading chart...</div>}>
+            {() => {
+              const {BinScalingChart} = require('./charts');
+              return <BinScalingChart data={data} colorMode={colorMode} />;
+            }}
+          </BrowserOnly>
+          <ScalingTable data={data} xLabel="Bins" xKey="bin_scaling" />
+        </>
+      )}
+
+      {data.post_processing && (
+        <>
+          <h2>Post-Processing Comparison</h2>
+          <p>
+            Records: {data.post_processing.record_count}, Bins: {data.post_processing.bin_count}.
+            Compares dict vs numpy at each data processing stage.
+          </p>
+          <BrowserOnly fallback={<div style={{height: 400}}>Loading chart...</div>}>
+            {() => {
+              const {PostProcessingChart} = require('./charts');
+              return <PostProcessingChart data={data} colorMode={colorMode} />;
+            }}
+          </BrowserOnly>
+          <PostProcessingTable data={data} />
+        </>
+      )}
+
+      {data.memory && (
+        <>
+          <h2>Memory Usage</h2>
+          <p>Bins: {data.memory.bin_count}. Peak memory measured via tracemalloc (Sync client only).</p>
+          <BrowserOnly fallback={<div style={{height: 400}}>Loading chart...</div>}>
+            {() => {
+              const {MemoryChart} = require('./charts');
+              return <MemoryChart data={data} colorMode={colorMode} />;
+            }}
+          </BrowserOnly>
+          <MemoryTable data={data} />
+        </>
+      )}
+
+      <h2>Key Takeaways</h2>
+      <ul>
+        {data.takeaways.map((t, i) => (
+          <li key={i}>{t}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ── Lazy-loading wrapper ────────────────────────────────────
+
+function LazyReportView({
+  date,
+  file,
+  baseUrl,
+  reports,
+  onLoad,
+  onError,
+}: {
+  date: string;
+  file: string;
+  baseUrl: string;
+  reports: Record<string, NumpyBenchmarkData>;
+  onLoad: (date: string, data: NumpyBenchmarkData) => void;
+  onError: (msg: string) => void;
+}) {
+  useEffect(() => {
+    if (reports[date]) return;
+    fetch(`${baseUrl}${file}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load ${file}`);
+        return res.json();
+      })
+      .then((data: NumpyBenchmarkData) => onLoad(date, data))
+      .catch((err) => onError(err.message));
+  }, [date, file, baseUrl, reports, onLoad, onError]);
+
+  if (!reports[date]) {
+    return <p>Loading {date}...</p>;
+  }
+  return <ReportView data={reports[date]} />;
+}
+
+// ── Main Component ──────────────────────────────────────────
+
+export default function NumpyBenchmarkReport(): React.ReactElement {
+  const [index, setIndex] = useState<IndexData | null>(null);
+  const [reports, setReports] = useState<Record<string, NumpyBenchmarkData>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const baseUrl = useBaseUrl('/benchmark/numpy-results/');
+
+  useEffect(() => {
+    fetch(`${baseUrl}index.json`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load index.json (${res.status})`);
+        return res.json();
+      })
+      .then((data: IndexData) => setIndex(data))
+      .catch((err) => setError(err.message));
+  }, [baseUrl]);
+
+  const handleLoad = React.useCallback(
+    (date: string, data: NumpyBenchmarkData) => {
+      setReports((prev) => ({...prev, [date]: data}));
+    },
+    [],
+  );
+
+  const handleError = React.useCallback(
+    (msg: string) => setError(msg),
+    [],
+  );
+
+  if (error) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.errorBox}>
+          <strong>Failed to load numpy benchmark data.</strong>
+          <p>Run <code>make run-numpy-benchmark-report</code> to generate benchmark data.</p>
+          <details><summary>Error details</summary><pre>{error}</pre></details>
+        </div>
+      </div>
+    );
+  }
+
+  if (!index) {
+    return <div className={styles.container}>Loading numpy benchmark data...</div>;
+  }
+
+  if (index.reports.length === 0) {
+    return (
+      <div className={styles.container}>
+        <p>No numpy benchmark results available. Run <code>make run-numpy-benchmark-report</code> to generate results.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <Tabs>
+        {index.reports.map((entry) => (
+          <TabItem
+            key={entry.date}
+            value={entry.date}
+            label={entry.date}
+            default={entry.date === index.reports[0].date}
+          >
+            <LazyReportView
+              date={entry.date}
+              file={entry.file}
+              baseUrl={baseUrl}
+              reports={reports}
+              onLoad={handleLoad}
+              onError={handleError}
+            />
+          </TabItem>
+        ))}
+      </Tabs>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `batch_read`(dict) vs `batch_read_numpy`(numpy) 전용 벤치마크 시스템 추가
- 4개 시나리오: Record Scaling, Bin Scaling, Post-Processing, Memory Usage
- Recharts 기반 React 차트 컴포넌트 (LineChart + BarChart)
- Docusaurus 페이지 및 Makefile 타겟 추가

## Changes
- **`benchmark/bench_batch_numpy.py`**: CLI 벤치마크 스크립트 (4 시나리오, Sync/Async 지원)
- **`benchmark/report_generator.py`**: `generate_numpy_report()` 함수 추가 (JSON 리포트 생성)
- **`docs/src/components/NumpyBenchmarkReport/`**: React 컴포넌트 3개 (index.tsx, charts.tsx, CSS)
- **`docs/docs/performance/numpy-benchmark-results.mdx`**: Docusaurus 페이지
- **`docs/docs/performance/overview.md`**: NumPy Batch Benchmark 링크 추가
- **`Makefile`**: `run-numpy-benchmark`, `run-numpy-benchmark-report` 타겟 추가

## Test plan
- [ ] `make run-numpy-benchmark` → 터미널에 4개 시나리오 테이블 출력 확인
- [ ] `make run-numpy-benchmark-report` → `docs/static/benchmark/numpy-results/`에 JSON 생성 확인
- [ ] `cd docs && npm start` → Performance > NumPy Batch Benchmark 페이지 확인
  - LineChart: Record/Bin scaling에서 4개 라인 표시
  - BarChart: Post-processing에서 4개 그룹 바 표시
  - BarChart: Memory에서 dict vs numpy 비교