### PR TITLE
docs: add versioning infrastructure and tab-separate CDT operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,15 @@ test-matrix: build ## Run unit tests across all Python versions
 # Helpers
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Documentation
+# ---------------------------------------------------------------------------
+
+.PHONY: docs-version
+docs-version: ## Create a new docs version (usage: make docs-version VERSION=0.1.0)
+	@test -n "$(VERSION)" || (echo "ERROR: VERSION required. Usage: make docs-version VERSION=0.1.0" && exit 1)
+	bash docs/scripts/create-version.sh $(VERSION)
+
 .PHONY: clean
 clean: ## Remove venv and build artifacts
 	rm -rf .venv target/ dist/ *.egg-info

--- a/docs/docs/guides/crud/operations.md
+++ b/docs/docs/guides/crud/operations.md
@@ -17,7 +17,8 @@ from aerospike_py import map_operations as map_ops
 import aerospike_py as aerospike
 ```
 
----
+<Tabs>
+  <TabItem value="list" label="List CDT Operations" default>
 
 ## List CDT Operations
 
@@ -416,7 +417,8 @@ with aerospike.client({
     print(f"Total scores: {bins['scores']}")
 ```
 
----
+  </TabItem>
+  <TabItem value="map" label="Map CDT Operations">
 
 ## Map CDT Operations
 
@@ -790,3 +792,6 @@ with aerospike.client({
     _, _, bins = client.operate(key, ops)
     print(f"Total subjects: {bins['scores']}")
 ```
+
+  </TabItem>
+</Tabs>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -45,6 +45,17 @@ const config: Config = {
           editUrl:
             'https://github.com/KimSoungRyoul/aerospike-py/tree/main/docs/',
           showLastUpdateTime: true,
+          // Versioning: 릴리스 전에는 current가 기본
+          // 첫 릴리스 후 lastVersion을 해당 버전으로 변경하고
+          // current.path를 'next', current.banner를 'unreleased'로 전환
+          lastVersion: 'current',
+          versions: {
+            current: {
+              label: 'In Development',
+              path: '',
+              banner: 'none',
+            },
+          },
         },
         blog: false,
         theme: {
@@ -75,6 +86,11 @@ const config: Config = {
           label: 'Docs',
         },
         {to: '/releases', label: 'Releases', position: 'left'},
+        {
+          type: 'docsVersionDropdown',
+          position: 'right',
+          dropdownActiveClassDisabled: true,
+        },
         {
           type: 'localeDropdown',
           position: 'right',

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "Next",
+    "message": "In Development",
     "description": "The label for version current"
   },
   "sidebar.docsSidebar.category.API Reference": {

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/operations.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/operations.md
@@ -17,7 +17,8 @@ from aerospike_py import map_operations as map_ops
 import aerospike_py as aerospike
 ```
 
----
+<Tabs>
+  <TabItem value="list" label="List CDT Operations" default>
 
 ## List CDT Operations
 
@@ -416,7 +417,8 @@ with aerospike.client({
     print(f"Total scores: {bins['scores']}")
 ```
 
----
+  </TabItem>
+  <TabItem value="map" label="Map CDT Operations">
 
 ## Map CDT Operations
 
@@ -790,3 +792,6 @@ with aerospike.client({
     _, _, bins = client.operate(key, ops)
     print(f"Total subjects: {bins['scores']}")
 ```
+
+  </TabItem>
+</Tabs>

--- a/docs/scripts/create-version.sh
+++ b/docs/scripts/create-version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/create-version.sh <version>
+# Example: ./scripts/create-version.sh 0.1.0
+
+VERSION="${1:?Usage: $0 <version>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOCS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$DOCS_DIR/.." && pwd)"
+
+echo "==> Creating documentation version: ${VERSION}"
+
+# Step 1: Regenerate API docs from current .pyi stubs
+echo "==> Regenerating API docs from .pyi stubs..."
+python3 "${PROJECT_ROOT}/scripts/generate-api-docs.py"
+
+# Step 2: Create the Docusaurus version snapshot
+echo "==> Running docusaurus docs:version ${VERSION}..."
+cd "$DOCS_DIR"
+npx docusaurus docs:version "$VERSION"
+
+# Step 3: Copy Korean i18n translations for the new version
+CURRENT_KO_DIR="${DOCS_DIR}/i18n/ko/docusaurus-plugin-content-docs/current"
+VERSION_KO_DIR="${DOCS_DIR}/i18n/ko/docusaurus-plugin-content-docs/version-${VERSION}"
+
+if [ -d "$CURRENT_KO_DIR" ]; then
+  echo "==> Copying Korean translations for version ${VERSION}..."
+  cp -r "$CURRENT_KO_DIR" "$VERSION_KO_DIR"
+  echo "   Created: ${VERSION_KO_DIR}"
+fi
+
+# Step 4: Create Korean version sidebar translation file
+CURRENT_KO_JSON="${DOCS_DIR}/i18n/ko/docusaurus-plugin-content-docs/current.json"
+VERSION_KO_JSON="${DOCS_DIR}/i18n/ko/docusaurus-plugin-content-docs/version-${VERSION}.json"
+if [ -f "$CURRENT_KO_JSON" ]; then
+  sed "s/\"In Development\"/\"${VERSION}\"/" "$CURRENT_KO_JSON" > "$VERSION_KO_JSON"
+  echo "   Created: ${VERSION_KO_JSON}"
+fi
+
+echo ""
+echo "==> Version ${VERSION} created successfully!"
+echo ""
+echo "Files created:"
+echo "  - versioned_docs/version-${VERSION}/"
+echo "  - versioned_sidebars/version-${VERSION}-sidebars.json"
+echo "  - versions.json (updated)"
+[ -d "$VERSION_KO_DIR" ] && echo "  - i18n/ko/.../version-${VERSION}/"
+[ -f "$VERSION_KO_JSON" ] && echo "  - i18n/ko/.../version-${VERSION}.json"
+echo ""
+echo "IMPORTANT: Update docusaurus.config.ts:"
+echo "  lastVersion: '${VERSION}'"
+echo "  versions: {"
+echo "    current: { label: 'Next (unreleased)', path: 'next', banner: 'unreleased' },"
+echo "    '${VERSION}': { label: '${VERSION}', banner: 'none' },"
+echo "  }"

--- a/docs/scripts/generate-agent-docs.mjs
+++ b/docs/scripts/generate-agent-docs.mjs
@@ -13,8 +13,29 @@ import { dirname, join, extname, relative } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const DOCS_DIR = join(__dirname, '..', 'docs');
 const STATIC_DIR = join(__dirname, '..', 'static');
+
+/**
+ * Determine the docs source directory.
+ * If versioned docs exist (versions.json), use the latest versioned snapshot.
+ * Otherwise, fall back to the current docs/ directory.
+ */
+function getDocsDir() {
+  const versionsFile = join(__dirname, '..', 'versions.json');
+  if (existsSync(versionsFile)) {
+    const versions = JSON.parse(readFileSync(versionsFile, 'utf-8'));
+    if (versions.length > 0) {
+      const latestVersion = versions[0];
+      const versionedDir = join(__dirname, '..', 'versioned_docs', `version-${latestVersion}`);
+      if (existsSync(versionedDir)) {
+        return versionedDir;
+      }
+    }
+  }
+  return join(__dirname, '..', 'docs');
+}
+
+const DOCS_DIR = getDocsDir();
 const SITE_URL = 'https://kimsoungryoul.github.io/aerospike-py';
 const BASE_URL = '/docs';
 

--- a/docs/static/llms-full.txt
+++ b/docs/static/llms-full.txt
@@ -3434,7 +3434,7 @@ from aerospike_py import map_operations as map_ops
 import aerospike_py as aerospike
 ```
 
----
+##### List CDT Operations
 
 #### List CDT Operations
 
@@ -3825,7 +3825,7 @@ with aerospike.client({
     print(f"Total scores: {bins['scores']}")
 ```
 
----
+##### Map CDT Operations
 
 #### Map CDT Operations
 


### PR DESCRIPTION
## Summary
- Docusaurus 문서 버전관리 인프라 추가 (`lastVersion`, `versions` 설정, navbar 버전 드롭다운)
- `make docs-version VERSION=X.Y.Z`로 버전 스냅샷 생성 가능 (API 재생성 + i18n 자동 복사)
- `generate-agent-docs.mjs`가 versioned docs 존재 시 최신 버전에서 llms.txt 생성
- Operations 문서의 List/Map CDT Operations를 탭으로 분리하여 가독성 개선

## Test plan
- [x] `npm run build` en/ko 양쪽 빌드 성공 확인
- [x] broken links 에러 없음