### PR TITLE
ci: trigger docs rebuild on GitHub Release publish

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -2,6 +2,8 @@ name: Publish Docs
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- `docs-publish.yaml`에 `release: types: [published]` 트리거 추가
- GitHub Release 게시 시 docs 사이트가 자동으로 재빌드/배포되어 릴리스 노트가 즉시 반영됨
- 기존 `fetch-releases.mjs`가 빌드 시점에 GitHub API에서 최신 릴리스를 가져오므로 추가 스크립트 불필요

## Test plan
- [ ] GitHub에서 테스트 릴리스 생성 후 `Publish Docs` 워크플로우가 자동 트리거되는지 확인
- [ ] 배포된 docs 사이트의 `/releases` 페이지에서 새 릴리스 노트가 표시되는지 확인