### PR TITLE
ci: add docs build verification job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'pyproject.toml'
-      - 'docs/**'
       - '.github/workflows/ci.yaml'
   pull_request:
     branches: [main]
@@ -21,7 +20,6 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'pyproject.toml'
-      - 'docs/**'
       - '.github/workflows/ci.yaml'
 
   workflow_dispatch:
@@ -387,25 +385,3 @@ jobs:
 
       - name: Run compatibility tests
         run: uvx --with tox-uv tox -e compat
-
-  docs-check:
-    name: Docs Build Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          cache: npm
-          cache-dependency-path: docs/package-lock.json
-
-      - name: Install dependencies
-        working-directory: docs
-        run: npm ci
-
-      - name: Build docs
-        working-directory: docs
-        run: npm run build

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+
+jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
## Summary
- CI에 `docs-check` job 추가: `npm run build`로 문서 빌드 검증
- broken link 자동 감지

## Test plan
- [x] CI workflow syntax 검증