### PR TITLE
docs(rust): add doc comments to all public items and document unsafe Safety

### DIFF
--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -1,3 +1,5 @@
+//! Python-visible batch record types for `batch_read` results.
+
 use aerospike_core::BatchRecord;
 use log::trace;
 use pyo3::prelude::*;
@@ -6,6 +8,7 @@ use crate::errors::result_code_to_int;
 use crate::types::key::key_to_py;
 use crate::types::record::record_to_py;
 
+/// A single record within batch results, exposed to Python.
 #[pyclass(name = "BatchRecord")]
 pub struct PyBatchRecord {
     #[pyo3(get)]
@@ -16,12 +19,14 @@ pub struct PyBatchRecord {
     record: Py<PyAny>,
 }
 
+/// Container holding a list of [`PyBatchRecord`]s, exposed to Python.
 #[pyclass(name = "BatchRecords")]
 pub struct PyBatchRecords {
     #[pyo3(get)]
     batch_records: Vec<Py<PyBatchRecord>>,
 }
 
+/// Convert a slice of `BatchRecord`s into a Python [`PyBatchRecords`] object.
 pub fn batch_to_batch_records_py(
     py: Python<'_>,
     results: &[BatchRecord],

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -1,3 +1,9 @@
+//! Aerospike operation codes and Python-visible constants.
+//!
+//! Internal operation codes (`OP_*`) are used by [`crate::operations`] to
+//! dispatch Python operation dicts. Public constants (policy, index, result
+//! codes, etc.) are registered on the native module for use from Python.
+
 use pyo3::prelude::*;
 
 // ── Basic operation type constants ──────────────────────────────
@@ -71,7 +77,11 @@ pub const OP_MAP_GET_BY_RANK_RANGE: i32 = 2025;
 pub const OP_MAP_GET_BY_KEY_LIST: i32 = 2026;
 pub const OP_MAP_GET_BY_VALUE_LIST: i32 = 2027;
 
-/// Register all constants into the module
+/// Register all Aerospike constants onto the native Python module.
+///
+/// Groups: policy keys/exists/gen/replica/commit, TTL, auth mode, operators,
+/// index types, log levels, serializers, list/map return types and flags,
+/// privilege codes, and server result codes.
 pub fn register_constants(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // --- Policy Key ---
     m.add("POLICY_KEY_DIGEST", 0)?;

--- a/rust/src/expressions.rs
+++ b/rust/src/expressions.rs
@@ -1,3 +1,10 @@
+//! Conversion of Python expression dict trees to `aerospike_core::Expression`.
+//!
+//! Expressions are represented in Python as nested dicts with an `"__expr__"` key
+//! identifying the expression type (e.g. `"eq"`, `"int_bin"`, `"and"`).
+//! The `aerospike_py.exp` Python module provides builder functions that produce
+//! these dicts; this module recursively converts them to Rust `Expression` values.
+
 use aerospike_core::expressions::{self, ExpType, Expression};
 use aerospike_core::Value;
 use pyo3::prelude::*;
@@ -255,6 +262,7 @@ fn parse_sub_expr_list(dict: &Bound<'_, PyDict>, key: &str) -> PyResult<Vec<Expr
     Ok(result)
 }
 
+/// Map a Python integer to an [`ExpType`] enum variant used by key expressions.
 fn int_to_exp_type(val: i64) -> PyResult<ExpType> {
     match val {
         0 => Ok(ExpType::NIL),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,9 @@
+//! Native Aerospike client for Python, implemented in Rust via PyO3.
+//!
+//! This crate provides both synchronous ([`client::PyClient`]) and asynchronous
+//! ([`async_client::PyAsyncClient`]) wrappers around `aerospike_core`, exposing
+//! them as Python classes through the `_aerospike` native module.
+
 use log::info;
 use pyo3::prelude::*;
 

--- a/rust/src/policy/admin_policy.rs
+++ b/rust/src/policy/admin_policy.rs
@@ -1,8 +1,13 @@
+//! Admin policy parsing and user/role type conversion.
+
 use aerospike_core::{Privilege, PrivilegeCode};
 use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 
+/// Parse a Python policy dict into an `AdminPolicy`.
+///
+/// Supported keys: `"timeout"` (u32, milliseconds).
 pub fn parse_admin_policy(
     policy: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<aerospike_core::AdminPolicy> {

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -1,3 +1,5 @@
+//! Batch policy parsing from Python dicts.
+
 use aerospike_core::BatchPolicy;
 use log::trace;
 use pyo3::prelude::*;

--- a/rust/src/policy/client_policy.rs
+++ b/rust/src/policy/client_policy.rs
@@ -1,3 +1,5 @@
+//! Client-level policy parsing, including authentication and cluster settings.
+
 use aerospike_core::{AuthMode, ClientPolicy};
 use log::trace;
 use pyo3::prelude::*;

--- a/rust/src/policy/query_policy.rs
+++ b/rust/src/policy/query_policy.rs
@@ -1,3 +1,5 @@
+//! Query/scan policy parsing from Python dicts.
+
 use aerospike_core::QueryPolicy;
 use log::trace;
 use pyo3::prelude::*;

--- a/rust/src/policy/read_policy.rs
+++ b/rust/src/policy/read_policy.rs
@@ -1,3 +1,5 @@
+//! Read policy parsing from Python dicts.
+
 use std::sync::LazyLock;
 
 use aerospike_core::ReadPolicy;
@@ -8,6 +10,7 @@ use pyo3::types::PyDict;
 use super::extract_policy_fields;
 use crate::expressions::{is_expression, py_to_expression};
 
+/// Lazily-initialized default read policy used when no policy dict is provided.
 pub static DEFAULT_READ_POLICY: LazyLock<ReadPolicy> = LazyLock::new(ReadPolicy::default);
 
 /// Parse a Python policy dict into a ReadPolicy

--- a/rust/src/policy/write_policy.rs
+++ b/rust/src/policy/write_policy.rs
@@ -1,3 +1,5 @@
+//! Write policy parsing from Python dicts, including TTL and generation handling.
+
 use std::sync::LazyLock;
 
 use aerospike_core::{CommitLevel, Expiration, GenerationPolicy, RecordExistsAction, WritePolicy};
@@ -8,9 +10,12 @@ use pyo3::types::PyDict;
 use super::extract_policy_fields;
 use crate::expressions::{is_expression, py_to_expression};
 
+/// Lazily-initialized default write policy used when no policy dict is provided.
 pub static DEFAULT_WRITE_POLICY: LazyLock<WritePolicy> = LazyLock::new(WritePolicy::default);
 
-/// Convert a TTL integer value to an Expiration enum
+/// Convert a TTL integer value to an [`Expiration`] enum.
+///
+/// Special values: `0` = namespace default, `-1` = never expire, `-2` = don't update.
 fn parse_ttl(ttl_val: i64) -> Expiration {
     match ttl_val {
         0 => Expiration::NamespaceDefault,

--- a/rust/src/record_helpers.rs
+++ b/rust/src/record_helpers.rs
@@ -1,3 +1,5 @@
+//! Helpers for converting Aerospike records and batch results to Python objects.
+
 use aerospike_core::BatchRecord;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};

--- a/rust/src/runtime.rs
+++ b/rust/src/runtime.rs
@@ -1,7 +1,16 @@
+//! Shared Tokio runtime used by the synchronous [`crate::client::PyClient`].
+//!
+//! The runtime is initialized lazily on first access and lives for the
+//! lifetime of the Python process.
+
 use std::sync::LazyLock;
 
 use log::info;
 
+/// Global multi-threaded Tokio runtime shared across all sync client operations.
+///
+/// Async client operations do not use this runtime; they rely on
+/// `pyo3_async_runtimes::tokio::future_into_py` which manages its own event loop.
 pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     info!("Initializing Tokio multi-thread runtime");
     tokio::runtime::Builder::new_multi_thread()

--- a/rust/src/tracing.rs
+++ b/rust/src/tracing.rs
@@ -7,11 +7,16 @@
 //
 // When the `otel` feature is disabled, `traced_op!` falls back to `timed_op!`.
 
-/// Connection metadata attached to every span.
+/// Connection metadata attached to every OTel span and used for metric labels.
+///
+/// Populated during `connect()` from the first host in the config.
 #[derive(Clone, Debug, Default)]
 pub struct ConnectionInfo {
+    /// Address of the first seed host (e.g. `"127.0.0.1"`).
     pub server_address: String,
+    /// Port of the first seed host (e.g. `18710`).
     pub server_port: i64,
+    /// Cluster name from the client config (empty string if unset).
     pub cluster_name: String,
 }
 

--- a/rust/src/types/bin.rs
+++ b/rust/src/types/bin.rs
@@ -1,3 +1,5 @@
+//! Conversion from Python dicts to `aerospike_core::Bin` vectors.
+
 use aerospike_core::Bin;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;

--- a/rust/src/types/host.rs
+++ b/rust/src/types/host.rs
@@ -1,3 +1,5 @@
+//! Host configuration parsing from Python config dicts to connection strings.
+
 use log::debug;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};

--- a/rust/src/types/key.rs
+++ b/rust/src/types/key.rs
@@ -1,3 +1,5 @@
+//! Bidirectional conversion between Python key tuples and `aerospike_core::Key`.
+
 use aerospike_core::{Key, Value};
 use log::trace;
 use pyo3::prelude::*;

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -1,3 +1,11 @@
+//! Type conversion between Python objects and `aerospike_core` types.
+//!
+//! - [`value`]: Python ↔ `aerospike_core::Value`
+//! - [`key`]: Python tuple ↔ `aerospike_core::Key`
+//! - [`bin`]: Python dict ↔ `Vec<aerospike_core::Bin>`
+//! - [`record`]: `aerospike_core::Record` → Python tuple `(key, meta, bins)`
+//! - [`host`]: Python config dict → connection string
+
 pub mod bin;
 pub mod host;
 pub mod key;

--- a/rust/src/types/record.rs
+++ b/rust/src/types/record.rs
@@ -1,3 +1,5 @@
+//! Conversion from `aerospike_core::Record` to the Python `(key, meta, bins)` tuple.
+
 use aerospike_core::{Key, Record};
 use log::trace;
 use pyo3::prelude::*;

--- a/rust/src/types/value.rs
+++ b/rust/src/types/value.rs
@@ -1,9 +1,12 @@
+//! Bidirectional conversion between Python objects and `aerospike_core::Value`.
+
 use aerospike_core::Value;
 use log::warn;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString};
 use std::collections::HashMap;
 
+/// Maximum recursion depth for nested list/dict values to prevent stack overflow.
 const MAX_NESTING_DEPTH: usize = 64;
 
 /// Convert a Python object to an Aerospike Value


### PR DESCRIPTION
## Summary

- Add module-level //! doc comments to all 26 Rust source files
- Add /// doc comments to all pub functions, structs, and statics
- Document Safety invariants for all unsafe code blocks in numpy_support.rs
- Add exception hierarchy ASCII diagram to errors.rs

## Test plan

- [x] cargo check passes
- [x] cargo fmt passes
- [x] No functional changes