### PR TITLE
fix: comprehensive safety audit — eliminate panics, improve error handling, add tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'pyproject.toml'
-      - 'tox.toml'
       - '.github/workflows/ci.yaml'
   pull_request:
     branches: [main]
@@ -21,7 +20,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'pyproject.toml'
-      - 'tox.toml'
       - '.github/workflows/ci.yaml'
 
   workflow_dispatch:

--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -1068,11 +1068,12 @@ impl PyAsyncClient {
 
             Python::attach(|py| {
                 if use_numpy {
-                    crate::numpy_support::batch_to_numpy_py(
-                        py,
-                        &results,
-                        &dtype_py.unwrap().into_bound(py),
-                    )
+                    let dtype = dtype_py.ok_or_else(|| {
+                        pyo3::exceptions::PyRuntimeError::new_err(
+                            "numpy dtype is required when use_numpy is true",
+                        )
+                    })?;
+                    crate::numpy_support::batch_to_numpy_py(py, &results, &dtype.into_bound(py))
                 } else {
                     let batch_records = batch_to_batch_records_py(py, &results)?;
                     Ok(Py::new(py, batch_records)?.into_any())

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -38,7 +38,7 @@ pub fn batch_to_batch_records_py(
         };
 
         let record_py = match &br.record {
-            Some(_) => record_to_py(py, br.record.as_ref().unwrap(), Some(&br.key))?,
+            Some(ref rec) => record_to_py(py, rec, Some(&br.key))?,
             None => py.None(),
         };
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -400,73 +400,66 @@ impl PyClient {
 
         #[cfg(feature = "otel")]
         let parent_ctx = crate::tracing::otel_impl::extract_python_context(py);
-        #[allow(unused)]
-        let conn_info = &self.connection_info;
-
-        let timer = crate::metrics::OperationTimer::start(
-            "exists",
-            &rust_key.namespace,
-            &rust_key.set_name,
-        );
+        #[cfg(not(feature = "otel"))]
+        let parent_ctx = ();
+        let conn_info = self.connection_info.clone();
 
         let result = if policy.is_none() {
             let rp = &*DEFAULT_READ_POLICY;
-            py.detach(|| RUNTIME.block_on(async { client.get(rp, &rust_key, Bins::None).await }))
+            py.detach(|| {
+                RUNTIME.block_on(async {
+                    traced_op!(
+                        "exists",
+                        &rust_key.namespace,
+                        &rust_key.set_name,
+                        parent_ctx,
+                        conn_info,
+                        {
+                            match client.get(rp, &rust_key, Bins::None).await {
+                                Ok(record) => Ok(Some(record)),
+                                Err(AsError::ServerError(ResultCode::KeyNotFoundError, _, _)) => {
+                                    Ok(None)
+                                }
+                                Err(e) => Err(e),
+                            }
+                        }
+                    )
+                })
+            })?
         } else {
             let read_policy = parse_read_policy(policy)?;
             py.detach(|| {
-                RUNTIME.block_on(async { client.get(&read_policy, &rust_key, Bins::None).await })
-            })
+                RUNTIME.block_on(async {
+                    traced_op!(
+                        "exists",
+                        &rust_key.namespace,
+                        &rust_key.set_name,
+                        parent_ctx,
+                        conn_info,
+                        {
+                            match client.get(&read_policy, &rust_key, Bins::None).await {
+                                Ok(record) => Ok(Some(record)),
+                                Err(AsError::ServerError(ResultCode::KeyNotFoundError, _, _)) => {
+                                    Ok(None)
+                                }
+                                Err(e) => Err(e),
+                            }
+                        }
+                    )
+                })
+            })?
         };
 
-        match &result {
-            Ok(_) => timer.finish(""),
-            Err(AsError::ServerError(ResultCode::KeyNotFoundError, _, _)) => timer.finish(""),
-            Err(e) => timer.finish(&crate::metrics::error_type_from_aerospike_error(e)),
-        }
-
-        // OTel span for exists
-        #[cfg(feature = "otel")]
-        {
-            use opentelemetry::trace::{SpanKind, TraceContextExt, Tracer};
-            use opentelemetry::KeyValue;
-            let tracer = crate::tracing::otel_impl::get_tracer();
-            let span_name = format!("EXISTS {}.{}", rust_key.namespace, rust_key.set_name);
-            let span = tracer
-                .span_builder(span_name)
-                .with_kind(SpanKind::Client)
-                .with_attributes(vec![
-                    KeyValue::new("db.system.name", "aerospike"),
-                    KeyValue::new("db.namespace", rust_key.namespace.clone()),
-                    KeyValue::new("db.collection.name", rust_key.set_name.clone()),
-                    KeyValue::new("db.operation.name", "EXISTS"),
-                    KeyValue::new("server.address", conn_info.server_address.clone()),
-                    KeyValue::new("server.port", conn_info.server_port),
-                    KeyValue::new("db.aerospike.cluster_name", conn_info.cluster_name.clone()),
-                ])
-                .start_with_context(&tracer, &parent_ctx);
-            let cx = parent_ctx.with_span(span);
-            let span_ref = opentelemetry::trace::TraceContextExt::span(&cx);
-            match &result {
-                Ok(_) | Err(AsError::ServerError(ResultCode::KeyNotFoundError, _, _)) => {}
-                Err(e) => {
-                    crate::tracing::otel_impl::record_error_on_span(&span_ref, e);
-                }
-            }
-            span_ref.end();
-        }
-
         match result {
-            Ok(record) => {
+            Some(record) => {
                 let meta = record_to_meta(py, &record)?;
                 let tuple = PyTuple::new(py, [key_py, meta])?;
                 Ok(tuple.into_any().unbind())
             }
-            Err(AsError::ServerError(ResultCode::KeyNotFoundError, _, _)) => {
+            None => {
                 let tuple = PyTuple::new(py, [key_py, py.None()])?;
                 Ok(tuple.into_any().unbind())
             }
-            Err(e) => Err(as_to_pyerr(e)),
         }
     }
 
@@ -1583,6 +1576,9 @@ impl PyClient {
             .map(|k| py_to_key(&k))
             .collect::<PyResult<_>>()?;
 
+        // Clone rust_ops per key because BatchOperation::write takes Vec<Operation>
+        // by value (ownership). Arc wrapping won't help since we must materialize a
+        // Vec for each batch entry. This is O(n×m) but unavoidable given the API.
         let batch_ops: Vec<BatchOperation> = rust_keys
             .iter()
             .map(|k| BatchOperation::write(&write_policy, k.clone(), rust_ops.clone()))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,8 +20,8 @@ mod types;
 
 /// Return collected metrics in Prometheus text format.
 #[pyfunction]
-fn get_metrics_text() -> String {
-    metrics::get_text()
+fn get_metrics_text() -> PyResult<String> {
+    metrics::get_text().map_err(pyo3::exceptions::PyRuntimeError::new_err)
 }
 
 /// Native Aerospike Python client module

--- a/rust/src/metrics.rs
+++ b/rust/src/metrics.rs
@@ -91,11 +91,15 @@ pub fn error_type_from_aerospike_error(err: &AsError) -> String {
     }
 }
 
-pub fn get_text() -> String {
+pub fn get_text() -> Result<String, String> {
     let mut buf = String::new();
-    let registry = METRICS.registry.lock().unwrap();
-    prometheus_client::encoding::text::encode(&mut buf, &registry).unwrap();
-    buf
+    let registry = METRICS
+        .registry
+        .lock()
+        .map_err(|e| format!("Metrics lock poisoned: {e}"))?;
+    prometheus_client::encoding::text::encode(&mut buf, &registry)
+        .map_err(|e| format!("Metrics encoding failed: {e}"))?;
+    Ok(buf)
 }
 
 /// Instrument a data operation with metrics.

--- a/rust/src/numpy_support.rs
+++ b/rust/src/numpy_support.rs
@@ -104,7 +104,9 @@ fn get_array_data_ptr(array: &Bound<'_, PyAny>) -> PyResult<*mut u8> {
     if readonly {
         return Err(PyValueError::new_err("numpy array is read-only"));
     }
-    debug_assert!(ptr_int != 0, "numpy array data pointer is null");
+    if ptr_int == 0 {
+        return Err(PyValueError::new_err("numpy array has null data pointer"));
+    }
     Ok(ptr_int as *mut u8)
 }
 

--- a/rust/src/record_helpers.rs
+++ b/rust/src/record_helpers.rs
@@ -35,7 +35,10 @@ pub fn record_to_meta(py: Python<'_>, record: &aerospike_core::Record) -> PyResu
     meta.set_item("gen", record.generation)?;
     let ttl: u32 = record
         .time_to_live()
-        .map(|d| d.as_secs() as u32)
+        .map(|d| {
+            // Cap at u32::MAX to prevent truncation of very large TTL values
+            d.as_secs().try_into().unwrap_or(u32::MAX)
+        })
         .unwrap_or(0xFFFFFFFF_u32);
     meta.set_item("ttl", ttl)?;
     Ok(meta.into_any().unbind())

--- a/rust/src/runtime.rs
+++ b/rust/src/runtime.rs
@@ -7,5 +7,8 @@ pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("Failed to create Tokio runtime")
+        .unwrap_or_else(|e| {
+            eprintln!("FATAL: Failed to create Tokio runtime: {}", e);
+            std::process::exit(1);
+        })
 });

--- a/rust/src/types/host.rs
+++ b/rust/src/types/host.rs
@@ -43,7 +43,11 @@ pub fn parse_hosts_from_config(config: &Bound<'_, PyDict>) -> PyResult<ParsedHos
                 // Parse "host:port" or just "host"
                 if let Some((h, p)) = s.rsplit_once(':') {
                     first_address = h.to_string();
-                    first_port = p.parse().unwrap_or(3000);
+                    first_port = p.parse().map_err(|_| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "Invalid port number: '{p}'"
+                        ))
+                    })?;
                 } else {
                     first_address = s.clone();
                     first_port = 3000;

--- a/rust/src/types/key.rs
+++ b/rust/src/types/key.rs
@@ -16,6 +16,13 @@ pub fn py_to_key(key_tuple: &Bound<'_, PyAny>) -> PyResult<Key> {
         ));
     }
 
+    if tuple.len() > 4 {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Key tuple must have 3-4 elements, got {}",
+            tuple.len()
+        )));
+    }
+
     let namespace: String = tuple.get_item(0)?.extract()?;
     let set_name: String = tuple.get_item(1)?.extract()?;
     let user_key = py_to_value(&tuple.get_item(2)?)?;

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -981,8 +981,10 @@ class AsyncClient:
         self,
         username: Optional[str] = None,
         password: Optional[str] = None,
-    ) -> None:
+    ) -> "AsyncClient":
         """Connect to the Aerospike cluster.
+
+        Returns ``self`` for method chaining, matching the sync ``Client``.
 
         Args:
             username: Optional username for authentication.

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -1,0 +1,249 @@
+"""Unit tests for concurrent operation safety (no Aerospike server required)."""
+
+import socket
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import aerospike_py
+from aerospike_py import exp
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Metrics concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsConcurrency:
+    def test_concurrent_get_metrics(self):
+        errors: list = []
+
+        def worker(idx):
+            try:
+                text = aerospike_py.get_metrics()
+                assert isinstance(text, str)
+                assert "# HELP" in text
+            except Exception as e:
+                errors.append((idx, e))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(worker, i) for i in range(4)]
+            for f in as_completed(futures):
+                f.result()  # re-raise if worker raised
+
+        assert not errors, f"Concurrent get_metrics() errors: {errors}"
+
+    def test_concurrent_start_stop_metrics_server(self):
+        errors: list = []
+
+        def worker(idx):
+            try:
+                port = _find_free_port()
+                if idx % 2 == 0:
+                    try:
+                        aerospike_py.start_metrics_server(port=port)
+                    except OSError:
+                        pass
+                else:
+                    aerospike_py.stop_metrics_server()
+            except Exception as e:
+                errors.append((idx, e))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(worker, i) for i in range(4)]
+            for f in as_completed(futures):
+                f.result()
+
+        aerospike_py.stop_metrics_server()
+        assert not errors, f"Concurrent start/stop errors: {errors}"
+
+    def test_metrics_server_restart_under_load(self):
+        port1 = _find_free_port()
+        aerospike_py.start_metrics_server(port=port1)
+        try:
+            text1 = aerospike_py.get_metrics()
+            assert isinstance(text1, str)
+            assert "# HELP" in text1
+        finally:
+            aerospike_py.stop_metrics_server()
+
+        port2 = _find_free_port()
+        aerospike_py.start_metrics_server(port=port2)
+        try:
+            errors: list = []
+
+            def reader(idx):
+                try:
+                    text = aerospike_py.get_metrics()
+                    assert isinstance(text, str)
+                except Exception as e:
+                    errors.append((idx, e))
+
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futures = [pool.submit(reader, i) for i in range(4)]
+                for f in as_completed(futures):
+                    f.result()
+
+            assert not errors, f"Post-restart concurrent read errors: {errors}"
+        finally:
+            aerospike_py.stop_metrics_server()
+
+
+# ---------------------------------------------------------------------------
+# Client creation concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestClientCreationConcurrency:
+    def test_concurrent_client_creation(self):
+        clients: dict = {}
+        errors: list = []
+
+        def worker(idx):
+            try:
+                c = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]})
+                assert isinstance(c, aerospike_py.Client)
+                assert not c.is_connected()
+                clients[idx] = c
+            except Exception as e:
+                errors.append((idx, e))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(worker, i) for i in range(4)]
+            for f in as_completed(futures):
+                f.result()
+
+        assert not errors, f"Concurrent client creation errors: {errors}"
+        assert len(clients) == 4
+
+    def test_concurrent_async_client_creation(self):
+        clients: dict = {}
+        errors: list = []
+
+        def worker(idx):
+            try:
+                c = aerospike_py.AsyncClient({"hosts": [("127.0.0.1", 3000)]})
+                clients[idx] = c
+            except Exception as e:
+                errors.append((idx, e))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(worker, i) for i in range(4)]
+            for f in as_completed(futures):
+                f.result()
+
+        assert not errors, f"Concurrent async client creation errors: {errors}"
+        assert len(clients) == 4
+
+
+# ---------------------------------------------------------------------------
+# Tracing concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestTracingConcurrency:
+    def test_concurrent_init_shutdown_tracing(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        errors: list = []
+
+        def worker(idx):
+            try:
+                if idx % 2 == 0:
+                    aerospike_py.init_tracing()
+                else:
+                    aerospike_py.shutdown_tracing()
+            except Exception as e:
+                errors.append((idx, e))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(worker, i) for i in range(4)]
+            for f in as_completed(futures):
+                f.result()
+
+        aerospike_py.shutdown_tracing()
+        assert not errors, f"Concurrent tracing init/shutdown errors: {errors}"
+
+    def test_tracing_with_client_operations(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        aerospike_py.init_tracing()
+        try:
+            errors: list = []
+
+            def worker(idx):
+                try:
+                    c = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]})
+                    key = ("test", "demo", f"concurrency_key_{idx}")
+                    try:
+                        c.put(key, {"val": idx})
+                    except aerospike_py.ClientError:
+                        pass
+                    try:
+                        c.get(key)
+                    except aerospike_py.ClientError:
+                        pass
+                except Exception as e:
+                    errors.append((idx, e))
+
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futures = [pool.submit(worker, i) for i in range(4)]
+                for f in as_completed(futures):
+                    f.result()
+
+            assert not errors, f"Tracing + client ops errors: {errors}"
+        finally:
+            aerospike_py.shutdown_tracing()
+
+
+# ---------------------------------------------------------------------------
+# Expression concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestExpressionConcurrency:
+    def test_concurrent_expression_building(self):
+        results: dict = {}
+        errors: list = []
+
+        def worker(idx):
+            try:
+                if idx == 0:
+                    e = exp.and_(
+                        exp.ge(exp.int_bin("age"), exp.int_val(18)),
+                        exp.lt(exp.int_bin("age"), exp.int_val(65)),
+                    )
+                    assert e["__expr__"] == "and"
+                elif idx == 1:
+                    e = exp.or_(
+                        exp.eq(exp.string_bin("status"), exp.string_val("active")),
+                        exp.eq(exp.string_bin("status"), exp.string_val("pending")),
+                    )
+                    assert e["__expr__"] == "or"
+                elif idx == 2:
+                    e = exp.not_(
+                        exp.eq(exp.int_bin("deleted"), exp.int_val(1)),
+                    )
+                    assert e["__expr__"] == "not"
+                else:
+                    e = exp.let_(
+                        exp.def_("x", exp.int_bin("count")),
+                        exp.gt(exp.var("x"), exp.int_val(0)),
+                    )
+                    assert e["__expr__"] == "let"
+
+                results[idx] = e
+            except Exception as e:
+                errors.append((idx, e))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(worker, i) for i in range(4)]
+            for f in as_completed(futures):
+                f.result()
+
+        assert not errors, f"Concurrent expression building errors: {errors}"
+        assert len(results) == 4
+        for r in results.values():
+            assert "__expr__" in r

--- a/tests/unit/test_error_paths.py
+++ b/tests/unit/test_error_paths.py
@@ -1,0 +1,98 @@
+"""Unit tests for error handling paths (no server required)."""
+
+import pytest
+
+import aerospike_py
+from aerospike_py import exp
+
+
+def _make_client():
+    return aerospike_py.client({"hosts": [("127.0.0.1", 3000)]})
+
+
+def _make_async_client():
+    return aerospike_py.AsyncClient({"hosts": [("127.0.0.1", 3000)]})
+
+
+KEY = ("test", "demo", "error_path_key")
+
+
+class TestClientNotConnected:
+    def test_get_not_connected_raises_client_error(self):
+        c = _make_client()
+        with pytest.raises(aerospike_py.ClientError):
+            c.get(KEY)
+
+    def test_put_not_connected_raises_client_error(self):
+        c = _make_client()
+        with pytest.raises(aerospike_py.ClientError):
+            c.put(KEY, {"bin": 1})
+
+    def test_exists_not_connected_raises_client_error(self):
+        c = _make_client()
+        with pytest.raises(aerospike_py.ClientError):
+            c.exists(KEY)
+
+    def test_remove_not_connected_raises_client_error(self):
+        c = _make_client()
+        with pytest.raises(aerospike_py.ClientError):
+            c.remove(KEY)
+
+    def test_batch_read_not_connected_raises_client_error(self):
+        c = _make_client()
+        with pytest.raises(aerospike_py.ClientError):
+            c.batch_read([KEY])
+
+
+class TestInvalidArguments:
+    def test_put_non_dict_bins_raises_type_error(self):
+        c = _make_client()
+        with pytest.raises(TypeError):
+            c.put(KEY, {1, 2, 3})
+
+    def test_put_invalid_key_type_raises(self):
+        c = _make_client()
+        with pytest.raises((TypeError, aerospike_py.ClientError)):
+            c.put("not_a_tuple", {"bin": 1})
+
+    def test_key_too_short_raises(self):
+        c = _make_client()
+        with pytest.raises((TypeError, aerospike_py.AerospikeError)):
+            c.put(("test", "demo"), {"bin": 1})
+
+    def test_key_too_long_raises(self):
+        c = _make_client()
+        with pytest.raises((TypeError, aerospike_py.AerospikeError)):
+            c.put(("test", "demo", "pk", "extra", "extra2"), {"bin": 1})
+
+
+class TestExpressionErrors:
+    def test_invalid_expression_type_raises(self):
+        with pytest.raises(ValueError):
+            exp._cmd("nonexistent_op", val=42)
+
+    def test_expression_missing_expr_key_raises(self):
+        bad_expr = {"not_expr": "eq", "left": 1, "right": 2}
+        assert "__expr__" not in bad_expr
+        valid = exp.int_val(1)
+        assert "__expr__" in valid
+
+    def test_unknown_expression_op_raises(self):
+        with pytest.raises(ValueError, match="Unknown expression op"):
+            exp._cmd("totally_bogus_operation")
+
+    def test_expression_builder_rejects_empty_op(self):
+        with pytest.raises(ValueError):
+            exp._cmd("")
+
+
+class TestAsyncClientErrors:
+    async def test_async_get_not_connected_raises(self):
+        c = _make_async_client()
+        with pytest.raises(aerospike_py.ClientError):
+            await c.get(KEY)
+
+    async def test_async_put_not_connected_raises(self):
+        c = _make_async_client()
+        with pytest.raises(aerospike_py.ClientError):
+            await c.put(KEY, {"bin": 1})

--- a/tests/unit/test_expression_safety.py
+++ b/tests/unit/test_expression_safety.py
@@ -1,0 +1,156 @@
+"""Tests for expression filter safety: input validation, depth limits, builder correctness."""
+
+import pytest
+
+from aerospike_py import exp
+
+
+class TestUnaryFunctionsMissingArgs:
+    @pytest.mark.parametrize(
+        "fn",
+        [exp.num_abs, exp.num_floor, exp.num_ceil, exp.to_int, exp.to_float, exp.int_not, exp.int_count],
+        ids=["num_abs", "num_floor", "num_ceil", "to_int", "to_float", "int_not", "int_count"],
+    )
+    def test_unary_no_args_raises_type_error(self, fn):
+        with pytest.raises(TypeError):
+            fn()
+
+
+class TestBinaryFunctionsMissingArgs:
+    @pytest.mark.parametrize(
+        "fn",
+        [exp.num_mod, exp.num_pow, exp.num_log, exp.int_lshift, exp.int_rshift, exp.int_arshift],
+        ids=["num_mod", "num_pow", "num_log", "int_lshift", "int_rshift", "int_arshift"],
+    )
+    def test_binary_no_args_raises_type_error(self, fn):
+        with pytest.raises(TypeError):
+            fn()
+
+    @pytest.mark.parametrize(
+        "fn",
+        [exp.num_mod, exp.num_pow, exp.num_log, exp.int_lshift, exp.int_rshift],
+        ids=["num_mod", "num_pow", "num_log", "int_lshift", "int_rshift"],
+    )
+    def test_binary_one_arg_raises_type_error(self, fn):
+        with pytest.raises(TypeError):
+            fn(exp.int_val(1))
+
+
+class TestComparisonFunctionsMissingArgs:
+    @pytest.mark.parametrize(
+        "fn",
+        [exp.eq, exp.ne, exp.gt, exp.ge, exp.lt, exp.le],
+        ids=["eq", "ne", "gt", "ge", "lt", "le"],
+    )
+    def test_comparison_no_args_raises_type_error(self, fn):
+        with pytest.raises(TypeError):
+            fn()
+
+    @pytest.mark.parametrize(
+        "fn",
+        [exp.eq, exp.ne, exp.gt, exp.ge, exp.lt, exp.le],
+        ids=["eq", "ne", "gt", "ge", "lt", "le"],
+    )
+    def test_comparison_one_arg_raises_type_error(self, fn):
+        with pytest.raises(TypeError):
+            fn(exp.int_val(1))
+
+
+class TestDepthLimit:
+    def test_deep_nesting_produces_valid_structure(self):
+        """Build 50-level nested expression — verifies no Python-side limit."""
+        e = exp.int_val(1)
+        for _ in range(50):
+            e = exp.num_abs(e)
+        assert e["__expr__"] == "num_abs"
+
+    def test_very_deep_nesting_still_builds(self):
+        """Build 200-level nested expression — Python builder has no limit,
+        Rust parser enforces 128 depth limit when expression is used in policy."""
+        e = exp.int_val(1)
+        for _ in range(200):
+            e = exp.num_abs(e)
+        assert e["__expr__"] == "num_abs"
+        assert "exprs" in e
+        assert len(e["exprs"]) == 1
+
+
+class TestNormalOperationSmoke:
+    def test_basic_comparison(self):
+        e = exp.gt(exp.int_bin("age"), exp.int_val(21))
+        assert e["__expr__"] == "gt"
+        assert e["left"]["__expr__"] == "int_bin"
+        assert e["right"]["__expr__"] == "int_val"
+
+    def test_logical_and(self):
+        e = exp.and_(
+            exp.gt(exp.int_bin("age"), exp.int_val(18)),
+            exp.lt(exp.int_bin("age"), exp.int_val(65)),
+        )
+        assert e["__expr__"] == "and"
+        assert len(e["exprs"]) == 2
+
+    def test_logical_or(self):
+        e = exp.or_(
+            exp.eq(exp.string_bin("s"), exp.string_val("a")),
+            exp.eq(exp.string_bin("s"), exp.string_val("b")),
+        )
+        assert e["__expr__"] == "or"
+        assert len(e["exprs"]) == 2
+
+    def test_not(self):
+        e = exp.not_(exp.bin_exists("x"))
+        assert e["__expr__"] == "not"
+        assert e["expr"]["__expr__"] == "bin_exists"
+
+    def test_unary_with_valid_arg(self):
+        e = exp.num_abs(exp.int_bin("x"))
+        assert e["__expr__"] == "num_abs"
+        assert e["exprs"][0]["__expr__"] == "int_bin"
+
+    def test_binary_with_valid_args(self):
+        e = exp.num_mod(exp.int_bin("x"), exp.int_val(10))
+        assert e["__expr__"] == "num_mod"
+        assert len(e["exprs"]) == 2
+
+    def test_let_def_var(self):
+        e = exp.let_(
+            exp.def_("x", exp.int_bin("count")),
+            exp.gt(exp.var("x"), exp.int_val(0)),
+        )
+        assert e["__expr__"] == "let"
+        assert len(e["exprs"]) == 2
+
+    def test_cond_expression(self):
+        e = exp.cond(
+            exp.gt(exp.int_bin("age"), exp.int_val(18)),
+            exp.string_val("adult"),
+            exp.string_val("minor"),
+        )
+        assert e["__expr__"] == "cond"
+        assert len(e["exprs"]) == 3
+
+    def test_regex_compare(self):
+        e = exp.regex_compare("^test.*", 0, exp.string_bin("name"))
+        assert e["__expr__"] == "regex_compare"
+        assert e["regex"] == "^test.*"
+
+    def test_variadic_with_many_args(self):
+        e = exp.num_add(exp.int_val(1), exp.int_val(2), exp.int_val(3), exp.int_val(4))
+        assert e["__expr__"] == "num_add"
+        assert len(e["exprs"]) == 4
+
+
+class TestOpValidation:
+    def test_unknown_op_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown expression op"):
+            exp._cmd("nonexistent_op")
+
+    def test_empty_op_raises_value_error(self):
+        with pytest.raises(ValueError):
+            exp._cmd("")
+
+    def test_valid_op_accepted(self):
+        result = exp._cmd("int_val", val=42)
+        assert result["__expr__"] == "int_val"
+        assert result["val"] == 42

--- a/tests/unit/test_panic_regression.py
+++ b/tests/unit/test_panic_regression.py
@@ -1,0 +1,148 @@
+"""Regression tests for previously-crashing (panic) scenarios.
+
+Task 5 (key validation), Task 12 (metrics), Task 13 (deprecation), Task 14 (async connect).
+"""
+
+import asyncio
+import inspect
+import socket
+import warnings
+
+import pytest
+
+import aerospike_py
+
+
+def _make_client():
+    return aerospike_py.client({"hosts": [("127.0.0.1", 3000)]})
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+class TestKeyValidation:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            ("ns", "set", "pk", "extra", "extra2"),
+            ("ns", "set", "pk", 1, 2, 3),
+            tuple(range(7)),
+            ("a",) * 10,
+        ],
+        ids=["5-elem", "6-elem", "7-elem", "10-elem"],
+    )
+    def test_key_tuple_too_many_elements_raises(self, key):
+        """Key with >4 elements must not silently succeed — error before or after connect check."""
+        c = _make_client()
+        with pytest.raises((ValueError, TypeError, aerospike_py.ClientError)):
+            c.put(key, {"bin": 1})
+
+    def test_key_tuple_5_elements_raises(self):
+        c = _make_client()
+        with pytest.raises((ValueError, TypeError, aerospike_py.ClientError)):
+            c.put(("ns", "set", "pk", "x", "y"), {"b": 1})
+
+    def test_key_tuple_6_elements_raises(self):
+        c = _make_client()
+        with pytest.raises((ValueError, TypeError, aerospike_py.ClientError)):
+            c.put(("ns", "set", "pk", "x", "y", "z"), {"b": 1})
+
+    def test_key_tuple_3_elements_valid(self):
+        """3-element key is valid; on unconnected client we get ClientError (not a crash)."""
+        c = _make_client()
+        with pytest.raises(aerospike_py.ClientError):
+            c.put(("test", "demo", "key1"), {"bin": 1})
+
+    def test_key_tuple_too_short_raises(self):
+        c = _make_client()
+        with pytest.raises((ValueError, TypeError, aerospike_py.ClientError)):
+            c.put(("ns",), {"bin": 1})
+
+
+class TestMetricsThreadSafety:
+    def test_double_start_metrics_server_no_crash(self):
+        port1 = _find_free_port()
+        port2 = _find_free_port()
+        try:
+            aerospike_py.start_metrics_server(port=port1)
+            aerospike_py.start_metrics_server(port=port2)
+        finally:
+            aerospike_py.stop_metrics_server()
+
+    def test_stop_without_start_no_crash(self):
+        aerospike_py.stop_metrics_server()
+        aerospike_py.stop_metrics_server()
+
+
+class TestDeprecationWarnings:
+    def test_timeout_error_emits_deprecation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = aerospike_py.TimeoutError
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+            assert "TimeoutError" in str(deprecation_warnings[0].message)
+
+    def test_index_error_emits_deprecation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = aerospike_py.IndexError
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+            assert "IndexError" in str(deprecation_warnings[0].message)
+
+    def test_deprecated_timeout_alias_is_correct_class(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            te = aerospike_py.TimeoutError
+        assert te is aerospike_py.AerospikeTimeoutError
+
+    def test_deprecated_index_alias_is_correct_class(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            ie = aerospike_py.IndexError
+        assert ie is aerospike_py.AerospikeIndexError
+
+    def test_deprecated_aliases_still_work(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            te = aerospike_py.TimeoutError
+            ie = aerospike_py.IndexError
+        assert issubclass(te, aerospike_py.AerospikeError)
+        assert issubclass(ie, aerospike_py.ServerError)
+
+
+class TestAsyncClientConnectReturnType:
+    def test_async_connect_returns_self(self):
+        hints = inspect.get_annotations(aerospike_py.AsyncClient.connect)
+        return_hint = hints.get("return")
+        assert return_hint is not None
+        if isinstance(return_hint, str):
+            assert "AsyncClient" in return_hint
+        else:
+            assert return_hint is aerospike_py.AsyncClient or (
+                hasattr(return_hint, "__name__") and "AsyncClient" in return_hint.__name__
+            )
+
+    def test_async_connect_method_exists_on_wrapper(self):
+        assert "connect" in aerospike_py.AsyncClient.__dict__
+
+    def test_async_client_connect_is_coroutine(self):
+        assert asyncio.iscoroutinefunction(aerospike_py.AsyncClient.connect)
+
+
+class TestImportSmokeTests:
+    def test_import_no_crash(self):
+        import aerospike_py as ap  # noqa: F811
+
+        assert ap is not None
+        assert hasattr(ap, "Client")
+        assert hasattr(ap, "AsyncClient")
+
+    def test_basic_client_creation(self):
+        c = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]})
+        assert isinstance(c, aerospike_py.Client)
+        assert not c.is_connected()


### PR DESCRIPTION
## Summary

Comprehensive safety audit of the Rust (PyO3) and Python layers to eliminate user-triggerable process panics, improve error handling, and add test coverage for previously untested paths.

- **Zero user-triggerable process panics**: All `.unwrap()` calls in user-reachable Rust paths replaced with proper `PyResult`/`PyErr` returns
- **Expression parser safety**: Input validation before `.next()` + recursion depth limit (128 levels)
- **Mutex safety**: All `lock().unwrap()` replaced with proper error handling in metrics, tracing, and async client
- **Python API improvements**: Thread-safe metrics server, deprecation warnings for builtin shadows (`IndexError`/`TimeoutError`), `AsyncClient.connect()` chaining
- **88 new unit tests**: Expression safety, panic regression, error paths, and concurrency tests (380 total, up from 292)

## Changes by Wave

### Wave 1 — Rust Safety (7 commits)
| File | Fix |
|------|-----|
| `expressions.rs` | Guard `.next().unwrap()` panics + recursion depth limit (128) |
| `metrics.rs` + `lib.rs` | Replace mutex `.unwrap()` with proper error handling |
| `tracing.rs` | Replace mutex `.unwrap()` with match-based handling |
| `numpy_support.rs` | Replace `debug_assert!` with runtime null check |
| `types/key.rs` | Reject key tuples with >4 elements |
| `record_helpers.rs` | Safe u32 conversion for TTL (no silent truncation) |
| `batch_types.rs` | Eliminate redundant `.unwrap()` in match arm |

### Wave 2 — Rust Quality (4 commits)
| File | Fix |
|------|-----|
| `async_client.rs` | Mutex recovery + default policy fast-path + `exists()` OTel |
| `client.rs` | Document batch clone requirement + `exists()` OTel consistency |
| `query.rs` | Stream `foreach` results incrementally (no full collect) |
| `runtime.rs` | Graceful error on Tokio init failure |

### Wave 3 — Python API + CI (2 commits)
| File | Fix |
|------|-----|
| `__init__.py` | Thread-safe metrics server, deprecation warnings, `AsyncClient.connect()` chaining |
| `ci.yaml` | Remove stale `tox.toml` reference from triggers |

### Wave 4 — Test Coverage (1 commit)
| File | Tests |
|------|-------|
| `test_expression_safety.py` | 45 tests — unary/binary arg validation, depth nesting, op validation |
| `test_panic_regression.py` | 20 tests — key validation, metrics thread safety, deprecation, async connect |
| `test_error_paths.py` | 15 tests — client not connected, invalid args, expression errors |
| `test_concurrency.py` | 8 tests — concurrent metrics, client creation, tracing, expressions |

## Verification

- `cargo check` ✅ (default + otel features)
- `pytest tests/unit/ -v` — 380 passed ✅
- All pre-commit hooks pass (cargo fmt, clippy, ruff, pyright)
- No breaking API changes — backward compatible

## Stats
- **18 files changed**, 1,151 insertions, 260 deletions
- **14 commits**, 19 tasks completed
- **88 new tests** (380 total)