### PR TITLE
Refactor operation builders and policy parsing for code reuse

### DIFF
--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -16,7 +16,7 @@ use crate::errors::as_to_pyerr;
 use crate::policy::admin_policy::{parse_privileges, role_to_py, user_to_py};
 use crate::policy::client_policy::parse_client_policy;
 use crate::policy::write_policy::DEFAULT_WRITE_POLICY;
-use crate::record_helpers::{batch_records_to_py, record_to_meta};
+use crate::record_helpers::{batch_records_to_py, record_to_meta, record_to_ordered_tuple};
 use crate::types::host::parse_hosts_from_config;
 use crate::types::key::key_to_py;
 use crate::types::record::record_to_py;
@@ -668,29 +668,7 @@ impl PyAsyncClient {
                 }
             )?;
 
-            Python::attach(|py| {
-                let key_py = match &record.key {
-                    Some(k) => key_to_py(py, k)?,
-                    None => key_to_py(py, &args.key)?,
-                };
-                let meta_dict_obj = record_to_meta(py, &record)?;
-                let ordered_bins = PyList::empty(py);
-                for (name, value) in &record.bins {
-                    let tuple = PyTuple::new(
-                        py,
-                        [
-                            name.as_str().into_pyobject(py)?.into_any().unbind(),
-                            value_to_py(py, value)?,
-                        ],
-                    )?;
-                    ordered_bins.append(tuple)?;
-                }
-                let result = PyTuple::new(
-                    py,
-                    [key_py, meta_dict_obj, ordered_bins.into_any().unbind()],
-                )?;
-                Ok(result.into_any().unbind())
-            })
+            Python::attach(|py| record_to_ordered_tuple(py, &record, &args.key))
         })
     }
 

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -5,8 +5,7 @@ use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use super::extract_policy_fields;
-use crate::expressions::{is_expression, py_to_expression};
+use super::{extract_policy_fields, parse_filter_expression};
 
 /// Parse a Python policy dict into a BatchPolicy
 pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<BatchPolicy> {
@@ -27,10 +26,8 @@ pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<B
         "respond_all_keys" => policy.respond_all_keys
     });
 
-    if let Some(val) = dict.get_item("filter_expression")? {
-        if is_expression(&val) {
-            policy.filter_expression = Some(py_to_expression(&val)?);
-        }
+    if let Some(expr) = parse_filter_expression(dict)? {
+        policy.filter_expression = Some(expr);
     }
 
     Ok(policy)

--- a/rust/src/policy/mod.rs
+++ b/rust/src/policy/mod.rs
@@ -20,3 +20,16 @@ macro_rules! extract_policy_fields {
 }
 
 pub(crate) use extract_policy_fields;
+
+/// Parse an optional `filter_expression` field from a Python dict.
+pub fn parse_filter_expression(
+    dict: &pyo3::Bound<'_, pyo3::types::PyDict>,
+) -> pyo3::PyResult<Option<aerospike_core::expressions::Expression>> {
+    use pyo3::types::PyDictMethods;
+    if let Some(val) = dict.get_item("filter_expression")? {
+        if crate::expressions::is_expression(&val) {
+            return Ok(Some(crate::expressions::py_to_expression(&val)?));
+        }
+    }
+    Ok(None)
+}

--- a/rust/src/policy/query_policy.rs
+++ b/rust/src/policy/query_policy.rs
@@ -5,8 +5,7 @@ use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use super::extract_policy_fields;
-use crate::expressions::{is_expression, py_to_expression};
+use super::{extract_policy_fields, parse_filter_expression};
 
 /// Parse a Python policy dict into a QueryPolicy
 pub fn parse_query_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<QueryPolicy> {
@@ -28,10 +27,8 @@ pub fn parse_query_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<Q
         "record_queue_size" => policy.record_queue_size
     });
 
-    if let Some(val) = dict.get_item("filter_expression")? {
-        if is_expression(&val) {
-            policy.base_policy.filter_expression = Some(py_to_expression(&val)?);
-        }
+    if let Some(expr) = parse_filter_expression(dict)? {
+        policy.base_policy.filter_expression = Some(expr);
     }
 
     Ok(policy)

--- a/rust/src/policy/read_policy.rs
+++ b/rust/src/policy/read_policy.rs
@@ -7,8 +7,7 @@ use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use super::extract_policy_fields;
-use crate::expressions::{is_expression, py_to_expression};
+use super::{extract_policy_fields, parse_filter_expression};
 
 /// Lazily-initialized default read policy used when no policy dict is provided.
 pub static DEFAULT_READ_POLICY: LazyLock<ReadPolicy> = LazyLock::new(ReadPolicy::default);
@@ -30,10 +29,8 @@ pub fn parse_read_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<Re
         "sleep_between_retries" => policy.base_policy.sleep_between_retries
     });
 
-    if let Some(val) = dict.get_item("filter_expression")? {
-        if is_expression(&val) {
-            policy.base_policy.filter_expression = Some(py_to_expression(&val)?);
-        }
+    if let Some(expr) = parse_filter_expression(dict)? {
+        policy.base_policy.filter_expression = Some(expr);
     }
 
     Ok(policy)

--- a/rust/src/policy/write_policy.rs
+++ b/rust/src/policy/write_policy.rs
@@ -7,8 +7,7 @@ use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use super::extract_policy_fields;
-use crate::expressions::{is_expression, py_to_expression};
+use super::{extract_policy_fields, parse_filter_expression};
 
 /// Lazily-initialized default write policy used when no policy dict is provided.
 pub static DEFAULT_WRITE_POLICY: LazyLock<WritePolicy> = LazyLock::new(WritePolicy::default);
@@ -103,10 +102,8 @@ pub fn parse_write_policy(
     }
 
     // Filter expression
-    if let Some(val) = dict.get_item("filter_expression")? {
-        if is_expression(&val) {
-            policy.base_policy.filter_expression = Some(py_to_expression(&val)?);
-        }
+    if let Some(expr) = parse_filter_expression(dict)? {
+        policy.base_policy.filter_expression = Some(expr);
     }
 
     Ok(policy)

--- a/src/aerospike_py/list_operations.py
+++ b/src/aerospike_py/list_operations.py
@@ -77,36 +77,32 @@ _OP_LIST_SORT = 1030
 _OP_LIST_SET_ORDER = 1031
 
 
-def list_append(bin: str, val: Any, policy: Optional[ListPolicy] = None) -> Operation:
-    """Append a value to a list bin."""
-    op = {"op": _OP_LIST_APPEND, "bin": bin, "val": val}
+def _create_list_op(op_code: int, policy: Optional[ListPolicy] = None, **fields: Any) -> Operation:
+    """Build a list operation dict with optional list_policy."""
+    op: Operation = {"op": op_code, **fields}
     if policy:
         op["list_policy"] = policy
     return op
+
+
+def list_append(bin: str, val: Any, policy: Optional[ListPolicy] = None) -> Operation:
+    """Append a value to a list bin."""
+    return _create_list_op(_OP_LIST_APPEND, policy, bin=bin, val=val)
 
 
 def list_append_items(bin: str, values: list[Any], policy: Optional[ListPolicy] = None) -> Operation:
     """Append multiple values to a list bin."""
-    op = {"op": _OP_LIST_APPEND_ITEMS, "bin": bin, "val": values}
-    if policy:
-        op["list_policy"] = policy
-    return op
+    return _create_list_op(_OP_LIST_APPEND_ITEMS, policy, bin=bin, val=values)
 
 
 def list_insert(bin: str, index: int, val: Any, policy: Optional[ListPolicy] = None) -> Operation:
     """Insert a value at the given index."""
-    op = {"op": _OP_LIST_INSERT, "bin": bin, "index": index, "val": val}
-    if policy:
-        op["list_policy"] = policy
-    return op
+    return _create_list_op(_OP_LIST_INSERT, policy, bin=bin, index=index, val=val)
 
 
 def list_insert_items(bin: str, index: int, values: list[Any], policy: Optional[ListPolicy] = None) -> Operation:
     """Insert multiple values at the given index."""
-    op = {"op": _OP_LIST_INSERT_ITEMS, "bin": bin, "index": index, "val": values}
-    if policy:
-        op["list_policy"] = policy
-    return op
+    return _create_list_op(_OP_LIST_INSERT_ITEMS, policy, bin=bin, index=index, val=values)
 
 
 def list_pop(bin: str, index: int) -> Operation:
@@ -181,12 +177,7 @@ def list_get_by_index(bin: str, index: int, return_type: int) -> Operation:
 
 def list_get_by_index_range(bin: str, index: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Get items by index range with the specified return type."""
-    op = {
-        "op": _OP_LIST_GET_BY_INDEX_RANGE,
-        "bin": bin,
-        "index": index,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_LIST_GET_BY_INDEX_RANGE, "bin": bin, "index": index, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op
@@ -204,12 +195,7 @@ def list_get_by_rank(bin: str, rank: int, return_type: int) -> Operation:
 
 def list_get_by_rank_range(bin: str, rank: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Get items by rank range with the specified return type."""
-    op = {
-        "op": _OP_LIST_GET_BY_RANK_RANGE,
-        "bin": bin,
-        "rank": rank,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_LIST_GET_BY_RANK_RANGE, "bin": bin, "rank": rank, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op
@@ -279,12 +265,7 @@ def list_remove_by_index(bin: str, index: int, return_type: int) -> Operation:
 
 def list_remove_by_index_range(bin: str, index: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Remove items by index range."""
-    op = {
-        "op": _OP_LIST_REMOVE_BY_INDEX_RANGE,
-        "bin": bin,
-        "index": index,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_LIST_REMOVE_BY_INDEX_RANGE, "bin": bin, "index": index, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op
@@ -302,12 +283,7 @@ def list_remove_by_rank(bin: str, rank: int, return_type: int) -> Operation:
 
 def list_remove_by_rank_range(bin: str, rank: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Remove items by rank range."""
-    op = {
-        "op": _OP_LIST_REMOVE_BY_RANK_RANGE,
-        "bin": bin,
-        "rank": rank,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_LIST_REMOVE_BY_RANK_RANGE, "bin": bin, "rank": rank, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op
@@ -315,10 +291,7 @@ def list_remove_by_rank_range(bin: str, rank: int, return_type: int, count: Opti
 
 def list_increment(bin: str, index: int, val: int, policy: Optional[ListPolicy] = None) -> Operation:
     """Increment the value at the given index."""
-    op = {"op": _OP_LIST_INCREMENT, "bin": bin, "index": index, "val": val}
-    if policy:
-        op["list_policy"] = policy
-    return op
+    return _create_list_op(_OP_LIST_INCREMENT, policy, bin=bin, index=index, val=val)
 
 
 def list_sort(bin: str, sort_flags: int = 0) -> Operation:

--- a/src/aerospike_py/map_operations.py
+++ b/src/aerospike_py/map_operations.py
@@ -69,6 +69,14 @@ _OP_MAP_GET_BY_KEY_LIST = 2026
 _OP_MAP_GET_BY_VALUE_LIST = 2027
 
 
+def _create_map_op(op_code: int, policy: Optional[MapPolicy] = None, **fields: Any) -> Operation:
+    """Build a map operation dict with optional map_policy."""
+    op: Operation = {"op": op_code, **fields}
+    if policy:
+        op["map_policy"] = policy
+    return op
+
+
 def map_set_order(bin: str, map_order: int) -> Operation:
     """Set the map ordering."""
     return {"op": _OP_MAP_SET_ORDER, "bin": bin, "val": map_order}
@@ -76,34 +84,22 @@ def map_set_order(bin: str, map_order: int) -> Operation:
 
 def map_put(bin: str, key: Any, val: Any, policy: Optional[MapPolicy] = None) -> Operation:
     """Put a key/value pair into a map bin."""
-    op = {"op": _OP_MAP_PUT, "bin": bin, "map_key": key, "val": val}
-    if policy:
-        op["map_policy"] = policy
-    return op
+    return _create_map_op(_OP_MAP_PUT, policy, bin=bin, map_key=key, val=val)
 
 
 def map_put_items(bin: str, items: dict[str, Any], policy: Optional[MapPolicy] = None) -> Operation:
     """Put multiple key/value pairs into a map bin."""
-    op = {"op": _OP_MAP_PUT_ITEMS, "bin": bin, "val": items}
-    if policy:
-        op["map_policy"] = policy
-    return op
+    return _create_map_op(_OP_MAP_PUT_ITEMS, policy, bin=bin, val=items)
 
 
 def map_increment(bin: str, key: Any, incr: Any, policy: Optional[MapPolicy] = None) -> Operation:
     """Increment a value in a map by key."""
-    op = {"op": _OP_MAP_INCREMENT, "bin": bin, "map_key": key, "val": incr}
-    if policy:
-        op["map_policy"] = policy
-    return op
+    return _create_map_op(_OP_MAP_INCREMENT, policy, bin=bin, map_key=key, val=incr)
 
 
 def map_decrement(bin: str, key: Any, decr: Any, policy: Optional[MapPolicy] = None) -> Operation:
     """Decrement a value in a map by key."""
-    op = {"op": _OP_MAP_DECREMENT, "bin": bin, "map_key": key, "val": decr}
-    if policy:
-        op["map_policy"] = policy
-    return op
+    return _create_map_op(_OP_MAP_DECREMENT, policy, bin=bin, map_key=key, val=decr)
 
 
 def map_clear(bin: str) -> Operation:
@@ -185,12 +181,7 @@ def map_remove_by_index(bin: str, index: int, return_type: int) -> Operation:
 
 def map_remove_by_index_range(bin: str, index: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Remove items by index range."""
-    op = {
-        "op": _OP_MAP_REMOVE_BY_INDEX_RANGE,
-        "bin": bin,
-        "index": index,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_MAP_REMOVE_BY_INDEX_RANGE, "bin": bin, "index": index, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op
@@ -208,12 +199,7 @@ def map_remove_by_rank(bin: str, rank: int, return_type: int) -> Operation:
 
 def map_remove_by_rank_range(bin: str, rank: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Remove items by rank range."""
-    op = {
-        "op": _OP_MAP_REMOVE_BY_RANK_RANGE,
-        "bin": bin,
-        "rank": rank,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_MAP_REMOVE_BY_RANK_RANGE, "bin": bin, "rank": rank, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op
@@ -278,12 +264,7 @@ def map_get_by_index(bin: str, index: int, return_type: int) -> Operation:
 
 def map_get_by_index_range(bin: str, index: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Get items by index range."""
-    op = {
-        "op": _OP_MAP_GET_BY_INDEX_RANGE,
-        "bin": bin,
-        "index": index,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_MAP_GET_BY_INDEX_RANGE, "bin": bin, "index": index, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op
@@ -301,12 +282,7 @@ def map_get_by_rank(bin: str, rank: int, return_type: int) -> Operation:
 
 def map_get_by_rank_range(bin: str, rank: int, return_type: int, count: Optional[int] = None) -> Operation:
     """Get items by rank range."""
-    op = {
-        "op": _OP_MAP_GET_BY_RANK_RANGE,
-        "bin": bin,
-        "rank": rank,
-        "return_type": return_type,
-    }
+    op: Operation = {"op": _OP_MAP_GET_BY_RANK_RANGE, "bin": bin, "rank": rank, "return_type": return_type}
     if count is not None:
         op["count"] = count
     return op

--- a/src/aerospike_py/predicates.py
+++ b/src/aerospike_py/predicates.py
@@ -43,6 +43,15 @@ def contains(bin_name: str, index_type: int, val: Any) -> tuple[str, str, int, A
     return ("contains", bin_name, index_type, val)
 
 
+def _warn_geo_unsupported() -> None:
+    """Emit a FutureWarning about unsupported geo filters."""
+    warnings.warn(
+        "Geo filters are not yet supported; query execution will raise ClientError",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
 def geo_within_geojson_region(bin_name: str, geojson: str) -> tuple[str, str, str]:
     """Create a geospatial 'within region' predicate.
 
@@ -50,11 +59,7 @@ def geo_within_geojson_region(bin_name: str, geojson: str) -> tuple[str, str, st
         Geo filters are not yet supported in this version.
         Using this predicate in a query will raise ``ClientError`` at execution time.
     """
-    warnings.warn(
-        "Geo filters are not yet supported; query execution will raise ClientError",
-        FutureWarning,
-        stacklevel=2,
-    )
+    _warn_geo_unsupported()
     return ("geo_within_geojson_region", bin_name, geojson)
 
 
@@ -65,11 +70,7 @@ def geo_within_radius(bin_name: str, lat: float, lng: float, radius: float) -> t
         Geo filters are not yet supported in this version.
         Using this predicate in a query will raise ``ClientError`` at execution time.
     """
-    warnings.warn(
-        "Geo filters are not yet supported; query execution will raise ClientError",
-        FutureWarning,
-        stacklevel=2,
-    )
+    _warn_geo_unsupported()
     return ("geo_within_radius", bin_name, lat, lng, radius)
 
 
@@ -80,9 +81,5 @@ def geo_contains_geojson_point(bin_name: str, geojson: str) -> tuple[str, str, s
         Geo filters are not yet supported in this version.
         Using this predicate in a query will raise ``ClientError`` at execution time.
     """
-    warnings.warn(
-        "Geo filters are not yet supported; query execution will raise ClientError",
-        FutureWarning,
-        stacklevel=2,
-    )
+    _warn_geo_unsupported()
     return ("geo_contains_geojson_point", bin_name, geojson)


### PR DESCRIPTION
## Summary
This PR refactors operation builders and policy parsing across the codebase to reduce duplication and improve maintainability. Helper functions are extracted to centralize common patterns, and shared base classes are introduced for similar functionality.

## Key Changes

### Python Operation Builders
- **List operations**: Introduced `_create_list_op()` helper to consolidate operation dict creation with optional policy handling. Refactored `list_append()`, `list_append_items()`, `list_insert()`, `list_insert_items()`, and `list_increment()` to use this helper.
- **Map operations**: Introduced `_create_map_op()` helper with the same pattern. Refactored `map_put()`, `map_put_items()`, `map_increment()`, and `map_decrement()` to use this helper.
- **Code formatting**: Condensed multi-line operation dict literals to single lines for consistency.

### Rust Batch Processing
- **Client common**: Extracted `extract_batch_keys_and_ns()` helper function to eliminate duplicate key extraction and namespace/set derivation logic across `prepare_batch_read_args()`, `prepare_batch_operate_args()`, and `prepare_batch_remove_args()`.

### Rust Record Helpers
- **Record conversion**: Extracted `record_to_ordered_tuple()` helper to build `(key, meta, ordered_bins)` tuples for `operate_ordered`. Refactored both `client.rs` and `async_client.rs` to use this helper, eliminating ~25 lines of duplicated tuple construction logic.

### Rust Policy Parsing
- **Filter expression parsing**: Introduced `parse_filter_expression()` in `policy/mod.rs` to centralize filter expression extraction logic.
- **Policy modules**: Updated `batch_policy.rs`, `query_policy.rs`, `read_policy.rs`, and `write_policy.rs` to use the new `parse_filter_expression()` helper instead of inline expression checking.

### Python Logging and Query Classes
- **Logging level map**: Moved `_LEVEL_MAP` to module-level `_AEROSPIKE_LEVEL_MAP` constant in `__init__.py` for better organization.
- **Query class hierarchy**: Introduced `_QueryBase` base class to share `__init__()`, `select()`, and `where()` methods between `Query` and `AsyncQuery`, eliminating code duplication.

### Python Predicates
- **Geo warning consolidation**: Extracted `_warn_geo_unsupported()` helper to centralize the FutureWarning emitted by all three geo predicate functions, with corrected `stacklevel=3`.

## Implementation Details
- All refactored functions maintain identical behavior and signatures
- Helper functions use `**fields` pattern for flexible operation dict construction
- Extracted helpers are marked as private (leading underscore) where appropriate
- No changes to public APIs or external behavior

https://claude.ai/code/session_01K5M6RyHVa6uENFqeDi4e8x