### PR TITLE
ci: add benchmark workflow for performance regression tracking

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -28,7 +28,7 @@ jobs:
 
     services:
       aerospike:
-        image: aerospike/aerospike-server:latest
+        image: aerospike/aerospike-server:7.2
         ports:
           - 3000:3000
           - 3001:3001
@@ -45,7 +45,7 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
           enable-cache: true
@@ -105,7 +105,8 @@ jobs:
               }
               const results = JSON.parse(fs.readFileSync(path.join(dir, files[0]), 'utf8'));
 
-              let body = '## Benchmark Results\n\n';
+              const marker = '<!-- benchmark-results -->';
+              let body = marker + '\n## Benchmark Results\n\n';
 
               const sections = [
                 ['aerospike_py_sync', 'aerospike-py (Sync)'],
@@ -136,12 +137,29 @@ jobs:
               body += `> **Config**: ${env.count || 'N/A'} ops/round, ${env.rounds || 'N/A'} rounds, concurrency ${env.concurrency || 'N/A'}\n`;
               body += '> Benchmark run on `ubuntu-latest`. Results may vary.';
 
-              await github.rest.issues.createComment({
+              // Find existing comment with marker
+              const { data: comments } = await github.rest.issues.listComments({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: body
               });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  comment_id: existing.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body
+                });
+              }
             } catch (e) {
               console.log('Could not parse benchmark results:', e.message);
             }


### PR DESCRIPTION
## Summary
- PR에 벤치마크 결과를 자동으로 코멘트하는 GitHub Actions 워크플로우 추가
- Rust/Python 소스 변경 시에만 트리거
- 기존 코멘트를 업데이트하는 방식으로 PR 코멘트 스팸 방지

## Changes from original PR #191
- `actions/checkout@v4` (v6 → v4)
- `astral-sh/setup-uv@v5` (v7 → v5)
- Aerospike 서버 이미지 `7.2`로 고정 (latest → 7.2)
- PR 코멘트 find-and-update 패턴 적용 (`<!-- benchmark-results -->` 마커)

## Test plan
- [ ] Workflow YAML 문법 검증
- [ ] 실제 PR에서 벤치마크 트리거 확인