### PR TITLE
chore: add PyPI classifiers, keywords, and project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,30 @@ authors = [
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 dependencies = []
+keywords = ["aerospike", "database", "nosql", "client", "async"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Framework :: AsyncIO",
+    "Typing :: Typed",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+]
+
+[project.urls]
+Homepage = "https://github.com/KimSoungRyoul/aerospike-py"
+Repository = "https://github.com/KimSoungRyoul/aerospike-py"
+Issues = "https://github.com/KimSoungRyoul/aerospike-py/issues"
 
 [project.optional-dependencies]
 numpy = ["numpy>=2.0"]


### PR DESCRIPTION
## Summary
- Added trove classifiers for PyPI discoverability: Python versions (3.10–3.13), Rust, AsyncIO, Typed, Beta status, Apache license, Database topic
- Added `keywords` for PyPI search: aerospike, database, nosql, client, async
- Added `project.urls` section with Homepage, Repository, and Issues links for PyPI sidebar