### PR TITLE
feat(client): add ping() health check method

### DIFF
--- a/docs/docs/guides/config/client-config.md
+++ b/docs/docs/guides/config/client-config.md
@@ -128,6 +128,27 @@ for r in results:
 version: str = client.info_random_node("build")
 ```
 
+## Health Check
+
+The client provides two ways to check cluster health:
+
+- **`is_connected()`** — checks local state only (no I/O). Fast but may return `True` even if the cluster is temporarily unreachable.
+- **`ping()`** — sends a lightweight `info("build")` command to a random node. Performs an actual network round-trip to verify liveness. Returns `True` if the node responds, `False` otherwise (never raises).
+
+```python
+# Kubernetes readiness probe / load-balancer health check
+if client.ping():
+    return {"status": "healthy"}
+
+# Async health endpoint (e.g., FastAPI)
+@app.get("/health")
+async def health():
+    ok = await async_client.ping()
+    return {"status": "ok" if ok else "degraded"}
+```
+
+The background **tend** process (configured via `tend_interval`, default 1000 ms) automatically monitors cluster membership and connection health. `ping()` complements this by providing on-demand verification.
+
 ## Sync vs Async
 
 <Tabs>

--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -113,6 +113,17 @@ impl PyAsyncClient {
         self.inner.load().is_some()
     }
 
+    /// Lightweight health check: returns `True` if a random node responds.
+    fn ping<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.inner.load_full();
+        future_into_py(py, async move {
+            match client {
+                Some(c) => Ok(client_ops::do_ping(&c).await),
+                None => Ok(false),
+            }
+        })
+    }
+
     /// Close connection (async).
     fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         info!("Closing async client connection");

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -111,6 +111,14 @@ impl PyClient {
         }
     }
 
+    /// Lightweight health check: returns `True` if a random node responds.
+    fn ping(&self, py: Python<'_>) -> bool {
+        match &self.inner {
+            Some(client) => py.detach(|| RUNTIME.block_on(client_ops::do_ping(client))),
+            None => false,
+        }
+    }
+
     /// Close the connection to the cluster
     fn close(&mut self, py: Python<'_>) -> PyResult<()> {
         info!("Closing client connection");

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -437,6 +437,17 @@ pub async fn do_info_random_node(client: &AsClient, args: &InfoArgs) -> PyResult
     Ok(map.get(&args.command).cloned().unwrap_or_default())
 }
 
+/// Lightweight health check: send `info("build")` to a random node.
+/// Returns `true` if the node responds, `false` otherwise.
+pub async fn do_ping(client: &AsClient) -> bool {
+    let node = match client.cluster.get_random_node() {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+    let policy = aerospike_core::AdminPolicy::default();
+    node.info(&policy, &["build"]).await.is_ok()
+}
+
 // ── Truncate ────────────────────────────────────────────────────────────────
 
 /// Truncate records in a namespace/set.

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -120,6 +120,29 @@ class Client:
         """
         ...
 
+    def ping(self) -> bool:
+        """Lightweight health check that verifies cluster liveness.
+
+        Sends an ``info("build")`` command to a random cluster node and
+        returns whether the node responded successfully. Unlike
+        ``is_connected()`` which only checks local state, this method
+        performs an actual network round-trip.
+
+        Useful for Kubernetes readiness probes, load-balancer health
+        checks, and connection-pool validation.
+
+        Returns:
+            ``True`` if a cluster node responded, ``False`` otherwise
+            (including when the client is not connected).
+
+        Example:
+            ```python
+            if client.ping():
+                print("Cluster is reachable")
+            ```
+        """
+        ...
+
     def close(self) -> None:
         """Close the connection to the cluster.
 
@@ -1047,6 +1070,29 @@ class AsyncClient:
             ```python
             if client.is_connected():
                 print("Connected")
+            ```
+        """
+        ...
+
+    async def ping(self) -> bool:
+        """Lightweight health check that verifies cluster liveness.
+
+        Sends an ``info("build")`` command to a random cluster node and
+        returns whether the node responded successfully. Unlike
+        ``is_connected()`` which only checks local state, this method
+        performs an actual network round-trip.
+
+        Useful for Kubernetes readiness probes, load-balancer health
+        checks, and connection-pool validation.
+
+        Returns:
+            ``True`` if a cluster node responded, ``False`` otherwise
+            (including when the client is not connected).
+
+        Example:
+            ```python
+            if await client.ping():
+                print("Cluster is reachable")
             ```
         """
         ...

--- a/src/aerospike_py/_async_client.py
+++ b/src/aerospike_py/_async_client.py
@@ -226,6 +226,10 @@ class AsyncClient:
         raw = await self._inner.batch_remove(keys, policy)
         return BatchRecordsTuple(batch_records=[_wrap_batch_record(br) for br in raw.batch_records])
 
+    @catch_unexpected("AsyncClient.ping")
+    async def ping(self) -> bool:
+        return await self._inner.ping()
+
     @catch_unexpected("AsyncClient.is_connected")
     def is_connected(self) -> bool:
         return self._inner.is_connected()

--- a/src/aerospike_py/_client.py
+++ b/src/aerospike_py/_client.py
@@ -362,6 +362,10 @@ class Client(_NativeClient):
 
     # -- Utility --
 
+    @catch_unexpected("Client.ping")
+    def ping(self) -> bool:
+        return super().ping()
+
     @catch_unexpected("Client.is_connected")
     def is_connected(self) -> bool:
         return super().is_connected()

--- a/tests/integration/test_health_check.py
+++ b/tests/integration/test_health_check.py
@@ -1,0 +1,46 @@
+"""Integration tests for ping() health check (requires Aerospike server)."""
+
+import pytest
+
+import aerospike_py
+from tests import AEROSPIKE_CONFIG
+
+
+class TestPing:
+    def test_ping_returns_true_when_connected(self, client):
+        """ping() returns True on a connected client."""
+        assert client.ping() is True
+
+    def test_ping_returns_false_when_not_connected(self):
+        """ping() returns False on an unconnected client (no exception)."""
+        c = aerospike_py.client(AEROSPIKE_CONFIG)
+        assert c.ping() is False
+
+    def test_ping_returns_false_after_close(self):
+        """ping() returns False after client.close()."""
+        c = aerospike_py.client(AEROSPIKE_CONFIG).connect()
+        assert c.ping() is True
+        c.close()
+        assert c.ping() is False
+
+
+class TestAsyncPing:
+    @pytest.mark.asyncio
+    async def test_async_ping_returns_true_when_connected(self, async_client):
+        """Async ping() returns True on a connected client."""
+        assert await async_client.ping() is True
+
+    @pytest.mark.asyncio
+    async def test_async_ping_returns_false_when_not_connected(self):
+        """Async ping() returns False on an unconnected client."""
+        c = aerospike_py.AsyncClient(AEROSPIKE_CONFIG)
+        assert await c.ping() is False
+
+    @pytest.mark.asyncio
+    async def test_async_ping_returns_false_after_close(self):
+        """Async ping() returns False after client.close()."""
+        c = aerospike_py.AsyncClient(AEROSPIKE_CONFIG)
+        await c.connect()
+        assert await c.ping() is True
+        await c.close()
+        assert await c.ping() is False

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -22,3 +22,8 @@ class TestInfoNotConnected:
             assert False, "Should have raised ClientError"
         except aerospike_py.ClientError:
             pass
+
+    def test_ping_returns_false_when_not_connected(self):
+        """ping() on unconnected client returns False (no exception)."""
+        c = aerospike_py.client(DUMMY_CONFIG)
+        assert c.ping() is False


### PR DESCRIPTION
## Summary
- Add lightweight `ping()` method to both `Client` and `AsyncClient` that sends `info("build")` to a random node to verify cluster liveness
- Returns `bool` (True/False) without raising exceptions — ideal for K8s readiness probes, load balancer health checks, and connection pool validation
- Unlike `is_connected()` which only checks local state, `ping()` performs an actual network round-trip

## Changes
| File | Description |
|------|-------------|
| `rust/src/client_ops.rs` | Add `do_ping()` async fn |
| `rust/src/client.rs` | Add `ping()` to sync `PyClient` |
| `rust/src/async_client.rs` | Add `ping()` to async `PyAsyncClient` |
| `src/aerospike_py/_client.py` | Add `ping()` Python wrapper (sync) |
| `src/aerospike_py/_async_client.py` | Add `ping()` Python wrapper (async) |
| `src/aerospike_py/__init__.pyi` | Add type stubs for both clients |
| `tests/unit/test_info.py` | Unit test: `ping()` returns False when not connected |
| `tests/integration/test_health_check.py` | Integration tests: connected, disconnected, after close |
| `docs/docs/guides/config/client-config.md` | Document health check usage patterns |

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] `make test-unit` — unit test verifies `ping()` returns `False` on unconnected client
- [ ] `make test-integration` — integration tests verify `ping()` returns `True` on connected client, `False` after close
- [ ] `make typecheck` — type stubs are consistent

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)