### PR TITLE
chore: add explicit ruff lint configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,41 @@ asyncio_mode = "auto"
 requires = ["maturin>=1.9,<2"]
 build-backend = "maturin"
 
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "TCH",  # flake8-type-checking
+    "RUF",  # ruff-specific rules
+]
+ignore = [
+    "E501",    # line length (handled by formatter)
+    "UP007",   # use X | Y for union types (requires 3.10+ syntax everywhere)
+    "UP045",   # Optional[X] → X | None (same as UP007, keep Optional for readability)
+    "UP037",   # remove quotes from type annotations in stubs
+    "UP035",   # import from collections.abc (keep typing imports for compatibility)
+    "RUF022",  # unsorted __all__ (intentionally grouped by category)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"benchmark/*" = ["B023", "B905", "SIM105", "RUF002", "RUF059", "RUF100", "I001"]
+"tests/*" = ["B011", "B007", "B905", "SIM105", "RUF059", "RUF100"]
+"src/aerospike_py/__init__.py" = ["I001", "RUF100"]
+"src/aerospike_py/exception.py" = ["I001"]
+"*.pyi" = ["I001"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["aerospike_py"]
+
 [tool.maturin]
 python-source = "src"
 module-name = "aerospike_py._aerospike"

--- a/tests/concurrency/test_thread_safety.py
+++ b/tests/concurrency/test_thread_safety.py
@@ -6,7 +6,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 import aerospike_py
 
-
 CONFIG = {"hosts": [("127.0.0.1", 3000)], "cluster_name": "docker"}
 NS = "test"
 SET_NAME = "conc_thread"
@@ -27,9 +26,7 @@ class TestThreadSafety:
             except Exception as e:
                 errors.put(e)
 
-        threads = [
-            threading.Thread(target=put_records, args=(t,)) for t in range(num_threads)
-        ]
+        threads = [threading.Thread(target=put_records, args=(t,)) for t in range(num_threads)]
         for t in threads:
             t.start()
         for t in threads:
@@ -101,9 +98,7 @@ class TestThreadSafety:
         with ThreadPoolExecutor(max_workers=8) as pool:
             list(pool.map(cycle, range(100)))
 
-        assert errors.empty(), (
-            f"Errors in ThreadPoolExecutor test: {list(_drain(errors))}"
-        )
+        assert errors.empty(), f"Errors in ThreadPoolExecutor test: {list(_drain(errors))}"
 
     def test_multiple_clients_from_threads(self):
         """Each thread creates its own client, uses it, and closes it."""
@@ -123,9 +118,7 @@ class TestThreadSafety:
             except Exception as e:
                 errors.put(e)
 
-        threads = [
-            threading.Thread(target=thread_fn, args=(t,)) for t in range(num_threads)
-        ]
+        threads = [threading.Thread(target=thread_fn, args=(t,)) for t in range(num_threads)]
         for t in threads:
             t.start()
         for t in threads:

--- a/tests/feasibility/test_fastapi.py
+++ b/tests/feasibility/test_fastapi.py
@@ -9,9 +9,10 @@ import pytest
 
 pytest.importorskip("fastapi")
 
-import aerospike_py  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
+
+import aerospike_py  # noqa: E402
 
 CONFIG = {"hosts": [("127.0.0.1", 3000)], "cluster_name": "docker"}
 NS = "test"

--- a/tests/integration/test_query_scan.py
+++ b/tests/integration/test_query_scan.py
@@ -1,7 +1,8 @@
 """Integration tests for query/scan operations (requires Aerospike server)."""
 
-import pytest
 import time
+
+import pytest
 
 import aerospike_py
 from aerospike_py import predicates as p
@@ -10,9 +11,7 @@ from aerospike_py import predicates as p
 @pytest.fixture(scope="module")
 def client():
     try:
-        c = aerospike_py.client(
-            {"hosts": [("127.0.0.1", 3000)], "cluster_name": "docker"}
-        ).connect()
+        c = aerospike_py.client({"hosts": [("127.0.0.1", 3000)], "cluster_name": "docker"}).connect()
     except Exception:
         pytest.skip("Aerospike server not available")
     yield c
@@ -25,9 +24,7 @@ def seed_data(client):
     keys = []
     for i in range(10):
         key = ("test", "query_test", f"qkey_{i}")
-        client.put(
-            key, {"name": f"user_{i}", "age": 20 + i, "group": "A" if i < 5 else "B"}
-        )
+        client.put(key, {"name": f"user_{i}", "age": 20 + i, "group": "A" if i < 5 else "B"})
         keys.append(key)
 
     # Create secondary index on 'age'

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,8 @@ bench = [
 ]
 dev = [
     { name = "maturin" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -73,6 +75,7 @@ bench = [
 ]
 dev = [
     { name = "maturin", specifier = ">=1.9,<2" },
+    { name = "numpy", specifier = ">=2.0" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },


### PR DESCRIPTION
## Summary
- Added explicit `[tool.ruff]` and `[tool.ruff.lint]` configuration to `pyproject.toml` instead of relying on ruff defaults
- Configured rule sets: E, W, F, I (isort), UP (pyupgrade), B (bugbear), SIM (simplify), TCH (type-checking), RUF
- Added per-file ignores for benchmark scripts and test files to avoid breaking existing patterns (test cleanup idioms, benchmark lambda captures)
- Fixed 3 auto-fixable import sorting issues in test files
- Set `target-version = "py310"` and `line-length = 120` to match project requirements
- Configured isort `known-first-party` for `aerospike_py`