### PR TITLE
feat(client): add get_server_version() convenience method

### DIFF
--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -147,6 +147,22 @@ class Client:
         """
         ...
 
+    def get_server_version(self) -> str:
+        """Return the Aerospike server build version string.
+
+        Convenience wrapper around ``info_random_node("build")``.
+
+        Returns:
+            The server version string (e.g. ``"8.1.0.3"``).
+
+        Example:
+            ```python
+            version = client.get_server_version()
+            print(version)  # "8.1.0.3"
+            ```
+        """
+        ...
+
     # -- Info --
 
     def info_all(
@@ -1070,6 +1086,22 @@ class AsyncClient:
         Example:
             ```python
             nodes = client.get_node_names()
+            ```
+        """
+        ...
+
+    async def get_server_version(self) -> str:
+        """Return the Aerospike server build version string.
+
+        Convenience wrapper around ``info_random_node("build")``.
+
+        Returns:
+            The server version string (e.g. ``"8.1.0.3"``).
+
+        Example:
+            ```python
+            version = await client.get_server_version()
+            print(version)  # "8.1.0.3"
             ```
         """
         ...

--- a/src/aerospike_py/_async_client.py
+++ b/src/aerospike_py/_async_client.py
@@ -234,6 +234,27 @@ class AsyncClient:
     def get_node_names(self) -> list[str]:
         return self._inner.get_node_names()
 
+    @catch_unexpected("AsyncClient.get_server_version")
+    async def get_server_version(self) -> str:
+        """Return the Aerospike server build version string.
+
+        Convenience wrapper around ``info_random_node("build")``.
+
+        Returns:
+            The server version string (e.g. ``"8.1.0.3"``).
+
+        Example:
+            ```python
+            version = await client.get_server_version()
+            print(version)  # "8.1.0.3"
+            ```
+        """
+        response = await self.info_random_node("build")
+        try:
+            return response.split("\t")[1].strip()
+        except IndexError:
+            return response.strip()
+
     @catch_unexpected("AsyncClient.info_random_node")
     async def info_random_node(self, command, policy=None) -> str:
         return await self._inner.info_random_node(command, policy)

--- a/src/aerospike_py/_client.py
+++ b/src/aerospike_py/_client.py
@@ -370,6 +370,27 @@ class Client(_NativeClient):
     def get_node_names(self) -> list[str]:
         return super().get_node_names()
 
+    @catch_unexpected("Client.get_server_version")
+    def get_server_version(self) -> str:
+        """Return the Aerospike server build version string.
+
+        Convenience wrapper around ``info_random_node("build")``.
+
+        Returns:
+            The server version string (e.g. ``"8.1.0.3"``).
+
+        Example:
+            ```python
+            version = client.get_server_version()
+            print(version)  # "8.1.0.3"
+            ```
+        """
+        response = self.info_random_node("build")
+        try:
+            return response.split("\t")[1].strip()
+        except IndexError:
+            return response.strip()
+
     # -- Query --
 
     def query(self, namespace, set_name) -> Query:

--- a/tests/unit/test_server_version.py
+++ b/tests/unit/test_server_version.py
@@ -1,0 +1,62 @@
+"""Unit tests for get_server_version() (no server required)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import aerospike_py
+from aerospike_py._async_client import AsyncClient
+from tests import DUMMY_CONFIG
+
+
+class TestClientGetServerVersion:
+    """Sync Client.get_server_version() tests."""
+
+    def test_parses_standard_response(self):
+        """Extracts version from standard 'build\\t8.1.0.3\\n' format."""
+        with patch.object(aerospike_py.Client, "info_random_node", return_value="build\t8.1.0.3\n"):
+            c = aerospike_py.client(DUMMY_CONFIG)
+            assert c.get_server_version() == "8.1.0.3"
+
+    def test_strips_whitespace(self):
+        """Strips trailing whitespace/newlines from parsed version."""
+        with patch.object(aerospike_py.Client, "info_random_node", return_value="build\t7.0.0.0  \n"):
+            c = aerospike_py.client(DUMMY_CONFIG)
+            assert c.get_server_version() == "7.0.0.0"
+
+    def test_fallback_on_unexpected_format(self):
+        """Falls back to stripped response when no tab separator found."""
+        with patch.object(aerospike_py.Client, "info_random_node", return_value="8.1.0.3\n"):
+            c = aerospike_py.client(DUMMY_CONFIG)
+            assert c.get_server_version() == "8.1.0.3"
+
+    def test_empty_response(self):
+        """Handles empty response gracefully."""
+        with patch.object(aerospike_py.Client, "info_random_node", return_value=""):
+            c = aerospike_py.client(DUMMY_CONFIG)
+            assert c.get_server_version() == ""
+
+
+class TestAsyncClientGetServerVersion:
+    """Async AsyncClient.get_server_version() tests."""
+
+    @pytest.mark.asyncio
+    async def test_parses_standard_response(self):
+        """Extracts version from standard 'build\\t8.1.0.3\\n' format."""
+        with patch.object(AsyncClient, "info_random_node", new_callable=AsyncMock, return_value="build\t8.1.0.3\n"):
+            c = AsyncClient(DUMMY_CONFIG)
+            assert await c.get_server_version() == "8.1.0.3"
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_unexpected_format(self):
+        """Falls back to stripped response when no tab separator found."""
+        with patch.object(AsyncClient, "info_random_node", new_callable=AsyncMock, return_value="8.1.0.3\n"):
+            c = AsyncClient(DUMMY_CONFIG)
+            assert await c.get_server_version() == "8.1.0.3"
+
+    @pytest.mark.asyncio
+    async def test_empty_response(self):
+        """Handles empty response gracefully."""
+        with patch.object(AsyncClient, "info_random_node", new_callable=AsyncMock, return_value=""):
+            c = AsyncClient(DUMMY_CONFIG)
+            assert await c.get_server_version() == ""


### PR DESCRIPTION
## Summary
- Add `get_server_version()` to `Client` and `AsyncClient` as a convenience wrapper around `info_random_node("build")`
- Update `.pyi` type stubs for both sync and async clients
- Add unit tests with mocked `info_random_node` responses (7 test cases)

Closes #245

## Test plan
- [x] `uv run pytest tests/unit/test_server_version.py -v` — all 7 tests pass
- [x] `ruff check` — no lint issues
- [x] `pyright` — 0 errors
- [ ] Integration test with live Aerospike server (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)