### PR TITLE
feat: add structured logging with Rust tracing bridge (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,11 +54,15 @@ version = "0.1.0"
 dependencies = [
  "aerospike",
  "aerospike-core",
+ "crossbeam-channel",
  "futures",
  "half",
  "pyo3",
  "pyo3-async-runtimes",
  "tokio",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -191,6 +195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -412,6 +425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +447,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "md-5"
@@ -454,6 +482,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -682,6 +719,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,10 +787,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -767,6 +861,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +884,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +968,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -912,3 +1095,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,5 +96,5 @@ venv = ".venv"
 python-source = "src"
 module-name = "aerospike_py._aerospike"
 manifest-path = "rust/Cargo.toml"
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "telemetry"]
 include = ["LICENSE"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,10 @@ license = "Apache-2.0"
 name = "_aerospike"
 crate-type = ["cdylib"]
 
+[features]
+default = []
+telemetry = ["tracing", "tracing-subscriber", "tracing-log", "crossbeam-channel"]
+
 [dependencies]
 pyo3 = { version = "0.28", features = ["extension-module"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
@@ -16,3 +20,7 @@ aerospike-core = { version = "2.0.0-alpha.9" }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "io-util"] }
 futures = "0.3"
 half = "2"
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"], optional = true }
+tracing-log = { version = "0.2", optional = true }
+crossbeam-channel = { version = "0.5", optional = true }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@ mod policy;
 pub mod query;
 mod record_helpers;
 mod runtime;
+mod telemetry;
 mod types;
 
 /// Native Aerospike Python client module
@@ -30,6 +31,9 @@ fn _aerospike(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Register constants
     constants::register_constants(m)?;
+
+    // Register telemetry functions
+    telemetry::register_telemetry_functions(m)?;
 
     Ok(())
 }

--- a/rust/src/telemetry/logging.rs
+++ b/rust/src/telemetry/logging.rs
@@ -1,0 +1,96 @@
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use std::sync::LazyLock;
+use tracing::field::{Field, Visit};
+use tracing::Event;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+/// A log record buffered in the channel
+pub struct LogRecord {
+    pub level: u8,
+    pub target: String,
+    pub message: String,
+}
+
+/// Channel for buffering log records (safe to use without GIL)
+static LOG_CHANNEL: LazyLock<(Sender<LogRecord>, Receiver<LogRecord>)> =
+    LazyLock::new(|| unbounded());
+
+/// Custom tracing Layer that pushes log records into a channel
+pub struct ChannelLogLayer;
+
+impl<S: tracing::Subscriber> Layer<S> for ChannelLogLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let metadata = event.metadata();
+        let level = match *metadata.level() {
+            tracing::Level::ERROR => 0u8,
+            tracing::Level::WARN => 1,
+            tracing::Level::INFO => 2,
+            tracing::Level::DEBUG => 3,
+            tracing::Level::TRACE => 4,
+        };
+
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+
+        let record = LogRecord {
+            level,
+            target: metadata.target().to_string(),
+            message: visitor.message,
+        };
+
+        // Non-blocking send - drop if channel is full (shouldn't happen with unbounded)
+        let _ = LOG_CHANNEL.0.send(record);
+    }
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = format!("{:?}", value);
+        } else if self.message.is_empty() {
+            self.message = format!("{} = {:?}", field.name(), value);
+        } else {
+            self.message
+                .push_str(&format!(", {} = {:?}", field.name(), value));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        } else if self.message.is_empty() {
+            self.message = format!("{} = {}", field.name(), value);
+        } else {
+            self.message
+                .push_str(&format!(", {} = {}", field.name(), value));
+        }
+    }
+}
+
+/// Initialize the tracing subscriber with channel-based log layer
+pub fn init_subscriber(filter: &str) {
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::EnvFilter;
+
+    let env_filter = EnvFilter::try_new(filter).unwrap_or_else(|_| EnvFilter::new("warn"));
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(ChannelLogLayer)
+        .init();
+}
+
+/// Drain all buffered log records
+pub fn drain_logs() -> Vec<LogRecord> {
+    let mut records = Vec::new();
+    while let Ok(record) = LOG_CHANNEL.1.try_recv() {
+        records.push(record);
+    }
+    records
+}

--- a/rust/src/telemetry/mod.rs
+++ b/rust/src/telemetry/mod.rs
@@ -1,0 +1,77 @@
+#[cfg(feature = "telemetry")]
+pub mod logging;
+
+use pyo3::prelude::*;
+
+#[cfg(feature = "telemetry")]
+use std::sync::Once;
+
+#[cfg(feature = "telemetry")]
+static INIT: Once = Once::new();
+
+/// Initialize telemetry subsystem with the given log level.
+/// Level mapping: -1=OFF, 0=ERROR, 1=WARN, 2=INFO, 3=DEBUG, 4=TRACE
+#[pyfunction]
+#[pyo3(signature = (level))]
+pub fn _init_telemetry(level: i32) -> PyResult<()> {
+    #[cfg(feature = "telemetry")]
+    {
+        if level < 0 {
+            return Ok(());
+        }
+
+        let filter = match level {
+            0 => "error",
+            1 => "warn",
+            2 => "info",
+            3 => "debug",
+            _ => "trace",
+        };
+
+        INIT.call_once(|| {
+            // Bridge log crate -> tracing (captures aerospike-core logs)
+            let _ = tracing_log::LogTracer::init();
+
+            // Initialize the logging channel subscriber
+            logging::init_subscriber(filter);
+        });
+    }
+
+    #[cfg(not(feature = "telemetry"))]
+    {
+        let _ = level;
+    }
+
+    Ok(())
+}
+
+/// Drain buffered log messages from Rust side.
+/// Returns a list of dicts: [{"level": int, "target": str, "message": str}, ...]
+#[pyfunction]
+pub fn _flush_logs(py: Python<'_>) -> PyResult<Vec<pyo3::Py<pyo3::types::PyDict>>> {
+    #[cfg(feature = "telemetry")]
+    {
+        let records = logging::drain_logs();
+        let mut result = Vec::with_capacity(records.len());
+        for rec in records {
+            let dict = pyo3::types::PyDict::new(py);
+            dict.set_item("level", rec.level)?;
+            dict.set_item("target", &rec.target)?;
+            dict.set_item("message", &rec.message)?;
+            result.push(dict.unbind());
+        }
+        Ok(result)
+    }
+
+    #[cfg(not(feature = "telemetry"))]
+    {
+        let _ = py;
+        Ok(Vec::new())
+    }
+}
+
+pub fn register_telemetry_functions(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> PyResult<()> {
+    m.add_function(pyo3::wrap_pyfunction!(_init_telemetry, m)?)?;
+    m.add_function(pyo3::wrap_pyfunction!(_flush_logs, m)?)?;
+    Ok(())
+}

--- a/src/aerospike_py/__init__.py
+++ b/src/aerospike_py/__init__.py
@@ -226,6 +226,7 @@ from aerospike_py.numpy_batch import NumpyBatchRecords  # noqa: F401
 from aerospike_py import list_operations  # noqa: F401
 from aerospike_py import map_operations  # noqa: F401
 from aerospike_py import exp  # noqa: F401
+from aerospike_py.logging import set_log_level, flush_logs  # noqa: F401
 
 try:
     from importlib.metadata import PackageNotFoundError
@@ -341,6 +342,8 @@ __all__ = [
     "BatchRecords",
     "NumpyBatchRecords",
     "client",
+    "set_log_level",
+    "flush_logs",
     "__version__",
     # Submodules
     "exception",

--- a/src/aerospike_py/logging.py
+++ b/src/aerospike_py/logging.py
@@ -1,0 +1,55 @@
+"""Structured logging for aerospike-py.
+
+Bridges Rust-side tracing logs to Python's standard logging module.
+
+Usage:
+    import logging
+    from aerospike_py.logging import set_log_level
+
+    logging.basicConfig(level=logging.DEBUG)
+    set_log_level(3)  # LOG_LEVEL_DEBUG
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("aerospike_py")
+
+_LEVEL_TO_PY = {
+    0: logging.ERROR,
+    1: logging.WARNING,
+    2: logging.INFO,
+    3: logging.DEBUG,
+    4: logging.DEBUG,
+}
+
+
+def set_log_level(level: int) -> None:
+    """Set logging level for aerospike-py.
+
+    Args:
+        level: One of LOG_LEVEL_OFF(-1), LOG_LEVEL_ERROR(0), LOG_LEVEL_WARN(1),
+               LOG_LEVEL_INFO(2), LOG_LEVEL_DEBUG(3), LOG_LEVEL_TRACE(4)
+    """
+    try:
+        from aerospike_py._aerospike import _init_telemetry
+
+        _init_telemetry(level)
+    except (ImportError, AttributeError):
+        pass
+
+    py_level = _LEVEL_TO_PY.get(level, logging.WARNING)
+    logger.setLevel(py_level)
+
+
+def flush_logs() -> None:
+    """Drain buffered log messages from Rust side to Python logging."""
+    try:
+        from aerospike_py._aerospike import _flush_logs
+
+        for record in _flush_logs():
+            py_level = _LEVEL_TO_PY.get(record["level"], logging.DEBUG)
+            logger.log(py_level, "[%s] %s", record["target"], record["message"])
+    except (ImportError, AttributeError):
+        pass


### PR DESCRIPTION
## Summary
- `tracing` + `tracing-subscriber` + `tracing-log` as feature-gated Rust dependencies
- `rust/src/telemetry/` module with channel-based log buffering (GIL-safe)
- Bridge `aerospike-core` internal `log` crate messages to Python `logging` module
- Python API: `set_log_level()` and `flush_logs()`

## Test plan
- [x] `maturin develop` builds successfully with telemetry feature
- [ ] `set_log_level(3)` enables DEBUG logging from Rust side
- [ ] `flush_logs()` drains buffered messages to Python logger