### PR TITLE
docs: enhance all 7 SKILL.md files with accurate references and guides

### DIFF
--- a/.claude/skills/aerospike-py/SKILL.md
+++ b/.claude/skills/aerospike-py/SKILL.md
@@ -9,59 +9,121 @@ user-invocable: false
 Aerospike Python client (Rust/PyO3). Sync/Async API 제공. 기본 포트 18710.
 전체 상수/타입 정의는 `src/aerospike_py/__init__.pyi` 참조.
 
-## Client
+## Client 생성
 
 ```python
 import aerospike_py
 
 # Sync - 메서드 체이닝
 client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()
-with aerospike_py.client(config).connect() as client: ...
+
+# Sync - context manager
+with aerospike_py.client(config).connect() as client:
+    record = client.get(("test", "demo", "key1"))
+
+# Sync - 인증
+client = aerospike_py.client(config).connect("admin", "admin")
 
 # Async
 client = aerospike_py.AsyncClient({"hosts": [("127.0.0.1", 18710)]})
 await client.connect()
-async with aerospike_py.AsyncClient(config) as client: ...
+
+# Async - context manager
+async with aerospike_py.AsyncClient(config) as client:
+    await client.connect()
+    record = await client.get(("test", "demo", "key1"))
+```
+
+### ClientConfig
+
+```python
+config: dict = {
+    "hosts": [("127.0.0.1", 18710)],  # 필수
+    "cluster_name": "docker",           # 클러스터 이름 검증
+    "auth_mode": aerospike_py.AUTH_INTERNAL,  # 인증 모드
+    "user": "admin",                    # 사용자
+    "password": "admin",               # 비밀번호
+    "timeout": 30000,                   # 연결 타임아웃 (ms)
+    "idle_timeout": 55000,             # 유휴 연결 타임아웃 (ms)
+    "max_conns_per_node": 300,         # 노드당 최대 연결 수
+    "min_conns_per_node": 0,           # 노드당 최소 연결 수
+    "tend_interval": 1000,             # 클러스터 상태 확인 주기 (ms)
+    "use_services_alternate": False,   # alternate 서비스 주소 사용
+}
 ```
 
 ## 반환 타입 (NamedTuple)
 
 ```python
-Record(key: AerospikeKey | None, meta: RecordMetadata | None, bins: Bins | None)
-AerospikeKey(namespace, set_name, user_key, digest)
-RecordMetadata(gen, ttl)
-ExistsResult(key, meta)  # meta is None if not found
-OperateOrderedResult(key, meta, ordered_bins: list[BinTuple])
-BinTuple(name, value)
-InfoNodeResult(node_name, error_code, response)
+from aerospike_py.types import Record, AerospikeKey, RecordMetadata, ExistsResult, \
+    OperateOrderedResult, BinTuple, InfoNodeResult
+
+Record(key: AerospikeKey | None, meta: RecordMetadata | None, bins: dict[str, Any] | None)
+AerospikeKey(namespace: str, set_name: str, user_key: str | int | bytes | None, digest: bytes)
+RecordMetadata(gen: int, ttl: int)
+ExistsResult(key: AerospikeKey | None, meta: RecordMetadata | None)  # meta is None if not found
+OperateOrderedResult(key: AerospikeKey | None, meta: RecordMetadata | None, ordered_bins: list[BinTuple])
+BinTuple(name: str, value: Any)
+InfoNodeResult(node_name: str, error_code: int, response: str)
+```
+
+## Connection
+
+```python
+client.connect(username=None, password=None) -> Client   # 메서드 체이닝
+client.is_connected() -> bool
+client.close() -> None
+client.get_node_names() -> list[str]
+
+# Async 동일 (await 필요, is_connected 제외)
+await client.connect()
+await client.close()
+await client.get_node_names()
 ```
 
 ## CRUD
 
 ```python
-key = ("test", "demo", "user1")
+key: tuple[str, str, str | int | bytes] = ("test", "demo", "user1")
 
 # Write
 client.put(key, {"name": "Alice", "age": 30})
-client.put(key, {"score": 100}, meta={"ttl": 300})  # with TTL
+client.put(key, {"score": 100}, meta={"ttl": 300})  # TTL 설정
 client.put(key, {"x": 1}, policy={"exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY})
+client.put(key, {"x": 1}, meta={"gen": 2}, policy={"gen": aerospike_py.POLICY_GEN_EQ})
 
 # Read -> Record
-record = client.get(key)  # record.bins, record.meta.gen, record.meta.ttl
-record = client.select(key, ["name"])  # specific bins only
+record: Record = client.get(key)
+record.bins     # {"name": "Alice", "age": 30}
+record.meta.gen # generation number
+record.meta.ttl # TTL in seconds
+
+# Select -> Record (특정 bin만 읽기)
+record: Record = client.select(key, ["name"])  # record.bins = {"name": "Alice"}
 
 # Exists -> ExistsResult
-result = client.exists(key)  # result.meta is None if not found
+result: ExistsResult = client.exists(key)
+if result.meta is not None:
+    print(f"Found, gen={result.meta.gen}")
 
 # Delete
 client.remove(key)
-client.touch(key, val=300)  # reset TTL
+client.remove(key, meta={"gen": 3}, policy={"gen": aerospike_py.POLICY_GEN_EQ})
 
-# String/Numeric
+# Touch (TTL 리셋)
+client.touch(key, val=300)
+
+# String 연산
 client.append(key, "name", "_suffix")
 client.prepend(key, "name", "prefix_")
-client.increment(key, "counter", 1)  # negative to decrement
-client.remove_bin(key, ["temp_bin"])
+
+# Numeric 연산
+client.increment(key, "counter", 1)      # int 증가
+client.increment(key, "score", 0.5)      # float 증가
+client.increment(key, "counter", -1)     # 감소
+
+# Bin 삭제
+client.remove_bin(key, ["temp_bin", "debug_bin"])
 
 # Async: 모든 메서드에 await 추가
 record = await client.get(key)
@@ -71,27 +133,75 @@ await client.put(key, {"name": "Alice"})
 ## Batch
 
 ```python
-keys = [("test", "demo", f"user_{i}") for i in range(10)]
+keys: list[tuple[str, str, str | int | bytes]] = [
+    ("test", "demo", f"user_{i}") for i in range(10)
+]
 
-batch = client.batch_read(keys, bins=["name", "age"])  # -> BatchRecords
-results = client.batch_operate(keys, ops)  # -> list[Record]
-results = client.batch_remove(keys)  # -> list[Record]
+# batch_read -> BatchRecords (raw 튜플, NamedTuple 아님)
+batch: BatchRecords = client.batch_read(keys)
+for br in batch.batch_records:
+    if br.result == 0 and br.record is not None:
+        key_tuple, meta_dict, bins = br.record
+        print(bins)
 
-# NumPy batch
+# 특정 bin만 읽기
+batch = client.batch_read(keys, bins=["name", "age"])
+
+# batch_operate -> list[Record] (NamedTuple)
+ops = [{"op": aerospike_py.OPERATOR_INCR, "bin": "views", "val": 1}]
+results: list[Record] = client.batch_operate(keys, ops)
+for record in results:
+    print(record.bins)
+
+# batch_remove -> list[Record]
+results: list[Record] = client.batch_remove(keys)
+
+# Async: 동일하게 await
+batch = await client.batch_read(keys, bins=["name", "age"])
+results = await client.batch_operate(keys, ops)
+results = await client.batch_remove(keys)
+```
+
+### NumPy Batch
+
+```python
 import numpy as np
-dtype = np.dtype([("age", "i4"), ("score", "f8")])
-result = client.batch_read(keys, bins=["age", "score"], _dtype=dtype)
+
+# dtype 정의 (int, float, fixed-length bytes만 가능)
+dtype = np.dtype([("age", "i4"), ("score", "f8"), ("name", "S32")])
+
+# batch_read + NumPy -> NumpyBatchRecords
+result: NumpyBatchRecords = client.batch_read(keys, bins=["age", "score", "name"], _dtype=dtype)
+
+# 결과 접근
+result.batch_records   # np.ndarray (structured array)
+result.meta            # np.ndarray, dtype=[("gen", "u4"), ("ttl", "u4")]
+result.result_codes    # np.ndarray (int32), 0 = 성공
+
+# 단일 레코드 조회 (primary key로)
+row = result.get("user_0")  # np.void (scalar record)
+row["age"]   # 30
+row["score"] # 95.5
+
+# 벡터 연산
+ages = result.batch_records["age"]
+mean_age = ages[result.result_codes == 0].mean()
 ```
 
 ## Operate (Multi-op)
 
 ```python
-ops = [
+# 단일 레코드에 대한 원자적 다중 연산
+ops: list[dict[str, Any]] = [
     {"op": aerospike_py.OPERATOR_INCR, "bin": "counter", "val": 1},
     {"op": aerospike_py.OPERATOR_READ, "bin": "counter", "val": None},
 ]
-record = client.operate(key, ops)  # -> Record
-result = client.operate_ordered(key, ops)  # -> OperateOrderedResult (순서 보존)
+record: Record = client.operate(key, ops)
+
+# 순서 보존 결과
+result: OperateOrderedResult = client.operate_ordered(key, ops)
+for bt in result.ordered_bins:
+    print(f"{bt.name} = {bt.value}")
 ```
 
 ### List CDT
@@ -101,12 +211,25 @@ from aerospike_py import list_operations as lop
 
 client.operate(key, [
     lop.list_append("mylist", "val"),
-    lop.list_get(("mylist", 0),
+    lop.list_get("mylist", 0),
     lop.list_size("mylist"),
 ])
-# 주요: list_append, list_insert, list_pop, list_remove, list_get, list_get_range,
-# list_get_by_value, list_get_by_index, list_get_by_rank, list_set, list_trim,
-# list_clear, list_size, list_increment, list_sort, list_set_order
+
+# 주요 함수 (모두 Operation dict를 반환):
+# 쓰기: list_append, list_append_items, list_insert, list_insert_items
+# 읽기: list_get, list_get_range, list_get_by_value, list_get_by_index,
+#        list_get_by_index_range, list_get_by_rank, list_get_by_rank_range,
+#        list_get_by_value_list, list_get_by_value_range
+# 삭제: list_pop, list_pop_range, list_remove, list_remove_range,
+#        list_remove_by_value, list_remove_by_value_list, list_remove_by_value_range,
+#        list_remove_by_index, list_remove_by_index_range,
+#        list_remove_by_rank, list_remove_by_rank_range
+# 수정: list_set, list_trim, list_clear, list_increment, list_sort, list_set_order
+# 정보: list_size
+#
+# return_type: LIST_RETURN_NONE, LIST_RETURN_VALUE, LIST_RETURN_COUNT,
+#              LIST_RETURN_INDEX, LIST_RETURN_RANK 등
+# policy (선택): {"list_order": LIST_ORDERED, "write_flags": LIST_WRITE_ADD_UNIQUE}
 ```
 
 ### Map CDT
@@ -119,12 +242,25 @@ client.operate(key, [
     mop.map_get_by_key("mymap", "k1", aerospike_py.MAP_RETURN_VALUE),
     mop.map_size("mymap"),
 ])
-# 주요: map_put, map_put_items, map_increment, map_decrement, map_clear,
-# map_remove_by_key, map_get_by_key, map_get_by_value, map_get_by_index,
-# map_get_by_rank, map_size, map_set_order
+
+# 주요 함수:
+# 쓰기: map_put, map_put_items, map_increment, map_decrement
+# 읽기: map_get_by_key, map_get_by_key_range, map_get_by_key_list,
+#        map_get_by_value, map_get_by_value_range, map_get_by_value_list,
+#        map_get_by_index, map_get_by_index_range,
+#        map_get_by_rank, map_get_by_rank_range
+# 삭제: map_remove_by_key, map_remove_by_key_list, map_remove_by_key_range,
+#        map_remove_by_value, map_remove_by_value_list, map_remove_by_value_range,
+#        map_remove_by_index, map_remove_by_index_range,
+#        map_remove_by_rank, map_remove_by_rank_range
+# 기타: map_clear, map_size, map_set_order
+#
+# return_type: MAP_RETURN_NONE, MAP_RETURN_VALUE, MAP_RETURN_KEY,
+#              MAP_RETURN_KEY_VALUE, MAP_RETURN_COUNT 등
+# policy (선택): {"map_order": MAP_KEY_ORDERED, "write_flags": MAP_WRITE_FLAGS_CREATE_ONLY}
 ```
 
-## Query (Sync Client 전용)
+## Query (Sync/Async 모두 지원)
 
 ```python
 from aerospike_py import predicates as p
@@ -132,34 +268,93 @@ from aerospike_py import predicates as p
 # 인덱스 먼저 생성
 client.index_integer_create("test", "demo", "age", "age_idx")
 
-query = client.query("test", "demo")
+# Sync
+query: Query = client.query("test", "demo")
+query.select("name", "age")             # 특정 bin 선택
+query.where(p.between("age", 20, 40))   # 필터 설정
+records: list[Record] = query.results()  # 실행
+
+# foreach (콜백, return False로 조기 중단)
+def process(record: Record) -> bool | None:
+    print(record.bins)
+    return None  # continue (return False to stop)
+query.foreach(process)
+
+# Async
+query: AsyncQuery = client.query("test", "demo")
 query.select("name", "age")
 query.where(p.between("age", 20, 40))
-records = query.results()  # -> list[Record]
-query.foreach(callback)    # callback(record) -> return False to stop
+records: list[Record] = await query.results()
+await query.foreach(process)
 
-# Predicates: equals, between, contains, geo_within_geojson_region,
-# geo_within_radius, geo_contains_geojson_point
+# Predicates:
+# p.equals(bin_name, val)
+# p.between(bin_name, min_val, max_val)
+# p.contains(bin_name, index_type, val)  # collection index
+# p.geo_within_geojson_region(bin_name, geojson)  # 미지원
+# p.geo_within_radius(bin_name, lat, lng, radius)  # 미지원
+# p.geo_contains_geojson_point(bin_name, geojson)  # 미지원
 ```
 
 ## Expression 필터
 
+서버 사이드 필터링 (Aerospike 5.2+). 인덱스 불필요.
+
 ```python
 from aerospike_py import exp
 
+# 단순 비교
 expr = exp.gt(exp.int_bin("age"), exp.int_val(21))
 record = client.get(key, policy={"expressions": expr})
 
-# 복합 조건
+# 복합 조건 (AND/OR)
 expr = exp.and_(
     exp.gt(exp.int_bin("age"), exp.int_val(18)),
     exp.eq(exp.string_bin("status"), exp.string_val("active")),
 )
-# 값: int_val, float_val, string_val, bool_val, blob_val, list_val, map_val
-# Bin: int_bin, float_bin, string_bin, list_bin, map_bin, bin_exists
-# 비교: eq, ne, gt, ge, lt, le | 논리: and_, or_, not_, xor_
-# 메타: ttl, last_update, void_time, record_size, set_name, digest_modulo
+
+# 레코드 메타데이터
+expr = exp.gt(exp.ttl(), exp.int_val(3600))  # TTL > 1시간
+expr = exp.eq(exp.set_name(), exp.string_val("demo"))
+
+# bin 존재 여부
+expr = exp.bin_exists("optional_field")
+
+# 정규식
+expr = exp.regex_compare("^user_", 0, exp.string_bin("name"))
+
+# 변수 바인딩
+expr = exp.let_(
+    exp.def_("x", exp.int_bin("a")),
+    exp.gt(exp.var("x"), exp.int_val(10)),
+)
+
+# 조건 분기
+expr = exp.cond(
+    exp.gt(exp.int_bin("score"), exp.int_val(90)), exp.string_val("A"),
+    exp.gt(exp.int_bin("score"), exp.int_val(80)), exp.string_val("B"),
+    exp.string_val("C"),  # default
+)
+
+# policy에서 사용
+record = client.get(key, policy={"expressions": expr})
+batch = client.batch_read(keys, policy={"filter_expression": expr})
+query.results(policy={"expressions": expr})
 ```
+
+### Expression 빌더 함수 목록
+
+| 카테고리 | 함수 |
+|----------|------|
+| 값 | `int_val`, `float_val`, `string_val`, `bool_val`, `blob_val`, `list_val`, `map_val`, `geo_val`, `nil`, `infinity`, `wildcard` |
+| Bin | `int_bin`, `float_bin`, `string_bin`, `bool_bin`, `blob_bin`, `list_bin`, `map_bin`, `geo_bin`, `hll_bin`, `bin_exists`, `bin_type` |
+| 비교 | `eq`, `ne`, `gt`, `ge`, `lt`, `le` |
+| 논리 | `and_`, `or_`, `not_`, `xor_` |
+| 메타 | `key`, `key_exists`, `set_name`, `record_size`, `last_update`, `since_update`, `void_time`, `ttl`, `is_tombstone`, `digest_modulo` |
+| 수치 | `num_add`, `num_sub`, `num_mul`, `num_div`, `num_mod`, `num_pow`, `num_log`, `num_abs`, `num_floor`, `num_ceil`, `to_int`, `to_float`, `min_`, `max_` |
+| 비트 | `int_and`, `int_or`, `int_xor`, `int_not`, `int_lshift`, `int_rshift`, `int_arshift`, `int_count`, `int_lscan`, `int_rscan` |
+| 패턴 | `regex_compare`, `geo_compare` |
+| 제어 | `cond`, `var`, `def_`, `let_` |
 
 ## Index
 
@@ -168,25 +363,31 @@ client.index_integer_create("test", "demo", "age", "age_idx")
 client.index_string_create("test", "demo", "name", "name_idx")
 client.index_geo2dsphere_create("test", "demo", "location", "geo_idx")
 client.index_remove("test", "age_idx")
+
+# Async
+await client.index_integer_create("test", "demo", "age", "age_idx")
+await client.index_remove("test", "age_idx")
 ```
 
 ## Admin
 
 ```python
-# User
+# User 관리
 client.admin_create_user("user1", "pass", ["read-write"])
 client.admin_drop_user("user1")
 client.admin_change_password("user1", "new_pass")
 client.admin_grant_roles("user1", ["sys-admin"])
 client.admin_revoke_roles("user1", ["read-write"])
-client.admin_query_user_info("user1")  # -> dict
-client.admin_query_users_info()  # -> list[dict]
+client.admin_query_user_info("user1")  # -> dict (user, roles, conns_in_use)
+client.admin_query_users_info()        # -> list[dict]
 
-# Role
+# Role 관리
 client.admin_create_role("role1", [{"code": aerospike_py.PRIV_READ, "ns": "test", "set": ""}])
 client.admin_drop_role("role1")
-client.admin_grant_privileges("role1", privileges)
-client.admin_revoke_privileges("role1", privileges)
+client.admin_grant_privileges("role1", [{"code": aerospike_py.PRIV_WRITE, "ns": "", "set": ""}])
+client.admin_revoke_privileges("role1", [{"code": aerospike_py.PRIV_WRITE, "ns": "", "set": ""}])
+client.admin_query_role("role1")    # -> dict (name, privileges, allowlist, read_quota, write_quota)
+client.admin_query_roles()          # -> list[dict]
 client.admin_set_whitelist("role1", ["10.0.0.0/8"])
 client.admin_set_quotas("role1", read_quota=1000, write_quota=500)
 ```
@@ -202,56 +403,158 @@ client.udf_remove("my_udf")
 ## Info / Truncate
 
 ```python
-results = client.info_all("namespaces")  # -> list[InfoNodeResult]
-response = client.info_random_node("build")  # -> str
+results: list[InfoNodeResult] = client.info_all("namespaces")
+for node_name, error_code, response in results:
+    print(f"{node_name}: {response}")
+
+response: str = client.info_random_node("build")
 client.truncate("test", "demo")
+client.truncate("test", "demo", nanos=1234567890)  # 특정 시점 이전 레코드만
 ```
 
 ## Observability
 
 ```python
-aerospike_py.start_metrics_server(port=9464)  # Prometheus /metrics
-aerospike_py.get_metrics()  # Prometheus text format
+# Prometheus Metrics
+aerospike_py.start_metrics_server(port=9464)  # /metrics HTTP 엔드포인트
+metrics_text: str = aerospike_py.get_metrics()  # Prometheus text format
 aerospike_py.stop_metrics_server()
 
-aerospike_py.init_tracing()     # OTel (OTEL_* env vars)
-aerospike_py.shutdown_tracing()
+# OpenTelemetry Tracing (OTEL_* 환경변수로 설정)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# OTEL_SERVICE_NAME=my-service
+# OTEL_SDK_DISABLED=true (비활성화)
+aerospike_py.init_tracing()
+aerospike_py.shutdown_tracing()  # 프로세스 종료 전 호출
 
-aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)  # -1~4
+# Logging
+aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)
+# LOG_LEVEL_OFF=-1, LOG_LEVEL_ERROR=0, LOG_LEVEL_WARN=1,
+# LOG_LEVEL_INFO=2, LOG_LEVEL_DEBUG=3, LOG_LEVEL_TRACE=4
+```
+
+## Policy 타입
+
+```python
+# ReadPolicy
+{"socket_timeout": 30000, "total_timeout": 1000, "max_retries": 2,
+ "expressions": expr, "replica": POLICY_REPLICA_MASTER, "read_mode_ap": POLICY_READ_MODE_AP_ONE}
+
+# WritePolicy
+{"socket_timeout": 30000, "total_timeout": 1000, "max_retries": 0,
+ "durable_delete": False, "key": POLICY_KEY_DIGEST, "exists": POLICY_EXISTS_IGNORE,
+ "gen": POLICY_GEN_IGNORE, "commit_level": POLICY_COMMIT_LEVEL_ALL,
+ "ttl": 0, "expressions": expr}
+
+# WriteMeta
+{"gen": 1, "ttl": 300}
+
+# BatchPolicy
+{"socket_timeout": 30000, "total_timeout": 1000, "max_retries": 2, "filter_expression": expr}
+
+# QueryPolicy
+{"socket_timeout": 30000, "total_timeout": 0, "max_retries": 2,
+ "max_records": 1000, "records_per_second": 0, "expressions": expr}
+
+# AdminPolicy
+{"timeout": 5000}
 ```
 
 ## 주요 상수
 
 ```python
 # Policy Exists
-POLICY_EXISTS_IGNORE=0, POLICY_EXISTS_CREATE_ONLY=4, POLICY_EXISTS_UPDATE_ONLY=1, POLICY_EXISTS_REPLACE=2
+POLICY_EXISTS_IGNORE = 0         # 있으면 덮어쓰기, 없으면 생성 (기본)
+POLICY_EXISTS_CREATE_ONLY = 4    # 있으면 에러
+POLICY_EXISTS_UPDATE = 6         # 있으면 업데이트, 없으면 생성 (IGNORE와 동일)
+POLICY_EXISTS_UPDATE_ONLY = 1    # 없으면 에러
+POLICY_EXISTS_REPLACE = 2        # 전체 교체 (다른 bin 삭제)
+POLICY_EXISTS_REPLACE_ONLY = 5   # 전체 교체, 없으면 에러
+
 # Policy Gen
-POLICY_GEN_IGNORE=0, POLICY_GEN_EQ=1, POLICY_GEN_GT=2
+POLICY_GEN_IGNORE = 0   # generation 무시 (기본)
+POLICY_GEN_EQ = 1       # meta.gen과 서버 gen이 같을 때만 쓰기
+POLICY_GEN_GT = 2       # meta.gen이 서버 gen보다 클 때만 쓰기
+
 # Policy Key
-POLICY_KEY_DIGEST=0, POLICY_KEY_SEND=1
+POLICY_KEY_DIGEST = 0   # digest만 저장 (기본)
+POLICY_KEY_SEND = 1     # 원본 키도 서버에 저장
+
+# Policy Replica
+POLICY_REPLICA_MASTER = 0       # master 노드에서만 읽기
+POLICY_REPLICA_SEQUENCE = 1     # 순차 복제본 읽기
+POLICY_REPLICA_PREFER_RACK = 2  # 같은 rack 우선
+
+# Policy Commit Level
+POLICY_COMMIT_LEVEL_ALL = 0     # 모든 복제본 커밋 (기본)
+POLICY_COMMIT_LEVEL_MASTER = 1  # master만 커밋
+
+# Policy Read Mode AP
+POLICY_READ_MODE_AP_ONE = 0  # 하나의 노드에서 읽기 (기본)
+POLICY_READ_MODE_AP_ALL = 1  # 모든 노드에서 읽기
 
 # TTL
-TTL_NAMESPACE_DEFAULT=0, TTL_NEVER_EXPIRE=-1, TTL_DONT_UPDATE=-2
+TTL_NAMESPACE_DEFAULT = 0   # namespace 기본값 사용
+TTL_NEVER_EXPIRE = -1       # 만료 없음
+TTL_DONT_UPDATE = -2        # TTL 변경하지 않음
+TTL_CLIENT_DEFAULT = -3     # 클라이언트 정책 기본값
 
 # Operator (operate용)
-OPERATOR_READ=1, OPERATOR_WRITE=2, OPERATOR_INCR=5, OPERATOR_APPEND=9, OPERATOR_PREPEND=10, OPERATOR_TOUCH=11, OPERATOR_DELETE=12
+OPERATOR_READ = 1       # bin 읽기
+OPERATOR_WRITE = 2      # bin 쓰기
+OPERATOR_INCR = 5       # 숫자 증가
+OPERATOR_APPEND = 9     # 문자열 뒤에 추가
+OPERATOR_PREPEND = 10   # 문자열 앞에 추가
+OPERATOR_TOUCH = 11     # TTL 리셋
+OPERATOR_DELETE = 12    # 레코드 삭제
 
-# Map/List Return
-MAP_RETURN_NONE=0, MAP_RETURN_VALUE=7, MAP_RETURN_KEY_VALUE=8, MAP_RETURN_COUNT=5
-LIST_RETURN_NONE=0, LIST_RETURN_VALUE=7, LIST_RETURN_COUNT=5
+# Map/List Return Type
+MAP_RETURN_NONE = 0           # 반환 없음
+MAP_RETURN_INDEX = 1          # 인덱스 반환
+MAP_RETURN_REVERSE_INDEX = 2  # 역순 인덱스
+MAP_RETURN_RANK = 3           # 랭크 반환
+MAP_RETURN_REVERSE_RANK = 4   # 역순 랭크
+MAP_RETURN_COUNT = 5          # 개수 반환
+MAP_RETURN_KEY = 6            # 키 반환
+MAP_RETURN_VALUE = 7          # 값 반환
+MAP_RETURN_KEY_VALUE = 8      # 키-값 쌍 반환
+MAP_RETURN_EXISTS = 9         # 존재 여부
 
-# Index
-INDEX_NUMERIC, INDEX_STRING, INDEX_GEO2DSPHERE
+LIST_RETURN_NONE = 0          # 반환 없음
+LIST_RETURN_VALUE = 7         # 값 반환
+LIST_RETURN_COUNT = 5         # 개수 반환
+LIST_RETURN_INDEX = 1         # 인덱스 반환
+LIST_RETURN_RANK = 3          # 랭크 반환
+
+# Index Type
+INDEX_NUMERIC, INDEX_STRING, INDEX_BLOB, INDEX_GEO2DSPHERE
 INDEX_TYPE_DEFAULT, INDEX_TYPE_LIST, INDEX_TYPE_MAPKEYS, INDEX_TYPE_MAPVALUES
 
 # Privilege
-PRIV_READ=10, PRIV_WRITE=13, PRIV_READ_WRITE=11, PRIV_SYS_ADMIN=1, PRIV_DATA_ADMIN=2
+PRIV_READ, PRIV_WRITE, PRIV_READ_WRITE, PRIV_READ_WRITE_UDF
+PRIV_SYS_ADMIN, PRIV_USER_ADMIN, PRIV_DATA_ADMIN
+PRIV_UDF_ADMIN, PRIV_SINDEX_ADMIN, PRIV_TRUNCATE
 
 # Auth
-AUTH_INTERNAL=0, AUTH_EXTERNAL=1, AUTH_PKI=2
+AUTH_INTERNAL = 0, AUTH_EXTERNAL = 1, AUTH_PKI = 2
 
-# Log Level
-LOG_LEVEL_OFF=-1, LOG_LEVEL_ERROR=0, LOG_LEVEL_WARN=1, LOG_LEVEL_INFO=2, LOG_LEVEL_DEBUG=3, LOG_LEVEL_TRACE=4
+# Serializer
+SERIALIZER_NONE, SERIALIZER_PYTHON, SERIALIZER_USER
+
+# Map Order / Write Flags
+MAP_UNORDERED, MAP_KEY_ORDERED, MAP_KEY_VALUE_ORDERED
+MAP_WRITE_FLAGS_DEFAULT, MAP_WRITE_FLAGS_CREATE_ONLY, MAP_WRITE_FLAGS_UPDATE_ONLY
+MAP_WRITE_FLAGS_NO_FAIL, MAP_WRITE_FLAGS_PARTIAL
+
+# List Order / Sort / Write Flags
+LIST_UNORDERED, LIST_ORDERED
+LIST_SORT_DEFAULT, LIST_SORT_DROP_DUPLICATES
+LIST_WRITE_DEFAULT, LIST_WRITE_ADD_UNIQUE, LIST_WRITE_INSERT_BOUNDED
+LIST_WRITE_NO_FAIL, LIST_WRITE_PARTIAL
+
+# Bit / HLL Write Flags
+BIT_WRITE_DEFAULT, BIT_WRITE_CREATE_ONLY, BIT_WRITE_UPDATE_ONLY
+HLL_WRITE_DEFAULT, HLL_WRITE_CREATE_ONLY, HLL_WRITE_UPDATE_ONLY, HLL_WRITE_ALLOW_FOLD
 ```
 
 ## 예외
@@ -259,10 +562,36 @@ LOG_LEVEL_OFF=-1, LOG_LEVEL_ERROR=0, LOG_LEVEL_WARN=1, LOG_LEVEL_INFO=2, LOG_LEV
 ```python
 try:
     record = client.get(key)
-except aerospike_py.RecordNotFound: ...
-except aerospike_py.AerospikeTimeoutError: ...
-except aerospike_py.AerospikeError: ...
-# 계층: AerospikeError > {ClientError, ClusterError, InvalidArgError,
-# AerospikeTimeoutError, RecordError > {RecordNotFound, RecordExistsError, ...},
-# ServerError > {AerospikeIndexError, QueryError, AdminError, UDFError}}
+except aerospike_py.RecordNotFound:
+    print("Not found")
+except aerospike_py.AerospikeTimeoutError:
+    print("Timeout")
+except aerospike_py.AerospikeError as e:
+    print(f"Error: {e}")
+
+# 예외 계층:
+# AerospikeError (기본)
+# +-- ClientError (클라이언트 에러, 연결 안됨 등)
+# +-- ClusterError (클러스터 연결 실패)
+# +-- InvalidArgError (잘못된 인자)
+# +-- AerospikeTimeoutError (타임아웃)
+# +-- TimeoutError (deprecated alias)
+# +-- RecordError (레코드 관련)
+# |   +-- RecordNotFound
+# |   +-- RecordExistsError
+# |   +-- RecordGenerationError
+# |   +-- RecordTooBig
+# |   +-- BinNameError
+# |   +-- BinExistsError
+# |   +-- BinNotFound
+# |   +-- BinTypeError
+# |   +-- FilteredOut
+# +-- ServerError (서버 관련)
+#     +-- AerospikeIndexError (IndexError는 deprecated alias)
+#     |   +-- IndexNotFound
+#     |   +-- IndexFoundError
+#     +-- QueryError
+#     |   +-- QueryAbortedError
+#     +-- AdminError
+#     +-- UDFError
 ```

--- a/.claude/skills/bench-compare/SKILL.md
+++ b/.claude/skills/bench-compare/SKILL.md
@@ -10,7 +10,10 @@ aerospike-py와 공식 Aerospike C 클라이언트의 성능 비교를 실행합
 
 ## 사전 조건
 
-Aerospike 서버가 실행 중이어야 합니다. 서버가 없으면 먼저 시작합니다:
+1. Aerospike 서버가 실행 중이어야 합니다.
+2. 공식 C 클라이언트(`aerospike` PyPI 패키지)가 설치되어 있어야 합니다 (`bench` 의존성 그룹에 포함).
+
+서버가 없으면 먼저 시작합니다:
 ```bash
 make run-aerospike-ce
 ```
@@ -19,7 +22,7 @@ make run-aerospike-ce
 
 ### 1. 서버 상태 확인
 ```bash
-docker ps | grep aerospike || podman ps | grep aerospike
+podman ps | grep aerospike || docker ps | grep aerospike
 ```
 
 ### 2. 빌드 (최신 코드 반영)
@@ -27,25 +30,85 @@ docker ps | grep aerospike || podman ps | grep aerospike
 make build
 ```
 
-### 3. 벤치마크 실행
+### 3. 기본 벤치마크 실행
 ```bash
 make run-benchmark
 ```
 
-환경변수로 벤치마크 파라미터를 조정할 수 있습니다:
-- `BENCH_COUNT`: 레코드 수 (기본: 1000)
-- `ROUNDS`: 반복 횟수 (기본: 3)
-- `CONCURRENCY`: 동시성 레벨 (기본: 10)
+**기본 파라미터** (`Makefile` 기본값):
+| 파라미터 | 환경변수 | 기본값 | 설명 |
+|---------|---------|--------|------|
+| 레코드 수 | `BENCH_COUNT` | 5000 | 테스트에 사용할 총 레코드 수 |
+| 반복 횟수 | `BENCH_ROUNDS` | 20 | 각 연산의 측정 반복 횟수 |
+| 동시성 | `BENCH_CONCURRENCY` | 50 | 동시 요청 수 |
+| 배치 그룹 | `BENCH_BATCH_GROUPS` | 10 | 배치 연산 그룹 수 |
+| 호스트 | `AEROSPIKE_HOST` | 127.0.0.1 | 서버 주소 |
+| 포트 | `AEROSPIKE_PORT` | 18710 | 서버 포트 |
 
-### 4. NumPy 배치 벤치마크 (선택)
+**커스텀 파라미터 예시:**
+```bash
+BENCH_COUNT=10000 BENCH_ROUNDS=10 BENCH_CONCURRENCY=100 make run-benchmark
+```
+
+### 4. 대규모 벤치마크 (선택)
+```bash
+make run-benchmark-large
+```
+100K ops, 5 rounds로 실행. 안정적인 성능 측정에 적합.
+
+### 5. 벤치마크 리포트 생성 (선택)
+```bash
+make run-benchmark-report
+```
+JSON 파일 + 차트 이미지를 생성합니다.
+
+### 6. NumPy 배치 벤치마크 (선택)
 ```bash
 make run-numpy-benchmark
 ```
 
+dict 기반 `batch_read` vs NumPy `batch_read_numpy` 성능 비교.
+
+**NumPy 벤치마크 파라미터:**
+| 파라미터 | 환경변수 | 기본값 |
+|---------|---------|--------|
+| 반복 횟수 | `NUMPY_BENCH_ROUNDS` | 10 |
+| 동시성 | `NUMPY_BENCH_CONCURRENCY` | 50 |
+| 배치 그룹 | `NUMPY_BENCH_BATCH_GROUPS` | 10 |
+
+**NumPy 벤치마크 시나리오** (`--scenario` 옵션):
+| 시나리오 | 설명 |
+|---------|------|
+| `record_scaling` | 레코드 수 변화에 따른 성능 (100, 500, 1K, 5K, 10K) |
+| `bin_scaling` | bin 수 변화에 따른 성능 (1, 3, 5, 10, 20) |
+| `post_processing` | 후처리 단계별 성능 (raw read -> column access -> filter -> aggregation) |
+| `memory` | tracemalloc 기반 메모리 사용량 비교 |
+| `all` | 전체 시나리오 (기본값) |
+
+NumPy 리포트 생성:
+```bash
+make run-numpy-benchmark-report
+```
+
+## 벤치마크 방법론
+
+`benchmark/bench_compare.py`의 측정 방법:
+1. **Warmup phase** (500 ops): 연결 안정화, 결과 폐기
+2. **Multiple rounds**: 각 연산을 `BENCH_ROUNDS` 회 반복, 라운드별 중앙값 측정
+3. **Data pre-seeding**: 읽기 벤치마크 전 데이터 사전 생성
+4. **GC disabled**: 측정 중 GC 비활성화
+5. **Isolated key prefixes**: 각 클라이언트가 격리된 키 프리픽스 사용
+
 ## 결과 분석
 
 벤치마크 결과를 분석하여 다음을 보고합니다:
-- Sync/Async 각각의 throughput 비교
-- 레이턴시 (p50, p95, p99) 비교
-- 이전 벤치마크 대비 성능 변화 (있는 경우)
-- 성능 저하가 있는 경우 원인 분석 및 개선 제안
+- **연산별 비교**: sync put/get, async put/get, batch_read 등
+- **Throughput**: ops/sec 비교
+- **레이턴시**: 중앙값 (median of round medians) 비교
+- **aerospike-py vs 공식 클라이언트 비율**: 몇 배 빠른지/느린지
+- **이전 벤치마크 대비 성능 변화** (있는 경우)
+- **성능 저하가 있는 경우 원인 분석 및 개선 제안**
+
+## 벤치마크 실행 후 자동 정리
+
+`make run-benchmark`, `make run-numpy-benchmark` 등 모든 벤치마크 Makefile 타겟은 실행 후 자동으로 `make stop-aerospike-ce`를 호출하여 컨테이너를 정리합니다.

--- a/.claude/skills/project-goals/SKILL.md
+++ b/.claude/skills/project-goals/SKILL.md
@@ -2,28 +2,42 @@
 
 ## 핵심 목표
 
-Aerospike Rust Client(`aerospike-rust` crate)를 PyO3로 래핑하여, Python에서 Aerospike를 고성능으로 사용할 수 있는 클라이언트 라이브러리를 만든다.
+Aerospike Rust Client(`aerospike` crate + `aerospike-core`)를 PyO3로 래핑하여, Python에서 Aerospike를 고성능으로 사용할 수 있는 클라이언트 라이브러리를 만든다.
 
 ## 주요 기능 축
 
 ### 1. Sync / Async Client
 
 - Rust 네이티브 클라이언트를 기반으로 **동기(`Client`) + 비동기(`AsyncClient`)** 양쪽 API를 제공한다.
-- 공식 C 클라이언트(`aerospike` PyPI 패키지)와 **API 호환성**을 유지하면 좋지만 Rust 네이티브 클라이언트 API 스펙을 더 우선한다
+- 공식 C 클라이언트(`aerospike` PyPI 패키지)와 **API 호환성**을 유지하면 좋지만 Rust 네이티브 클라이언트 API 스펙을 더 우선한다.
 - Python 3.10~3.14 (3.14t free-threaded 포함) 지원.
+- Sync Client: `py.detach()`로 GIL 해제 후 `RUNTIME.block_on()`으로 async 호출.
+- Async Client: `future_into_py()`로 Python awaitable 반환, `Python::attach()`로 GIL 재획득.
 
 ### 2. NumPy 통합
 
 - `batch_read` 등 배치 연산에서 **NumPy structured array**를 입출력으로 지원한다.
 - 대량 레코드를 Python dict 변환 없이 zero-copy에 가깝게 처리하여 성능을 높인다.
 - optional dependency (`pip install aerospike-py[numpy]`)로 제공.
+- `NumpyBatchRecords` 클래스: 배치 결과를 NumPy structured array로 래핑.
 
-### 3. Observability (OpenTelemetry)
+### 3. Observability (OpenTelemetry + Prometheus)
 
-- **Tracing**: 각 DB 연산을 OTel span으로 자동 계측. W3C TraceContext 전파 지원.
-- **Metrics**: Prometheus 형식의 연산별 지연시간 히스토그램. 내장 metrics 서버 제공.
-- **Logging**: Rust 내부 로그를 Python 로그 레벨과 연동.
-- optional dependency (`pip install aerospike-py[otel]`)로 제공.
+- **Tracing**: 각 DB 연산을 OTel span으로 자동 계측. W3C TraceContext 전파 지원. `traced_op!` / `traced_exists_op!` 매크로 사용.
+- **Metrics**: Prometheus 형식의 연산별 지연시간 히스토그램. 내장 metrics HTTP 서버 제공 (`start_metrics_server(port)`).
+- **Logging**: Rust 내부 로그를 Python 로그 레벨과 연동 (`set_log_level()`).
+- `otel` feature는 `pyproject.toml`의 `[tool.maturin] features`에서 기본 활성화. Python optional dependency (`pip install aerospike-py[otel]`)로 `opentelemetry-api` 설치.
+
+### 4. Expression 필터
+
+- Aerospike 서버 사이드 필터를 Python에서 빌더 패턴으로 구성.
+- `aerospike_py.exp` 모듈에 60+ 빌더 함수 제공 (values, bins, metadata, comparison, logical, numeric, pattern, control flow).
+
+### 5. CDT (Collection Data Types) 연산
+
+- `list_operations` / `map_operations` 모듈로 List/Map CDT 연산을 `operate()` API에서 사용.
+- List: 37개 연산 (append, insert, get_by_index, remove_by_rank_range 등).
+- Map: 33개 연산 (put, get_by_key, remove_by_rank_range 등).
 
 ## 설계 원칙
 
@@ -31,36 +45,51 @@ Aerospike Rust Client(`aerospike-rust` crate)를 PyO3로 래핑하여, Python에
 - **공식 클라이언트 호환**: 메서드 시그니처, 상수, 예외를 공식 C 클라이언트와 가능한 동일하게 맞춘다.
 - **Type-safe**: `.pyi` 스텁을 제공하여 IDE 자동완성과 타입 체커를 완벽히 지원한다.
 - **Zero Python dependency**: 기본 설치 시 외부 Python 의존성 없음. NumPy, OTel은 optional.
+- **NamedTuple 반환**: `get`, `select`, `exists` 등 복합 반환값은 Python `NamedTuple`로 래핑하여 `record.key`, `record.bins` 등 이름 접근 제공.
 
 ## 기술 스택
 
-| 레이어        | 기술                                                 |
-| ------------- | ---------------------------------------------------- |
-| Core          | `aerospike` crate (2.0.0-alpha) + `aerospike-core`   |
-| Binding       | PyO3 0.28 + maturin                                  |
-| Async Runtime | Tokio (multi-thread) + pyo3-async-runtimes            |
-| Metrics       | prometheus-client (Rust)                              |
-| Tracing       | opentelemetry + opentelemetry-otlp (gRPC/Tonic)       |
-| NumPy         | 직접 buffer 조작 (numpy C API via PyO3)                |
+| 레이어        | 기술                                                 | 버전        |
+| ------------- | ---------------------------------------------------- | ----------- |
+| Core          | `aerospike` + `aerospike-core` crate                 | 2.0.0-alpha.9 |
+| Binding       | PyO3 + maturin                                       | PyO3 0.28, maturin >=1.9,<2.0 |
+| Async Runtime | Tokio (multi-thread) + pyo3-async-runtimes           | tokio 1.x   |
+| Metrics       | prometheus-client (Rust)                              | 0.23        |
+| Tracing       | opentelemetry + opentelemetry-otlp (gRPC/Tonic)       | 0.28 (optional `otel` feature) |
+| NumPy         | 직접 buffer 조작 (numpy C API via PyO3)                | numpy >=2.0 |
+| Build         | uv (패키지 매니저) + tox-uv (테스트 매트릭스)            | -           |
+| CI/CD         | GitHub Actions (lint, build 3.10-3.14+3.14t, integration, concurrency, feasibility, compat) | - |
 
 ## 현재 구현 상태
 
 ### 완료
 
-- Sync/Async Client: CRUD, batch, operate, query, index, truncate, UDF, admin
-- NumPy batch_read (structured array 반환)
-- Prometheus metrics (히스토그램, 내장 서버)
-- OTel tracing (span 생성, TraceContext 전파)
-- Logging (Rust → Python 레벨 연동)
-- Expression 필터
-- List/Map CDT 연산 헬퍼
-- 공식 C 클라이언트 호환성 테스트 (완벽하게 호환할 필요 없음)
-- scan 함수는 deprecated 되었어 구현하지마
+- **Sync/Async Client**: CRUD (`put`, `get`, `select`, `exists`, `remove`, `append`, `prepend`, `increment`, `touch`)
+- **Batch 연산**: `batch_read`, `batch_operate`, `batch_remove`, `batch_read_numpy` (NumPy structured array 반환)
+- **Operate**: `operate()` (반환값 dict), `operate_ordered()` (반환값 순서 보존 list[BinTuple])
+- **Query**: `query()` (sync) / `query()` (async) - predicate 필터, expression 필터, `foreach()` 콜백, `results()` 일괄 수집
+- **Index**: `index_create()` / `index_remove()` - `INDEX_STRING`, `INDEX_NUMERIC`, `INDEX_GEO2DSPHERE`, `INDEX_BLOB`
+- **Truncate**: `truncate()`
+- **UDF**: `udf_put()` / `udf_remove()` / `udf_list()` / `udf_get()`
+- **Admin**: `admin_create_user()` / `admin_drop_user()` / `admin_set_password()` / `admin_change_password()` / `admin_grant_roles()` / `admin_revoke_roles()` / `admin_query_user()` / `admin_query_users()` / `admin_create_role()` / `admin_drop_role()` / `admin_grant_privileges()` / `admin_revoke_privileges()` / `admin_query_role()` / `admin_query_roles()`
+- **Info**: `info_all()` / `info_single_node()`
+- **Prometheus metrics**: 히스토그램, 내장 HTTP 서버 (`start_metrics_server()` / `stop_metrics_server()`)
+- **OTel tracing**: span 생성, W3C TraceContext 전파 (`init_tracing()` / `shutdown_tracing()`)
+- **Logging**: Rust -> Python 레벨 연동 (`set_log_level()`)
+- **Expression 필터**: 60+ 빌더 함수
+- **List/Map CDT 연산 헬퍼**: `list_operations` (37), `map_operations` (33)
+- **NumPy batch_read**: `batch_read_numpy()` + `NumpyBatchRecords` 클래스
+- **공식 C 클라이언트 호환성 테스트** (완벽하게 호환할 필요 없음)
+- **Python 3.14t free-threaded 지원**: CI에서 빌드 + 유닛 + 동시성 테스트
 
 ### 미구현 / 향후 과제
 
+- scan 함수는 deprecated 되었으므로 구현하지 않음
 - Batch write (batch_operate로 대체 가능하나 별도 API 검토)
-- batch write numpy (numpy structued array로 주어진 데이터를 records list로 batch_write하는 API 스펙)
-- HyperLogLog / Bitwise 연산 헬퍼
-- Connection pool 세부 설정
+- batch write numpy (numpy structured array로 주어진 데이터를 records list로 batch_write하는 API 스펙)
+- HyperLogLog 연산 헬퍼
+- Bitwise 연산 헬퍼
+- Connection pool 세부 설정 노출
 - Rack-aware 읽기 최적화
+- Query Pagination (파티션 필터 기반)
+- Aggregate (UDF 기반 MapReduce)

--- a/.claude/skills/release-check/SKILL.md
+++ b/.claude/skills/release-check/SKILL.md
@@ -14,31 +14,112 @@ disable-model-invocation: true
 ```bash
 make lint
 ```
-ruff check + cargo clippy (-D warnings) 실행. 모든 경고/에러가 해결되어야 합니다.
+내부적으로 실행되는 명령어:
+- `uv run ruff check src/ tests/ benchmark/` - Python 린트
+- `uv run ruff format --check src/ tests/ benchmark/` - Python 포맷 확인
+- `cargo clippy --manifest-path rust/Cargo.toml --features otel -- -D warnings` - Rust 린트 (otel feature 포함, 경고를 에러로)
 
-### 2. 유닛 테스트
+모든 경고/에러가 해결되어야 합니다.
+
+### 2. 포맷 자동 수정 (필요 시)
+```bash
+make fmt
+```
+내부적으로 실행되는 명령어:
+- `uv run ruff format src/ tests/ benchmark/`
+- `uv run ruff check --fix src/ tests/ benchmark/`
+- `cargo fmt --manifest-path rust/Cargo.toml`
+
+### 3. 유닛 테스트
 ```bash
 make test-unit
 ```
-서버 없이 실행 가능한 모든 유닛 테스트를 실행합니다.
+서버 없이 실행 가능한 모든 유닛 테스트를 실행합니다. 빌드 포함 (`maturin develop --release`).
 
-### 3. Pyright 타입 체크
+### 4. Pyright 타입 체크
 ```bash
 uv run pyright src/
 ```
-Python 타입 에러가 없는지 확인합니다.
+Python 타입 에러가 없는지 확인합니다. 설정 (`pyproject.toml`):
+- `pythonVersion = "3.10"` (최소 지원 버전 기준)
+- `typeCheckingMode = "basic"`
+- `include = ["src/aerospike_py"]`
 
-### 4. Type Stub 일관성 검증
-`src/aerospike_py/__init__.pyi`와 `rust/src/client.rs`, `rust/src/async_client.rs`를 비교합니다:
-- 모든 `#[pymethod]`가 `.pyi`에 반영되었는지
-- 시그니처(파라미터 이름, 타입, 기본값) 일치 여부
-- 반환 타입 정확성 확인
-- 누락된 상수나 예외 클래스 확인
+### 5. Type Stub 일관성 검증
 
-### 5. 버전 확인
-`pyproject.toml`의 `version` 필드가 올바르게 업데이트되었는지 확인합니다.
-git tag와 일치하는지도 확인합니다.
+`src/aerospike_py/__init__.pyi`와 Rust 구현을 비교합니다:
+
+**확인 사항:**
+
+| 검증 항목 | 비교 대상 |
+|-----------|-----------|
+| Sync Client 메서드 | `.pyi` `class Client` vs `rust/src/client.rs` `#[pymethods] impl PyClient` |
+| Async Client 메서드 | `.pyi` `class AsyncClient` vs `rust/src/async_client.rs` `#[pymethods] impl PyAsyncClient` |
+| Python 래퍼 메서드 | `.pyi` vs `src/aerospike_py/__init__.py` `class Client` / `class AsyncClient` |
+| 시그니처 일치 | 파라미터 이름, 타입, 기본값, 반환 타입 |
+| 상수 완전성 | `.pyi` 상수 vs `rust/src/constants.rs` + `__init__.py` re-export |
+| 예외 클래스 | `.pyi` / `exception.pyi` vs `rust/src/errors.rs` |
+| NamedTuple 정의 | `.pyi` 타입 vs `src/aerospike_py/types.py` |
+
+**빠른 확인 방법:**
+```bash
+# Rust에서 #[pyo3(signature 가 있는 메서드 목록
+grep -n '#\[pyo3(signature' rust/src/client.rs rust/src/async_client.rs
+
+# .pyi에서 정의된 메서드 목록
+grep -n 'def ' src/aerospike_py/__init__.pyi | head -60
+```
+
+### 6. 버전 확인
+
+`pyproject.toml`의 `version` 필드가 올바르게 업데이트되었는지 확인합니다:
+```bash
+grep 'version' pyproject.toml
+```
+참고: 이 프로젝트는 `dynamic = ["version"]`이며 maturin이 `Cargo.toml`에서 버전을 가져옵니다.
+```bash
+grep '^version' rust/Cargo.toml
+```
+
+git tag와 일치하는지도 확인합니다:
+```bash
+git tag --sort=-version:refname | head -5
+```
+
+### 7. Pre-commit Hook 전체 실행
+```bash
+uvx pre-commit run --all-files
+```
+CI의 lint job에서도 이 명령을 실행합니다. 포함 항목:
+- trailing-whitespace
+- ruff format / ruff lint
+- pyright
+- cargo fmt
+- cargo clippy (-D warnings)
+
+### 8. Python 버전 매트릭스 테스트 (선택)
+```bash
+make test-matrix
+```
+Python 3.10, 3.11, 3.12, 3.13, 3.14, 3.14t (free-threaded) 전체에서 유닛 테스트를 실행합니다.
+tox-uv를 사용하여 각 Python 버전별 가상환경을 자동 생성합니다.
+
+### 9. 통합 테스트 (서버 필요, 선택)
+```bash
+make test-all
+```
+Aerospike 서버가 실행 중이어야 합니다 (`make run-aerospike-ce`).
+모든 테스트 스위트를 실행합니다 (unit + integration + concurrency + feasibility + compat).
 
 ## 결과 보고
 
 각 단계의 성공/실패를 요약하고, 실패한 항목에 대해 수정 방법을 제안합니다.
+
+**릴리스 가능 조건:**
+1. `make lint` 통과 (ruff + clippy 경고 0개)
+2. `make test-unit` 통과
+3. `uv run pyright src/` 에러 0개
+4. Type stub 일관성 확인
+5. 버전 번호 정확
+6. (권장) `make test-matrix` 전체 통과
+7. (권장) `make test-all` 전체 통과 (서버 필요)

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -13,14 +13,14 @@ aerospike-py 테스트를 실행합니다. Aerospike 서버가 필요한 테스�
 
 `/run-tests [test-type]` 형식으로 호출합니다.
 
-| test-type | 서버 필요 | 설명 |
-|-----------|----------|------|
-| `unit` | No | 유닛 테스트 (기본값) |
-| `integration` | Yes | 통합 테스트 |
-| `concurrency` | Yes | 스레드/async 안전성 테스트 |
-| `compat` | Yes | 공식 C 클라이언트 호환성 테스트 |
-| `all` | Yes | 전체 테스트 |
-| `matrix` | No | Python 3.10~3.14 매트릭스 테스트 |
+| test-type | 서버 필요 | 설명 | Makefile 타겟 |
+|-----------|----------|------|--------------|
+| `unit` | No | 유닛 테스트 (기본값) | `make test-unit` |
+| `integration` | Yes | 통합 테스트 | `make test-integration` |
+| `concurrency` | Yes | 스레드/async 안전성 테스트 | `make test-concurrency` |
+| `compat` | Yes | 공식 C 클라이언트 호환성 테스트 | `make test-compat` |
+| `all` | Yes | 전체 테스트 | `make test-all` |
+| `matrix` | No | Python 3.10~3.14 + 3.14t 매트릭스 테스트 | `make test-matrix` |
 
 인자가 없으면 `unit`을 실행합니다.
 
@@ -30,6 +30,7 @@ aerospike-py 테스트를 실행합니다. Aerospike 서버가 필요한 테스�
 ```bash
 make build
 ```
+내부적으로 `uv sync --group dev --group bench && uv run maturin develop --release` 실행.
 
 ### 2. Aerospike 서버 보장 (unit, matrix 제외)
 
@@ -40,6 +41,9 @@ make build
 ```bash
 podman compose -f compose.local.yaml up -d
 ```
+
+컨테이너 런타임은 `RUNTIME` 환경변수로 지정 (기본: `podman`, `docker` 가능).
+`compose.local.yaml`: Aerospike CE 8.1, 호스트 포트 `18710` -> 컨테이너 포트 `3000`.
 
 #### 2-2. Health check (최대 30초 대기)
 ```bash
@@ -57,17 +61,83 @@ health check가 30초 안에 통과하지 못하면 `podman logs aerospike`로 �
 
 ### 3. 테스트 실행
 
-인자에 따라 해당 Makefile 타겟을 실행합니다:
+인자에 따라 해당 명령어를 실행합니다:
 
-| 인자 | 명령어 |
-|------|--------|
-| `unit` | `uv run pytest tests/unit/ -v` |
-| `integration` | `uvx --with tox-uv tox -e integration` |
-| `concurrency` | `uvx --with tox-uv tox -e concurrency` |
-| `compat` | `uvx --with tox-uv tox -e compat` |
-| `all` | `uvx --with tox-uv tox -e all` |
-| `matrix` | `uvx --with tox-uv tox` |
+| 인자 | 명령어 | tox 환경 |
+|------|--------|----------|
+| `unit` | `uv run pytest tests/unit/ -v` | - |
+| `integration` | `uvx --with tox-uv tox -e integration` | `test-integration` 의존성 그룹 |
+| `concurrency` | `uvx --with tox-uv tox -e concurrency` | 기본 `test` 의존성 그룹 |
+| `compat` | `uvx --with tox-uv tox -e compat` | `test-compat` 의존성 그룹 (공식 `aerospike` 포함) |
+| `all` | `uvx --with tox-uv tox -e all` | `test-all` 의존성 그룹 |
+| `matrix` | `uvx --with tox-uv tox` | py310~py314 + py314t 전체 |
 
 ### 4. 결과 보고
 - 통과한 테스트 수 / 실패한 테스트 수 요약
 - 실패한 테스트가 있으면 에러 메시지와 원인 분석
+
+## 환경변수
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `AEROSPIKE_HOST` | `127.0.0.1` | Aerospike 서버 호스트 |
+| `AEROSPIKE_PORT` | `18710` | Aerospike 서버 포트 (로컬 개발용) |
+| `RUNTIME` | `podman` | 컨테이너 런타임 (`docker` or `podman`) |
+
+**CI 환경**: GitHub Actions에서는 서비스 컨테이너를 사용하며 `AEROSPIKE_PORT=3000`.
+
+## 테스트 인프라
+
+### 테스트 설정 (`tests/__init__.py`)
+
+```python
+AEROSPIKE_CONFIG = {
+    "hosts": [(os.environ.get("AEROSPIKE_HOST", "127.0.0.1"),
+               int(os.environ.get("AEROSPIKE_PORT", "18710")))],
+    "cluster_name": "docker",
+}
+```
+
+### 공유 Fixture (`tests/conftest.py`)
+
+| Fixture | Scope | 설명 |
+|---------|-------|------|
+| `client` | module | Sync 클라이언트. 서버 미가용 시 `pytest.skip()` |
+| `async_client` | function | Async 클라이언트. 서버 미가용 시 `pytest.skip()` |
+| `cleanup` | function | `keys` 리스트에 append -> 테스트 후 자동 `client.remove()` |
+| `async_cleanup` | function | async 버전의 cleanup. `async_client.remove()` |
+
+### pytest 설정 (`pyproject.toml`)
+
+- `asyncio_mode = "auto"` -> async 테스트에 `@pytest.mark.asyncio` 데코레이터 불필요.
+- `tox` 환경에 `pass_env = ["AEROSPIKE_HOST", "AEROSPIKE_PORT"]` 설정으로 환경변수 전달.
+
+### 테스트 디렉토리 구조
+
+```
+tests/
+├── __init__.py           # AEROSPIKE_CONFIG 정의
+├── conftest.py           # 공유 fixture (client, async_client, cleanup)
+├── unit/                 # 서버 불필요. 인자 검증, 타입 에러, 미연결 에러 테스트
+├── integration/          # 서버 필요. 실제 CRUD, batch, query 등 테스트
+│   └── conftest.py       # integration 전용 fixture (autouse cleanup 등)
+├── concurrency/          # 스레드 안전성, async 동시성 테스트
+│   └── test_freethreading.py  # Python 3.14t 전용 (concurrency tox 환경에서 제외)
+├── compatibility/        # 공식 C 클라이언트(`aerospike` PyPI)와 동작 비교
+└── feasibility/          # 프레임워크 통합 테스트
+    ├── test_fastapi.py   # FastAPI 앱에서 AsyncClient 사용
+    └── test_gunicorn.py  # Gunicorn multi-worker에서 Client 사용
+```
+
+## CI 워크플로우 (`ci.yaml`) 대응
+
+| CI Job | 테스트 타입 | Python | 서버 |
+|--------|------------|--------|------|
+| lint | pre-commit (ruff, clippy, fmt) | 3.13 | No |
+| build | unit (매트릭스) | 3.10~3.14 | No |
+| build-freethreaded | unit | 3.14t | No |
+| integration | all | 3.13 | AS 7.2 + latest |
+| test-concurrency | concurrency | 3.13 | AS latest |
+| test-concurrency-freethreaded | freethreading | 3.14t | AS latest |
+| feasibility | fastapi, gunicorn | 3.13 | AS latest |
+| compatibility | compat | 3.13 | AS latest |

--- a/.claude/skills/test-sample-fastapi/SKILL.md
+++ b/.claude/skills/test-sample-fastapi/SKILL.md
@@ -8,6 +8,46 @@ disable-model-invocation: true
 
 aerospike-py에 변경사항이 생겼을 때, 로컬에서 빌드 후 sample-fastapi 앱이 정상 동작하는지 검증합니다.
 
+## 프로젝트 구조
+
+```
+examples/sample-fastapi/
+├── app/
+│   ├── main.py              # FastAPI 앱 (lifespan으로 AsyncClient 관리)
+│   ├── config.py             # 설정
+│   ├── dependencies.py       # FastAPI 의존성 (Request.app.state.aerospike)
+│   ├── models.py             # Pydantic 모델
+│   └── routers/
+│       ├── records.py        # CRUD 엔드포인트
+│       ├── batch.py          # 배치 연산
+│       ├── operations.py     # operate 연산
+│       ├── indexes.py        # 인덱스 관리
+│       ├── truncate.py       # truncate
+│       ├── udf.py            # UDF 관리
+│       ├── cluster.py        # 클러스터 정보
+│       ├── admin_users.py    # 사용자 관리
+│       ├── admin_roles.py    # 역할 관리
+│       ├── users.py          # 사용자 CRUD
+│       ├── numpy_batch.py    # NumPy 배치 엔드포인트
+│       └── observability.py  # 메트릭/트레이싱 엔드포인트
+├── tests/
+│   ├── conftest.py           # TestContainers 기반 Aerospike 서버 + FastAPI TestClient
+│   ├── test_records.py       # CRUD 테스트
+│   ├── test_batch.py         # 배치 테스트
+│   ├── test_operations.py    # operate 테스트
+│   ├── test_indexes.py       # 인덱스 테스트
+│   ├── test_truncate.py      # truncate 테스트
+│   ├── test_udf.py           # UDF 테스트
+│   ├── test_cluster.py       # 클러스터 정보 테스트
+│   ├── test_health.py        # 헬스 체크 테스트
+│   ├── test_admin_users.py   # 사용자 관리 테스트
+│   ├── test_admin_roles.py   # 역할 관리 테스트
+│   ├── test_users.py         # 사용자 CRUD 테스트
+│   ├── test_numpy_batch.py   # NumPy 배치 테스트
+│   └── test_observability.py # 메트릭/트레이싱 테스트
+└── pyproject.toml            # uv.sources: aerospike-py = { path = "../.." }
+```
+
 ## 실행 단계
 
 ### 1. aerospike-py 빌드
@@ -29,7 +69,7 @@ cd /Users/ksr/github/aerospike-py/examples/sample-fastapi && uv sync --extra dev
 ```bash
 docker ps | grep aerospike || podman ps | grep aerospike
 ```
-- 실행 중이면 그대로 진행
+- 실행 중이면 그대로 진행 (conftest.py가 `AEROSPIKE_HOST`/`AEROSPIKE_PORT` 환경변수 또는 기본 `127.0.0.1:3000`에 연결 시도)
 - 실행 중이 아니면 TestContainers가 자동으로 컨테이너를 생성하므로 Docker/Podman 데몬이 실행 중인지만 확인
 
 ### 4. 테스트 실행
@@ -44,3 +84,39 @@ cd /Users/ksr/github/aerospike-py/examples/sample-fastapi && uv run pytest tests
   - 실패한 테스트 이름과 에러 메시지를 정리
   - aerospike-py 변경사항과의 관계 분석
   - 수정 방향 제안 (aerospike-py 쪽 문제인지, sample-fastapi 쪽 문제인지 구분)
+
+## 테스트 인프라 상세
+
+### conftest.py 주요 Fixture
+
+| Fixture | Scope | 설명 |
+|---------|-------|------|
+| `aerospike_container` | session | TestContainers로 Aerospike CE 8.1 시작. 로컬 서버가 이미 가용하면 재사용. `(container, port)` 반환. |
+| `jaeger_container` | session | Jaeger all-in-one 컨테이너. 트레이싱 테스트용. `(container, otlp_port, ui_port)` 반환. |
+| `aerospike_client` | session | sync 클라이언트 (데이터 setup/teardown용). `POLICY_KEY_SEND` 설정. |
+| `client` | session | FastAPI `TestClient`. lifespan에서 `AsyncClient` 생성. `OTEL_SDK_DISABLED=true` 기본 설정. |
+| `cleanup` | function (autouse) | 테스트 후 레코드 자동 정리. `keys` 리스트에 append하면 자동 삭제. |
+
+### TestContainers 동작
+
+1. `AEROSPIKE_HOST`/`AEROSPIKE_PORT` 환경변수 또는 기본 `127.0.0.1:3000`에 TCP 연결 시도
+2. 성공하면 기존 서버 재사용 (컨테이너 생성 안 함)
+3. 실패하면 랜덤 포트로 Aerospike CE 컨테이너 자동 생성
+4. `heartbeat-received` 로그를 기다린 후 2초 추가 대기
+5. 커스텀 `aerospike.template.conf`를 마운트하여 access-port 설정
+
+### FastAPI TestClient 동작
+
+`conftest.py`의 `client` fixture가 FastAPI 앱의 lifespan을 오버라이드합니다:
+1. `OTEL_SDK_DISABLED=true` 환경변수 설정 (Jaeger 없이 테스트)
+2. `aerospike_py.set_log_level(LOG_LEVEL_INFO)` 로그 레벨 설정
+3. `aerospike_py.init_tracing()` 트레이싱 초기화
+4. `AsyncClient` 생성 후 `app.state.aerospike`에 저장
+5. 테스트 후 `AsyncClient.close()` + `shutdown_tracing()`
+
+## CI에서의 실행
+
+CI의 `feasibility` job에서 `tox -e fastapi`로 실행됩니다:
+- Python 3.13, Aerospike latest 서비스 컨테이너 사용
+- `AEROSPIKE_PORT=3000` 환경변수
+- 의존성 그룹: `test-fastapi` (pytest, pytest-asyncio, fastapi, httpx)


### PR DESCRIPTION
## Summary

- Rewrite aerospike-py/SKILL.md API quick reference with complete type hints and code examples
- Update project-goals/SKILL.md implementation status and tech stack versions
- Enhance new-api/SKILL.md with client_common.rs patterns and traced_op! macro details
- Add fixture table, env vars, and CI workflow mapping to run-tests/SKILL.md
- Expand release-check/SKILL.md checklist with pyright and type stub verification
- Add NumPy benchmark scenarios and methodology to bench-compare/SKILL.md
- Add project structure and TestContainers flow to test-sample-fastapi/SKILL.md

## Test plan

- [x] No code changes, documentation only