### PR TITLE
fix(sample-fastapi): Podman 지원 및 테스트 불일치 수정

### DIFF
--- a/examples/sample-fastapi/app/routers/users.py
+++ b/examples/sample-fastapi/app/routers/users.py
@@ -40,7 +40,7 @@ async def create_user(body: UserCreate, request: Request):
     user_id = uuid.uuid4().hex
     key = _key(user_id)
 
-    bins = body.model_dump()
+    bins = {"user_id": user_id, **body.model_dump()}
     await client.put(key, bins)
 
     _, meta, bins = await client.get(key)
@@ -93,10 +93,17 @@ async def delete_user(user_id: str, request: Request):
 
 @router.get("", response_model=list[UserResponse])
 async def list_users(request: Request):
-    """List all users via batch read of known keys.
-
-    Note: Full namespace scan is no longer supported.
-    This endpoint returns an empty list as a placeholder.
-    In production, maintain a separate index of user IDs.
-    """
-    return []
+    """List all users by scanning the set via query().results()."""
+    client = _get_client(request)
+    records = await client.query(NS, SET).results()
+    result = []
+    for key, meta, bins in records:
+        if bins is None:
+            continue
+        # query()는 aerospike-core 알파 제한으로 user_key=None을 반환하므로
+        # 생성 시 bins에 저장한 user_id를 우선 사용한다.
+        user_id = bins.get("user_id") or (key[2] if key else None)
+        if user_id is None or not isinstance(bins.get("name"), str):
+            continue
+        result.append(_to_response(str(user_id), meta, bins))
+    return result

--- a/examples/sample-fastapi/tests/conftest.py
+++ b/examples/sample-fastapi/tests/conftest.py
@@ -3,17 +3,39 @@ from __future__ import annotations
 import contextlib
 import os
 import socket
+import stat
 import sys
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-import pytest
-from fastapi.testclient import TestClient
-from testcontainers.core.container import DockerContainer
-from testcontainers.core.waiting_utils import wait_for_logs
 
-import aerospike_py
+# Podman 소켓을 우선 사용하고, 없으면 Docker 소켓으로 폴백.
+# testcontainers 임포트 전에 DOCKER_HOST를 설정해야 하므로 최상단에 위치한다.
+def _is_real_socket(p: Path) -> bool:
+    try:
+        return stat.S_ISSOCK(p.stat().st_mode)
+    except OSError:
+        return False
+
+
+if not os.environ.get("DOCKER_HOST") and not _is_real_socket(Path("/var/run/docker.sock")):
+    _podman_candidates = [
+        Path.home() / ".local/share/containers/podman/machine/podman.sock",
+        Path("/run/podman/podman.sock"),
+        Path("/var/run/podman/podman.sock"),
+    ]
+    for _sock in _podman_candidates:
+        if _is_real_socket(_sock):
+            os.environ["DOCKER_HOST"] = f"unix://{_sock}"
+            break
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from testcontainers.core.container import DockerContainer  # noqa: E402
+from testcontainers.core.waiting_utils import wait_for_logs  # noqa: E402
+
+import aerospike_py  # noqa: E402
 
 # Ensure the app package is importable regardless of working directory.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/examples/sample-fastapi/tests/test_users.py
+++ b/examples/sample-fastapi/tests/test_users.py
@@ -65,19 +65,25 @@ def test_delete_user(client, aerospike_client, cleanup):
 
 
 def test_delete_user_not_found(client):
-    # Aerospike remove() does not raise RecordNotFound by default,
-    # so this returns 200 with a success message.
+    # aerospike-py remove()는 존재하지 않는 키에 대해 RecordNotFound를 발생시키므로
+    # 라우터가 404를 반환한다.
     resp = client.delete("/users/nonexistent-del-xyz")
 
-    assert resp.status_code == 200
+    assert resp.status_code == 404
 
 
-def test_list_users(client, aerospike_client, cleanup):
-    key1 = ("test", "users", "list-u1")
-    key2 = ("test", "users", "list-u2")
-    aerospike_client.put(key1, {"name": "Alice", "email": "a@b.com", "age": 30})
-    aerospike_client.put(key2, {"name": "Bob", "email": "b@b.com", "age": 25})
-    cleanup.extend([key1, key2])
+def test_list_users(client, cleanup):
+    # API로 생성해야 bins에 user_id가 포함되어 스캔 시 식별 가능하다.
+    r1 = client.post("/users", json={"name": "Alice", "email": "a@b.com", "age": 30})
+    r2 = client.post("/users", json={"name": "Bob", "email": "b@b.com", "age": 25})
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+    cleanup.extend(
+        [
+            ("test", "users", r1.json()["user_id"]),
+            ("test", "users", r2.json()["user_id"]),
+        ]
+    )
 
     resp = client.get("/users")
 


### PR DESCRIPTION
## Summary

- **Podman 소켓 자동 감지**: `/var/run/docker.sock`가 깨진 심볼릭 링크인 경우(Podman 환경에서 흔한 케이스) `~/.local/share/containers/podman/machine/podman.sock` 등 Podman 소켓을 탐색해 `DOCKER_HOST`를 설정한다. `DOCKER_HOST`가 이미 설정된 경우 건드리지 않아 CI 환경도 안전하다.
- **`list_users` 엔드포인트 구현**: 빈 리스트를 반환하던 placeholder를 `query().results()` 기반 실제 세트 스캔으로 교체한다. aerospike-core 2.0.0-alpha.9 의 한계(scan 결과에서 `Record.key = None`)를 우회하기 위해 생성 시 `user_id`를 bins에 함께 저장한다.
- **`test_delete_user_not_found` 수정**: `aerospike-py`의 `remove()`는 존재하지 않는 키에 대해 `RecordNotFound`를 발생시키므로 기대 status code를 `200 → 404`로 수정한다.
- **`test_list_users` 수정**: `aerospike_client.put()` 직접 삽입 대신 `POST /users` API를 통해 유저를 생성해 bins에 `user_id`가 포함되도록 한다.

## Test plan

- [x] `AEROSPIKE_HOST=127.0.0.1 AEROSPIKE_PORT=18710 uv run pytest -v` → 50 passed, 16 skipped (CE Admin skip), 0 failed
- [x] pre-commit hooks (ruff, pyright, cargo fmt/clippy) 모두 통과