### PR TITLE
feat: add bug report logging for unexpected internal errors

### DIFF
--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -43,7 +43,7 @@ pub fn batch_to_batch_records_py(
         };
 
         let record_py = match &br.record {
-            Some(_) => record_to_py(py, br.record.as_ref().unwrap(), Some(&br.key))?,
+            Some(record) => record_to_py(py, record, Some(&br.key))?,
             None => py.None(),
         };
 

--- a/rust/src/bug_report.rs
+++ b/rust/src/bug_report.rs
@@ -1,0 +1,97 @@
+//! Bug report logging for unexpected internal errors.
+//!
+//! When aerospike-py encounters an error that is likely a library bug
+//! (not an expected Aerospike server error), these helpers log a message
+//! suggesting the user file a GitHub issue.
+
+use log::error;
+
+const REPO: &str = "KimSoungRyoul/aerospike-py";
+
+/// Escape single quotes for shell single-quoted strings: `'` → `'\''`.
+fn shell_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
+}
+
+/// Truncate and sanitize a string for use in a GitHub issue title.
+fn sanitize_for_title(s: &str, max_len: usize) -> String {
+    let cleaned: String = s.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
+    if cleaned.len() <= max_len {
+        cleaned
+    } else {
+        format!("{}...", &cleaned[..max_len - 3])
+    }
+}
+
+/// Log an unexpected internal error with a `gh issue create` command.
+///
+/// Only call this for errors that are NOT expected Aerospike errors.
+pub fn log_unexpected_error(context: &str, error_detail: &str) {
+    let version = env!("CARGO_PKG_VERSION");
+    let title = format!("Unexpected error: {}", sanitize_for_title(error_detail, 80));
+    let body =
+        format!("aerospike-py version: {version}\nContext: {context}\nError: {error_detail}");
+    error!(
+        "Unexpected internal error in aerospike-py ({context}): {error_detail}\n\
+         \n\
+         This error may be a bug in aerospike-py. Please report it by running:\n\
+         gh issue create --repo {REPO} \
+         --title '{title}' \
+         --body '{body}'",
+        title = shell_escape(&title),
+        body = shell_escape(&body),
+    );
+}
+
+/// Replace `unreachable!()` with a version that logs a bug report
+/// and returns a `PyErr` instead of panicking.
+macro_rules! internal_bug {
+    ($context:expr, $($arg:tt)*) => {{
+        let detail = format!($($arg)*);
+        $crate::bug_report::log_unexpected_error($context, &detail);
+        Err(pyo3::exceptions::PyRuntimeError::new_err(
+            format!("aerospike-py internal error ({}): {}", $context, detail)
+        ))
+    }};
+}
+
+pub(crate) use internal_bug;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_short_string() {
+        assert_eq!(sanitize_for_title("hello", 80), "hello");
+    }
+
+    #[test]
+    fn test_sanitize_long_string() {
+        let long = "a".repeat(100);
+        let result = sanitize_for_title(&long, 80);
+        assert_eq!(result.len(), 80);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_sanitize_newlines() {
+        assert_eq!(sanitize_for_title("line1\nline2", 80), "line1 line2");
+    }
+
+    #[test]
+    fn test_sanitize_exact_length() {
+        let exact = "a".repeat(80);
+        assert_eq!(sanitize_for_title(&exact, 80), exact);
+    }
+
+    #[test]
+    fn test_shell_escape_no_quotes() {
+        assert_eq!(shell_escape("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_shell_escape_with_quotes() {
+        assert_eq!(shell_escape("it's a bug"), "it'\\''s a bug");
+    }
+}

--- a/rust/src/expressions.rs
+++ b/rust/src/expressions.rs
@@ -131,7 +131,10 @@ fn convert_bin_accessor(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Expressi
         "hll_bin" => Ok(expressions::hll_bin(name)),
         "bin_exists" => Ok(expressions::bin_exists(name)),
         "bin_type" => Ok(expressions::bin_type(name)),
-        _ => unreachable!("convert_bin_accessor called with unexpected op: {op}"),
+        _ => crate::bug_report::internal_bug!(
+            "expressions::convert_bin_accessor",
+            "unexpected op: {op}"
+        ),
     }
 }
 
@@ -147,7 +150,10 @@ fn convert_binary_comparison(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Exp
         "lt" => Ok(expressions::lt(left, right)),
         "le" => Ok(expressions::le(left, right)),
         "geo_compare" => Ok(expressions::geo_compare(left, right)),
-        _ => unreachable!("convert_binary_comparison called with unexpected op: {op}"),
+        _ => crate::bug_report::internal_bug!(
+            "expressions::convert_binary_comparison",
+            "unexpected op: {op}"
+        ),
     }
 }
 
@@ -169,7 +175,10 @@ fn convert_variadic_op(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Expressio
         "int_xor" => Ok(expressions::int_xor(exprs)),
         "cond" => Ok(expressions::cond(exprs)),
         "let" => Ok(expressions::exp_let(exprs)),
-        _ => unreachable!("convert_variadic_op called with unexpected op: {op}"),
+        _ => crate::bug_report::internal_bug!(
+            "expressions::convert_variadic_op",
+            "unexpected op: {op}"
+        ),
     }
 }
 
@@ -189,7 +198,9 @@ fn convert_unary_op(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Expression> 
         "to_float" => Ok(expressions::to_float(expr)),
         "int_not" => Ok(expressions::int_not(expr)),
         "int_count" => Ok(expressions::int_count(expr)),
-        _ => unreachable!("convert_unary_op called with unexpected op: {op}"),
+        _ => {
+            crate::bug_report::internal_bug!("expressions::convert_unary_op", "unexpected op: {op}")
+        }
     }
 }
 
@@ -218,7 +229,10 @@ fn convert_binary_pair_op(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Expres
         "int_arshift" => Ok(expressions::int_arshift(first, second)),
         "int_lscan" => Ok(expressions::int_lscan(first, second)),
         "int_rscan" => Ok(expressions::int_rscan(first, second)),
-        _ => unreachable!("convert_binary_pair_op called with unexpected op: {op}"),
+        _ => crate::bug_report::internal_bug!(
+            "expressions::convert_binary_pair_op",
+            "unexpected op: {op}"
+        ),
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,6 +9,7 @@ use pyo3::prelude::*;
 
 mod async_client;
 mod batch_types;
+mod bug_report;
 mod client;
 mod client_common;
 mod constants;

--- a/rust/src/runtime.rs
+++ b/rust/src/runtime.rs
@@ -16,5 +16,11 @@ pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("Failed to create Tokio runtime")
+        .unwrap_or_else(|e| {
+            crate::bug_report::log_unexpected_error(
+                "runtime::RUNTIME",
+                &format!("Failed to create Tokio runtime: {e}"),
+            );
+            panic!("Failed to create Tokio runtime: {e}")
+        })
 });

--- a/src/aerospike_py/__init__.py
+++ b/src/aerospike_py/__init__.py
@@ -254,6 +254,7 @@ from aerospike_py.types import (  # noqa: F401
     RoleInfo,
 )
 from aerospike_py._types import ListPolicy, MapPolicy, Operation  # noqa: F401
+from aerospike_py._bug_report import catch_unexpected
 
 try:
     from importlib.metadata import PackageNotFoundError
@@ -317,9 +318,11 @@ class Query:
     def where(self, predicate) -> None:
         self._inner.where(predicate)
 
+    @catch_unexpected("Query.results")
     def results(self, policy=None) -> list[Record]:
         return [_wrap_record(r) for r in self._inner.results(policy)]
 
+    @catch_unexpected("Query.foreach")
     def foreach(self, callback, policy=None) -> None:
         def _cb(raw):
             return callback(_wrap_record(raw))
@@ -344,10 +347,12 @@ class AsyncQuery:
     def where(self, predicate) -> None:
         self._inner.where(predicate)
 
+    @catch_unexpected("AsyncQuery.results")
     async def results(self, policy=None) -> list[Record]:
         raw = await asyncio.to_thread(self._inner.results, policy)
         return [_wrap_record(r) for r in raw]
 
+    @catch_unexpected("AsyncQuery.foreach")
     async def foreach(self, callback, policy=None) -> None:
         def _sync_foreach():
             def _cb(raw):
@@ -398,21 +403,27 @@ class Client(_NativeClient):
         super().connect(username, password)
         return self
 
+    @catch_unexpected("Client.get")
     def get(self, key, policy=None) -> Record:
         return _wrap_record(super().get(key, policy))
 
+    @catch_unexpected("Client.select")
     def select(self, key, bins, policy=None) -> Record:
         return _wrap_record(super().select(key, bins, policy))
 
+    @catch_unexpected("Client.exists")
     def exists(self, key, policy=None) -> ExistsResult:
         return _wrap_exists(super().exists(key, policy))
 
+    @catch_unexpected("Client.operate")
     def operate(self, key, ops, meta=None, policy=None) -> Record:
         return _wrap_record(super().operate(key, ops, meta, policy))
 
+    @catch_unexpected("Client.operate_ordered")
     def operate_ordered(self, key, ops, meta=None, policy=None) -> OperateOrderedResult:
         return _wrap_operate_ordered(super().operate_ordered(key, ops, meta, policy))
 
+    @catch_unexpected("Client.info_all")
     def info_all(self, command, policy=None) -> list[InfoNodeResult]:
         return [InfoNodeResult(*t) for t in super().info_all(command, policy)]
 
@@ -447,6 +458,7 @@ class Client(_NativeClient):
         """
         return super().batch_read(keys, bins, policy, _dtype)
 
+    @catch_unexpected("Client.batch_write_numpy")
     def batch_write_numpy(self, data, namespace, set_name, _dtype, key_field="_key", policy=None):
         """Write multiple records from a numpy structured array.
 
@@ -477,9 +489,11 @@ class Client(_NativeClient):
             _wrap_record(r) for r in super().batch_write_numpy(data, namespace, set_name, _dtype, key_field, policy)
         ]
 
+    @catch_unexpected("Client.batch_operate")
     def batch_operate(self, keys, ops, policy=None) -> list[Record]:
         return [_wrap_record(r) for r in super().batch_operate(keys, ops, policy)]
 
+    @catch_unexpected("Client.batch_remove")
     def batch_remove(self, keys, policy=None) -> list[Record]:
         return [_wrap_record(r) for r in super().batch_remove(keys, policy)]
 
@@ -564,21 +578,27 @@ class AsyncClient:
         logger.debug("Async client closing")
         return await self._inner.close()
 
+    @catch_unexpected("AsyncClient.get")
     async def get(self, key, policy=None) -> Record:
         return _wrap_record(await self._inner.get(key, policy))
 
+    @catch_unexpected("AsyncClient.select")
     async def select(self, key, bins, policy=None) -> Record:
         return _wrap_record(await self._inner.select(key, bins, policy))
 
+    @catch_unexpected("AsyncClient.exists")
     async def exists(self, key, policy=None) -> ExistsResult:
         return _wrap_exists(await self._inner.exists(key, policy))
 
+    @catch_unexpected("AsyncClient.operate")
     async def operate(self, key, ops, meta=None, policy=None) -> Record:
         return _wrap_record(await self._inner.operate(key, ops, meta, policy))
 
+    @catch_unexpected("AsyncClient.operate_ordered")
     async def operate_ordered(self, key, ops, meta=None, policy=None) -> OperateOrderedResult:
         return _wrap_operate_ordered(await self._inner.operate_ordered(key, ops, meta, policy))
 
+    @catch_unexpected("AsyncClient.info_all")
     async def info_all(self, command, policy=None) -> list[InfoNodeResult]:
         return [InfoNodeResult(*t) for t in await self._inner.info_all(command, policy)]
 
@@ -615,6 +635,7 @@ class AsyncClient:
         """
         return await self._inner.batch_read(keys, bins, policy, _dtype)
 
+    @catch_unexpected("AsyncClient.batch_write_numpy")
     async def batch_write_numpy(
         self, data, namespace: str, set_name: str, _dtype, key_field: str = "_key", policy=None
     ) -> list[Record]:
@@ -648,9 +669,11 @@ class AsyncClient:
             for r in await self._inner.batch_write_numpy(data, namespace, set_name, _dtype, key_field, policy)
         ]
 
+    @catch_unexpected("AsyncClient.batch_operate")
     async def batch_operate(self, keys, ops, policy=None) -> list[Record]:
         return [_wrap_record(r) for r in await self._inner.batch_operate(keys, ops, policy)]
 
+    @catch_unexpected("AsyncClient.batch_remove")
     async def batch_remove(self, keys, policy=None) -> list[Record]:
         return [_wrap_record(r) for r in await self._inner.batch_remove(keys, policy)]
 

--- a/src/aerospike_py/_bug_report.py
+++ b/src/aerospike_py/_bug_report.py
@@ -1,0 +1,98 @@
+"""Internal bug report helper for unexpected errors in aerospike-py."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import platform
+import sys
+import traceback
+
+logger = logging.getLogger("aerospike_py")
+
+_REPO = "KimSoungRyoul/aerospike-py"
+
+
+def _shell_escape(s: str) -> str:
+    """Escape single quotes for shell single-quoted strings."""
+    return s.replace("'", "'\\''")
+
+
+def log_unexpected_error(context: str, exc: BaseException) -> None:
+    """Log an unexpected error with a gh issue create command.
+
+    Only call this for errors that are NOT expected Aerospike errors
+    (i.e., not subclasses of AerospikeError).
+    """
+    from aerospike_py import __version__
+
+    exc_type = type(exc).__name__
+    exc_msg = str(exc)
+    tb_str = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)).strip()
+
+    title = f"Unexpected error: {exc_type}: {exc_msg[:80]}"
+    body = (
+        f"aerospike-py version: {__version__}\n"
+        f"Python: {sys.version}\n"
+        f"Platform: {platform.platform()}\n"
+        f"Context: {context}\n"
+        f"Error: {exc_type}: {exc_msg}\n\n"
+        f"Traceback:\n```\n{tb_str}\n```"
+    )
+
+    logger.error(
+        "Unexpected internal error in aerospike-py (%s): %s: %s\n"
+        "\n"
+        "This error may be a bug in aerospike-py. Please report it by running:\n"
+        "gh issue create --repo %s --title '%s' --body '%s'",
+        context,
+        exc_type,
+        exc_msg,
+        _REPO,
+        _shell_escape(title),
+        _shell_escape(body),
+    )
+
+
+def _maybe_log(method_name: str, exc: Exception) -> None:
+    """Log if exc is NOT an expected AerospikeError."""
+    from aerospike_py._aerospike import AerospikeError
+
+    if not isinstance(exc, AerospikeError):
+        log_unexpected_error(method_name, exc)
+
+
+def catch_unexpected(method_name: str):
+    """Decorator that catches unexpected errors and logs a bug report.
+
+    Expected AerospikeError subclasses pass through unmodified.
+    All other exceptions are logged with the bug report message,
+    then re-raised as-is (so the caller still sees the original error).
+    """
+
+    def decorator(func):
+        if asyncio.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as exc:
+                    _maybe_log(method_name, exc)
+                    raise
+
+            return async_wrapper
+        else:
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:
+                    _maybe_log(method_name, exc)
+                    raise
+
+            return wrapper
+
+    return decorator

--- a/tests/unit/test_bug_report.py
+++ b/tests/unit/test_bug_report.py
@@ -1,0 +1,144 @@
+"""Unit tests for aerospike_py._bug_report module."""
+
+import logging
+
+import pytest
+
+from aerospike_py._bug_report import catch_unexpected, log_unexpected_error
+
+
+class TestLogUnexpectedError:
+    """Tests for log_unexpected_error function."""
+
+    def test_logs_at_error_level(self, caplog):
+        exc = TypeError("test error message")
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"):
+            log_unexpected_error("TestContext.method", exc)
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.ERROR
+
+    def test_log_contains_gh_issue_create(self, caplog):
+        exc = ValueError("something broke")
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"):
+            log_unexpected_error("Client.get", exc)
+
+        msg = caplog.records[0].message
+        assert "gh issue create --repo KimSoungRyoul/aerospike-py" in msg
+
+    def test_log_contains_context(self, caplog):
+        exc = RuntimeError("internal failure")
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"):
+            log_unexpected_error("Client.operate", exc)
+
+        msg = caplog.records[0].message
+        assert "Client.operate" in msg
+
+    def test_log_contains_error_type_and_message(self, caplog):
+        exc = IndexError("index out of range")
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"):
+            log_unexpected_error("Client.get", exc)
+
+        msg = caplog.records[0].message
+        assert "IndexError" in msg
+        assert "index out of range" in msg
+
+    def test_log_contains_bug_report_message(self, caplog):
+        exc = TypeError("unexpected")
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"):
+            log_unexpected_error("Client.get", exc)
+
+        msg = caplog.records[0].message
+        assert "This error may be a bug in aerospike-py" in msg
+
+
+class TestCatchUnexpectedSync:
+    """Tests for catch_unexpected decorator with sync functions."""
+
+    def test_passes_through_aerospike_error(self):
+        from aerospike_py._aerospike import AerospikeError
+
+        @catch_unexpected("test.method")
+        def raises_aerospike():
+            raise AerospikeError("expected error")
+
+        with pytest.raises(AerospikeError):
+            raises_aerospike()
+
+    def test_aerospike_error_not_logged(self, caplog):
+        from aerospike_py._aerospike import AerospikeError
+
+        @catch_unexpected("test.method")
+        def raises_aerospike():
+            raise AerospikeError("expected error")
+
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"), pytest.raises(AerospikeError):
+            raises_aerospike()
+
+        assert len(caplog.records) == 0
+
+    def test_unexpected_error_logged_and_reraised(self, caplog):
+        @catch_unexpected("test.method")
+        def raises_type_error():
+            raise TypeError("unexpected bug")
+
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"), pytest.raises(TypeError, match="unexpected bug"):
+            raises_type_error()
+
+        assert len(caplog.records) == 1
+        assert "gh issue create" in caplog.records[0].message
+
+    def test_normal_return_value_preserved(self):
+        @catch_unexpected("test.method")
+        def returns_value():
+            return 42
+
+        assert returns_value() == 42
+
+
+class TestCatchUnexpectedAsync:
+    """Tests for catch_unexpected decorator with async functions."""
+
+    @pytest.mark.asyncio
+    async def test_async_passes_through_aerospike_error(self):
+        from aerospike_py._aerospike import AerospikeError
+
+        @catch_unexpected("test.async_method")
+        async def raises_aerospike():
+            raise AerospikeError("expected error")
+
+        with pytest.raises(AerospikeError):
+            await raises_aerospike()
+
+    @pytest.mark.asyncio
+    async def test_async_aerospike_error_not_logged(self, caplog):
+        from aerospike_py._aerospike import AerospikeError
+
+        @catch_unexpected("test.async_method")
+        async def raises_aerospike():
+            raise AerospikeError("expected error")
+
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"), pytest.raises(AerospikeError):
+            await raises_aerospike()
+
+        assert len(caplog.records) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_unexpected_error_logged_and_reraised(self, caplog):
+        @catch_unexpected("test.async_method")
+        async def raises_type_error():
+            raise TypeError("async bug")
+
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"), pytest.raises(TypeError, match="async bug"):
+            await raises_type_error()
+
+        assert len(caplog.records) == 1
+        assert "gh issue create" in caplog.records[0].message
+
+    @pytest.mark.asyncio
+    async def test_async_normal_return_value_preserved(self):
+        @catch_unexpected("test.async_method")
+        async def returns_value():
+            return 99
+
+        assert await returns_value() == 99


### PR DESCRIPTION
## Summary

- 라이브러리 내부 버그로 추정되는 예상치 못한 에러 발생 시 `gh issue create` 커맨드를 포함한 ERROR 로그를 자동 출력
- 예상된 AerospikeError 계열 에러는 기존 동작 그대로 유지 (로그 없이 pass-through)

### Rust (`rust/src/`)
- `bug_report.rs` 신규: `log_unexpected_error()` 함수 + `internal_bug!` 매크로 (panic 대신 PyErr 반환)
- `expressions.rs`: `unreachable!()` 5곳을 `internal_bug!`로 교체 (프로세스 크래시 방지)
- `runtime.rs`: Tokio 런타임 `.expect()` → 버그 리포트 로그 후 panic
- `errors.rs`: 미매핑 ResultCode/Error variant catch-all에 경고 로그 추가
- `batch_types.rs`: 불필요한 `.unwrap()` 제거 → 패턴 매칭 변수 직접 사용

### Python (`src/aerospike_py/`)
- `_bug_report.py` 신규: `log_unexpected_error()` + `catch_unexpected` 데코레이터
- `__init__.py`: Client/AsyncClient/Query/AsyncQuery의 결과 변환 메서드 22곳에 `@catch_unexpected` 적용

## Test plan
- [x] `cargo check` 통과
- [x] `make build` 통과
- [x] `make test-unit` — 344 passed (기존 331 + 신규 13)
- [x] `make lint` — ruff, pyright, cargo fmt, clippy 전부 통과