### PR TITLE
perf: add Cargo release profile with LTO and single codegen unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 members = ["rust"]
 resolver = "2"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"


### PR DESCRIPTION
## Summary
- Added `[profile.release]` to workspace `Cargo.toml` with optimized settings for production builds:
  - `lto = "fat"` — full cross-crate link-time optimization for smaller, faster binaries
  - `codegen-units = 1` — single codegen unit enables maximum optimization (at the cost of longer compile times)
  - `strip = "symbols"` — strips debug symbols from release binaries for smaller wheel size
- These settings only affect `maturin build --release` (pip installs); development builds (`maturin develop`) are unaffected