### PR TITLE
feat: add structured logging with Rust-to-Python bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "aerospike-core",
  "futures",
  "half",
+ "log",
  "pyo3",
  "pyo3-async-runtimes",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,3 +16,4 @@ aerospike-core = { version = "2.0.0-alpha.9" }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "time", "sync", "io-util"] }
 futures = "0.3"
 half = "2"
+log = "0.4"

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -1,4 +1,5 @@
 use aerospike_core::BatchRecord;
+use log::trace;
 use pyo3::prelude::*;
 
 use crate::errors::result_code_to_int;
@@ -25,6 +26,7 @@ pub fn batch_to_batch_records_py(
     py: Python<'_>,
     results: &[BatchRecord],
 ) -> PyResult<PyBatchRecords> {
+    trace!("Converting {} batch records to Python", results.len());
     let mut batch_records = Vec::with_capacity(results.len());
 
     for br in results {

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,4 +1,5 @@
 use aerospike_core::{Error as AsError, ResultCode};
+use log::debug;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
@@ -195,6 +196,7 @@ pub(crate) fn result_code_to_int(rc: &ResultCode) -> i32 {
 }
 
 pub fn as_to_pyerr(err: AsError) -> PyErr {
+    debug!("Mapping aerospike error: {}", err);
     match &err {
         AsError::Connection(msg) => ClusterError::new_err(format!("Connection error: {msg}")),
         AsError::Timeout(msg) => AerospikeTimeoutError::new_err(format!("Timeout: {msg}")),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,4 @@
+use log::info;
 use pyo3::prelude::*;
 
 mod async_client;
@@ -6,6 +7,7 @@ mod client;
 mod constants;
 mod errors;
 pub mod expressions;
+mod logging;
 mod numpy_support;
 mod operations;
 mod policy;
@@ -17,6 +19,8 @@ mod types;
 /// Native Aerospike Python client module
 #[pymodule]
 fn _aerospike(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    logging::init();
+
     // Register classes
     m.add_class::<client::PyClient>()?;
     m.add_class::<async_client::PyAsyncClient>()?;
@@ -31,5 +35,6 @@ fn _aerospike(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Register constants
     constants::register_constants(m)?;
 
+    info!("aerospike-py native module initialized");
     Ok(())
 }

--- a/rust/src/logging.rs
+++ b/rust/src/logging.rs
@@ -1,0 +1,61 @@
+//! Minimal Rust `log` → Python `logging` bridge.
+//!
+//! Implements the `log::Log` trait to forward Rust log messages
+//! to Python's `logging` module via PyO3.
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use pyo3::prelude::*;
+use std::sync::OnceLock;
+
+/// Maps Rust log levels to Python logging levels.
+fn rust_to_python_level(level: Level) -> u32 {
+    match level {
+        Level::Error => 40,
+        Level::Warn => 30,
+        Level::Info => 20,
+        Level::Debug => 10,
+        Level::Trace => 5,
+    }
+}
+
+/// A `log::Log` implementation that forwards to Python's `logging` module.
+struct PyLogger;
+
+static LOGGER: OnceLock<PyLogger> = OnceLock::new();
+
+impl Log for PyLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let level = rust_to_python_level(record.level());
+        let target = record.target();
+        let message = format!("{}", record.args());
+
+        // Try to acquire the GIL and forward to Python.
+        // If we can't (e.g., during shutdown), silently drop the message.
+        let _ = Python::try_attach(|py| -> PyResult<()> {
+            let logging = py.import("logging")?;
+            let logger = logging.call_method1("getLogger", (target,))?;
+            logger.call_method1("log", (level, &message))?;
+            Ok(())
+        });
+    }
+
+    fn flush(&self) {}
+}
+
+/// Initialize the Rust → Python logging bridge.
+///
+/// Call this once at module init time. Subsequent calls are no-ops.
+pub fn init() {
+    let logger = LOGGER.get_or_init(|| PyLogger);
+    // set_logger may fail if called more than once; that's fine.
+    let _ = log::set_logger(logger);
+    log::set_max_level(LevelFilter::Trace);
+}

--- a/rust/src/numpy_support.rs
+++ b/rust/src/numpy_support.rs
@@ -3,6 +3,7 @@ use std::ptr;
 
 use aerospike_core::{BatchRecord, FloatValue, Value};
 use half::f16;
+use log::{debug, warn};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -54,6 +55,7 @@ fn parse_dtype_fields(dtype: &Bound<'_, PyAny>) -> PyResult<(Vec<FieldInfo>, usi
             "S" => DtypeKind::FixedBytes,
             "V" => DtypeKind::VoidBytes,
             other => {
+                warn!("Unsupported dtype kind '{}' for field '{}'", other, name);
                 return Err(PyTypeError::new_err(format!(
                     "dtype field '{}' must be numeric (int/float) or fixed-length bytes, got {} (kind='{}')",
                     name, field_dtype, other,
@@ -275,6 +277,7 @@ pub fn batch_to_numpy_py(
     results: &[BatchRecord],
     dtype_obj: &Bound<'_, PyAny>,
 ) -> PyResult<Py<PyAny>> {
+    debug!("Converting batch to numpy: records_count={}", results.len());
     let np = py.import("numpy")?;
     let n = results.len();
 

--- a/rust/src/operations.rs
+++ b/rust/src/operations.rs
@@ -7,6 +7,7 @@ use aerospike_core::{
     operations::Operation,
     Bin, Value,
 };
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
@@ -240,6 +241,7 @@ fn values_from_list(val: &Value) -> Vec<Value> {
 /// Convert a Python list of operation dicts to Rust Operations.
 /// Each operation is a dict: {"op": int, "bin": str, "val": any, ...}
 pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> {
+    trace!("Converting {} Python operations to Rust", ops_list.len());
     let mut rust_ops: Vec<Operation> = Vec::with_capacity(ops_list.len());
 
     for item in ops_list.iter() {

--- a/rust/src/policy/admin_policy.rs
+++ b/rust/src/policy/admin_policy.rs
@@ -1,10 +1,12 @@
 use aerospike_core::{Privilege, PrivilegeCode};
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
 pub fn parse_admin_policy(
     policy: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<aerospike_core::AdminPolicy> {
+    trace!("Parsing admin policy");
     let mut p = aerospike_core::AdminPolicy::default();
     if let Some(dict) = policy {
         if let Some(val) = dict.get_item("timeout")? {

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -1,4 +1,5 @@
 use aerospike_core::BatchPolicy;
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -7,6 +8,7 @@ use crate::expressions::{is_expression, py_to_expression};
 
 /// Parse a Python policy dict into a BatchPolicy
 pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<BatchPolicy> {
+    trace!("Parsing batch policy");
     let mut policy = BatchPolicy::default();
 
     let dict = match policy_dict {

--- a/rust/src/policy/client_policy.rs
+++ b/rust/src/policy/client_policy.rs
@@ -1,4 +1,5 @@
 use aerospike_core::{AuthMode, ClientPolicy};
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -6,6 +7,7 @@ use super::extract_policy_fields;
 
 /// Parse a Python config dict into a ClientPolicy
 pub fn parse_client_policy(config: &Bound<'_, PyDict>) -> PyResult<ClientPolicy> {
+    trace!("Parsing client policy");
     let mut policy = ClientPolicy::default();
 
     extract_policy_fields!(config, {

--- a/rust/src/policy/query_policy.rs
+++ b/rust/src/policy/query_policy.rs
@@ -1,4 +1,5 @@
 use aerospike_core::QueryPolicy;
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -7,6 +8,7 @@ use crate::expressions::{is_expression, py_to_expression};
 
 /// Parse a Python policy dict into a QueryPolicy
 pub fn parse_query_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<QueryPolicy> {
+    trace!("Parsing query policy");
     let mut policy = QueryPolicy::default();
 
     let dict = match policy_dict {

--- a/rust/src/policy/read_policy.rs
+++ b/rust/src/policy/read_policy.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use aerospike_core::ReadPolicy;
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -11,6 +12,7 @@ pub static DEFAULT_READ_POLICY: LazyLock<ReadPolicy> = LazyLock::new(ReadPolicy:
 
 /// Parse a Python policy dict into a ReadPolicy
 pub fn parse_read_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<ReadPolicy> {
+    trace!("Parsing read policy");
     let mut policy = ReadPolicy::default();
 
     let dict = match policy_dict {

--- a/rust/src/policy/write_policy.rs
+++ b/rust/src/policy/write_policy.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use aerospike_core::{CommitLevel, Expiration, GenerationPolicy, RecordExistsAction, WritePolicy};
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -25,6 +26,7 @@ pub fn parse_write_policy(
     policy_dict: Option<&Bound<'_, PyDict>>,
     meta: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<WritePolicy> {
+    trace!("Parsing write policy");
     let mut policy = WritePolicy::default();
 
     // Apply meta (gen, ttl) first

--- a/rust/src/runtime.rs
+++ b/rust/src/runtime.rs
@@ -1,6 +1,9 @@
 use std::sync::LazyLock;
 
+use log::info;
+
 pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    info!("Initializing Tokio multi-thread runtime");
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/rust/src/types/host.rs
+++ b/rust/src/types/host.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
 
@@ -36,5 +37,7 @@ pub fn parse_hosts_from_config(config: &Bound<'_, PyDict>) -> PyResult<String> {
         ));
     }
 
-    Ok(host_strings.join(","))
+    let result = host_strings.join(",");
+    debug!("Parsed hosts: {}", result);
+    Ok(result)
 }

--- a/rust/src/types/key.rs
+++ b/rust/src/types/key.rs
@@ -1,4 +1,5 @@
 use aerospike_core::{Key, Value};
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyTuple;
 
@@ -6,6 +7,7 @@ use super::value::{py_to_value, value_to_py};
 
 /// Convert a Python key tuple (namespace, set, key) to Rust Key
 pub fn py_to_key(key_tuple: &Bound<'_, PyAny>) -> PyResult<Key> {
+    trace!("Converting Python key to Rust key");
     let tuple = key_tuple.cast::<PyTuple>()?;
 
     if tuple.len() < 3 {

--- a/rust/src/types/record.rs
+++ b/rust/src/types/record.rs
@@ -1,4 +1,5 @@
 use aerospike_core::Record;
+use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 
@@ -10,6 +11,7 @@ use super::value::value_to_py;
 /// meta = {"gen": generation, "ttl": ttl_seconds}
 /// bins = {"bin_name": value, ...}
 pub fn record_to_py(py: Python<'_>, record: &Record) -> PyResult<Py<PyAny>> {
+    trace!("Converting Rust record to Python");
     // Key tuple
     let key_py = match &record.key {
         Some(key) => key_to_py(py, key)?,

--- a/rust/src/types/value.rs
+++ b/rust/src/types/value.rs
@@ -1,4 +1,5 @@
 use aerospike_core::Value;
+use log::warn;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString};
 use std::collections::HashMap;
@@ -12,6 +13,10 @@ pub fn py_to_value(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
 
 fn py_to_value_inner(obj: &Bound<'_, PyAny>, depth: usize) -> PyResult<Value> {
     if depth > MAX_NESTING_DEPTH {
+        warn!(
+            "Value nesting exceeds maximum depth of {}",
+            MAX_NESTING_DEPTH
+        );
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
             "Value nesting exceeds maximum depth of {MAX_NESTING_DEPTH}"
         )));


### PR DESCRIPTION
## Summary

- Rust `log` crate → Python `logging` 모듈로 로그를 전달하는 커스텀 브릿지 구현 (`pyo3-log`이 pyo3 0.28과 호환되지 않아 직접 구현)
- Rust 코드 전반에 ~78개 로그 포인트 추가 (client, async_client, query, operations, types, policies, errors, runtime, numpy_support, batch)
- Python 측 `NullHandler` 기반 로거 설정 및 `set_log_level()` 편의 함수 추가
- 기본 동작: 로그 출력 없음 (하위 호환성 유지). `logging.basicConfig(level=logging.DEBUG)` 한 줄로 활성화 가능

## Architecture

```
Python logging module ← "aerospike_py" logger (Python-side logs)
    ↑
    │ Custom Rust→Python bridge (log::Log trait impl)
    │
Rust log facade ← log::info!(), log::debug!() etc.
    ↑
    │
aerospike-core internal logs + aerospike-py Rust code logs
```

## Log Level Policy

| Level | Usage | Frequency |
|-------|-------|-----------|
| ERROR | Unexpected failures | Rare |
| WARN  | Destructive ops (truncate), deep nesting | Rare |
| INFO  | Lifecycle: connect, close, index create/drop, UDF, admin | Low |
| DEBUG | Per-operation: put/get/remove(ns/set), batch size, error mapping | Medium |
| TRACE | Internal: policy parsing, type conversion, key conversion | High (zero cost when disabled) |

## Security

Passwords, record data, and user credentials are never logged. Only namespace, set, bin name, key digest, count, and policy parameters are logged.

## Changed Files

| File | Changes |
|------|---------|
| `rust/Cargo.toml` | Add `log = "0.4"` dependency |
| `rust/src/logging.rs` | **NEW** - Custom Rust→Python log bridge |
| `rust/src/lib.rs` | Initialize bridge + INFO log |
| `rust/src/client.rs` | ~25 log points |
| `rust/src/async_client.rs` | ~25 log points |
| `rust/src/errors.rs` | 1 DEBUG log |
| `rust/src/runtime.rs` | 1 INFO log |
| `rust/src/query.rs` | ~5 log points |
| `rust/src/operations.rs` | 1 TRACE log |
| `rust/src/numpy_support.rs` | 2 logs (DEBUG + WARN) |
| `rust/src/batch_types.rs` | 1 TRACE log |
| `rust/src/types/*.rs` | 4 logs (host, value, key, record) |
| `rust/src/policy/*.rs` | 6 TRACE logs |
| `src/aerospike_py/__init__.py` | Logger setup + `set_log_level()` + 4 Python logs |

## Test plan

- [x] `maturin develop` 빌드 성공
- [x] `pytest tests/unit/` 126개 테스트 전부 통과
- [x] pre-commit hooks 전부 통과 (ruff, pyright, cargo fmt, cargo clippy)
- [ ] 로깅 출력 동작 수동 테스트: `logging.basicConfig(level=logging.DEBUG); import aerospike_py`
- [ ] `set_log_level()` 동작 확인
- [ ] 기본 동작 (무설정시 로그 출력 없음) 확인