### PR TITLE
fix: pass AEROSPIKE env vars through tox and fix broken doc links

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/client.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/client.md
@@ -593,7 +593,7 @@ for key, meta, bins in records:
 
 :::note
 
-AsyncClient에는 `query()` 메서드가 없습니다. 서버사이드 필터링은 `scan()`과 [Expression Filters](../guides/expression-filters.md)를 조합하여 사용하세요.
+AsyncClient에는 `query()` 메서드가 없습니다. 서버사이드 필터링은 `scan()`과 [Expression Filters](../guides/query-scan/expression-filters.md)를 조합하여 사용하세요.
 
 :::
 
@@ -954,6 +954,6 @@ records = await client.batch_operate(keys, ops, policy={"filter_expression": exp
 :::tip
 
 레코드가 필터 expression과 매칭되지 않으면 `FilteredOut`이 발생합니다.
-자세한 문서는 [Expression 필터 가이드](../guides/expression-filters.md)를 참조하세요.
+자세한 문서는 [Expression 필터 가이드](../guides/query-scan/expression-filters.md)를 참조하세요.
 
 :::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ env_list = ["py{310,311,312,313,314}", "py314t"]
 [tool.tox.env_run_base]
 package = "wheel"
 dependency_groups = ["test"]
+pass_env = ["AEROSPIKE_HOST", "AEROSPIKE_PORT"]
 commands = [["pytest", "tests/unit/", "-v"]]
 
 [tool.tox.env.py314t]


### PR DESCRIPTION
## Summary

- **CI fix**: Add `pass_env = ["AEROSPIKE_HOST", "AEROSPIKE_PORT"]` to tox `env_run_base` config so CI integration/concurrency tests connect to port 3000 (service container) instead of the local default 18710
- **Docs fix**: Fix 2 broken markdown links in Korean `client.md` — `../guides/expression-filters.md` → `../guides/query-scan/expression-filters.md`

## Root Cause

### CI (`test_multiple_clients_from_threads` failure)
After commit `20c2d9e` changed the default port to 18710, tox environments no longer pass the `AEROSPIKE_PORT=3000` env var set in the CI workflow. Tests using the `client` fixture gracefully skip (via `pytest.skip`), but `test_multiple_clients_from_threads` creates clients directly without a fixture, causing `ClusterError` on port 18710.

### Publish Docs (broken links in Korean locale)
The expression-filters guide is located at `guides/query-scan/expression-filters.md`, but the Korean `client.md` linked to `guides/expression-filters.md` (missing the `query-scan/` subdirectory).

## Test plan
- [ ] CI workflow passes on this PR (integration tests connect to correct port)
- [ ] Publish Docs workflow passes (no broken links in Korean locale build)