### PR TITLE
fix(batch): apply TTL from policy and per-record meta in batch_write

### DIFF
--- a/docs/docs/api/client.md
+++ b/docs/docs/api/client.md
@@ -802,13 +802,15 @@ for br in results.batch_records:
 
 ### `batch_write(records, policy=None, retry=0)`
 
-Write multiple records with per-record bins in a single batch call. Each record is a `(key, bins)` tuple where bins is a dict. Unlike `batch_operate()` which applies the same operations to all keys, each record can have different bins.
+Write multiple records with per-record bins in a single batch call. Each record is a `(key, bins)` or `(key, bins, meta)` tuple. Unlike `batch_operate()` which applies the same operations to all keys, each record can have different bins and TTL.
 
 | Parameter | Description |
 |-----------|-------------|
-| `records` | List of ``(key, bins)`` tuples. Key is ``(namespace, set, primary_key)``, bins is a dict. |
-| `policy` | Optional [`BatchPolicy`](types.md#batchpolicy) dict. |
+| `records` | List of ``(key, bins)`` or ``(key, bins, meta)`` tuples. Key is ``(namespace, set, primary_key)``, bins is a dict, meta is an optional [`WriteMeta`](types.md#writemeta) dict (e.g. ``{"ttl": 300}``). |
+| `policy` | Optional [`BatchPolicy`](types.md#batchpolicy) dict. Supports ``"ttl"`` key for batch-level TTL (seconds). |
 | `retry` | Max retries for transient failures (default ``0``). Failed records are retried with exponential backoff. |
+
+**TTL precedence:** Per-record `meta["ttl"]` overrides batch-level `policy["ttl"]`. Records without meta use the batch-level TTL (or namespace default if unset).
 
 **Returns:** ``BatchRecords`` with per-record result codes. Each ``BatchRecord`` includes an ``in_doubt`` flag indicating whether the write may have completed despite the error.
 
@@ -821,9 +823,16 @@ records = [
     (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
 ]
 results = client.batch_write(records, retry=3)
-for br in results.batch_records:
-    if br.result != 0:
-        print(f"Failed: {br.key}, code={br.result}, in_doubt={br.in_doubt}")
+
+# With batch-level TTL (30 days)
+results = client.batch_write(records, policy={"ttl": 2592000})
+
+# With per-record TTL
+records_with_ttl = [
+    (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 3600}),
+    (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
+]
+results = client.batch_write(records_with_ttl)
 ```
 
   </TabItem>
@@ -835,9 +844,16 @@ records = [
     (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
 ]
 results = await client.batch_write(records, retry=3)
-for br in results.batch_records:
-    if br.result != 0:
-        print(f"Failed: {br.key}, code={br.result}, in_doubt={br.in_doubt}")
+
+# With batch-level TTL (30 days)
+results = await client.batch_write(records, policy={"ttl": 2592000})
+
+# With per-record TTL
+records_with_ttl = [
+    (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 3600}),
+    (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
+]
+results = await client.batch_write(records_with_ttl)
 ```
 
   </TabItem>

--- a/docs/docs/guides/crud/write.md
+++ b/docs/docs/guides/crud/write.md
@@ -176,6 +176,56 @@ for br in results.batch_records:
   </TabItem>
 </Tabs>
 
+### Batch Write with TTL
+
+TTL can be set at two levels:
+
+- **Batch-level**: `policy={"ttl": N}` applies to all records in the batch.
+- **Per-record**: `(key, bins, {"ttl": N})` overrides the batch-level TTL for that specific record.
+
+<Tabs>
+  <TabItem value="sync" label="Sync" default>
+
+```python
+# Batch-level TTL — all records expire in 30 days
+results = client.batch_write(records, policy={"ttl": 2592000})
+
+# Per-record TTL — each record has its own expiration
+records_with_ttl = [
+    (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 3600}),     # 1 hour
+    (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),      # 1 day
+    (("test", "demo", "user3"), {"name": "Charlie"}),                   # namespace default
+]
+results = client.batch_write(records_with_ttl)
+
+# Mix: batch-level default + per-record override
+results = client.batch_write(
+    [
+        (("test", "demo", "user1"), {"name": "Alice"}),                 # uses batch-level TTL
+        (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 3600}),   # overrides to 1 hour
+    ],
+    policy={"ttl": 86400},  # default: 1 day
+)
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async">
+
+```python
+# Batch-level TTL
+results = await client.batch_write(records, policy={"ttl": 2592000})
+
+# Per-record TTL
+records_with_ttl = [
+    (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 3600}),
+    (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
+]
+results = await client.batch_write(records_with_ttl)
+```
+
+  </TabItem>
+</Tabs>
+
 **Retry with auto-recovery:** Records that fail with transient errors (timeout, device overload, key busy) are automatically retried with exponential backoff:
 
 <Tabs>

--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -775,7 +775,11 @@ impl PyAsyncClient {
         let client = self.get_client()?;
         let limiter = self.limiter.clone();
         let args = client_common::prepare_batch_write_args(
-            py, records, policy, retry, &self.connection_info,
+            py,
+            records,
+            policy,
+            retry,
+            &self.connection_info,
         )?;
 
         future_into_py(py, async move {
@@ -821,9 +825,14 @@ impl PyAsyncClient {
         let parent_ctx = client_common::extract_parent_context(py);
         let conn_info = self.connection_info.clone();
 
-        let records = crate::numpy_support::numpy_to_records(
+        let raw_records = crate::numpy_support::numpy_to_records(
             py, data, _dtype, namespace, set_name, key_field,
         )?;
+        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy, None)?;
+        let records: Vec<_> = raw_records
+            .into_iter()
+            .map(|(k, b)| (k, b, write_policy.clone()))
+            .collect();
 
         let ns = namespace.to_string();
         let set = set_name.to_string();

--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -828,7 +828,7 @@ impl PyAsyncClient {
         let raw_records = crate::numpy_support::numpy_to_records(
             py, data, _dtype, namespace, set_name, key_field,
         )?;
-        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy, None)?;
+        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy)?;
         let records: Vec<_> = raw_records
             .into_iter()
             .map(|(k, b)| (k, b, write_policy.clone()))

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1186,7 +1186,11 @@ impl PyClient {
         debug!("batch_write: records_count={}", records.len());
         let client = self.get_client()?.clone();
         let args = client_common::prepare_batch_write_args(
-            py, records, policy, retry, &self.connection_info,
+            py,
+            records,
+            policy,
+            retry,
+            &self.connection_info,
         )?;
         let limiter = self.limiter.clone();
         let results = py.detach(|| {
@@ -1238,9 +1242,14 @@ impl PyClient {
         let parent_ctx = client_common::extract_parent_context(py);
         let conn_info = self.connection_info.clone();
 
-        let records = crate::numpy_support::numpy_to_records(
+        let raw_records = crate::numpy_support::numpy_to_records(
             py, data, _dtype, namespace, set_name, key_field,
         )?;
+        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy, None)?;
+        let records: Vec<_> = raw_records
+            .into_iter()
+            .map(|(k, b)| (k, b, write_policy.clone()))
+            .collect();
 
         let ns = namespace.to_string();
         let set = set_name.to_string();

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1245,7 +1245,7 @@ impl PyClient {
         let raw_records = crate::numpy_support::numpy_to_records(
             py, data, _dtype, namespace, set_name, key_field,
         )?;
-        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy, None)?;
+        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy)?;
         let records: Vec<_> = raw_records
             .into_iter()
             .map(|(k, b)| (k, b, write_policy.clone()))

--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use crate::policy::batch_policy::parse_batch_write_policy;
+use crate::policy::batch_policy::{apply_record_meta, parse_batch_write_policy};
 use aerospike_core::{
     operations::Operation, BatchDeletePolicy, BatchOperation, BatchReadPolicy, BatchWritePolicy,
     Bin, Bins, Key, ReadPolicy, UDFLang, Value, WritePolicy,
@@ -634,6 +634,8 @@ pub fn prepare_batch_write_args(
     conn_info: &Arc<ConnectionInfo>,
 ) -> PyResult<BatchWriteGenericArgs> {
     let batch_policy = parse_batch_policy(policy)?;
+    // Parse batch-level write policy once (TTL default for all records)
+    let base_write_policy = parse_batch_write_policy(policy)?;
     let mut rust_records = Vec::with_capacity(records.len());
 
     for item in records.iter() {
@@ -652,24 +654,16 @@ pub fn prepare_batch_write_args(
             .map_err(|_| pyo3::exceptions::PyTypeError::new_err("bins element must be a dict"))?;
         let bins = py_dict_to_bins(bins_dict)?;
 
-        // Parse per-record meta from optional 3rd tuple element
-        let meta = if tuple.len() >= 3 {
+        // Per-record meta (3rd tuple element) overrides batch-level TTL
+        let write_policy = if tuple.len() >= 3 {
             let meta_obj = tuple.get_item(2)?;
-            Some(
-                meta_obj
-                    .cast::<PyDict>()
-                    .map_err(|_| {
-                        pyo3::exceptions::PyTypeError::new_err("meta element must be a dict")
-                    })?
-                    .clone(),
-            )
+            let meta_dict = meta_obj.cast::<PyDict>().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err("meta element must be a dict")
+            })?;
+            apply_record_meta(&base_write_policy, meta_dict)?
         } else {
-            None
+            base_write_policy.clone()
         };
-
-        // Build per-record write policy: batch-level policy TTL as default,
-        // per-record meta TTL overrides
-        let write_policy = parse_batch_write_policy(policy, meta.as_ref())?;
 
         rust_records.push((key, bins, write_policy));
     }

--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use crate::policy::batch_policy::parse_batch_write_policy;
 use aerospike_core::{
     operations::Operation, BatchDeletePolicy, BatchOperation, BatchReadPolicy, BatchWritePolicy,
     Bin, Bins, Key, ReadPolicy, UDFLang, Value, WritePolicy,
@@ -617,7 +618,7 @@ impl BatchRemoveArgs {
 // ── batch_write (generic) ───────────────────────────────────────────────────
 
 pub struct BatchWriteGenericArgs {
-    pub records: Vec<(Key, Vec<Bin>)>,
+    pub records: Vec<(Key, Vec<Bin>, BatchWritePolicy)>,
     pub batch_policy: aerospike_core::BatchPolicy,
     pub batch_ns: String,
     pub batch_set: String,
@@ -637,9 +638,7 @@ pub fn prepare_batch_write_args(
 
     for item in records.iter() {
         let tuple = item.cast::<PyTuple>().map_err(|_| {
-            pyo3::exceptions::PyTypeError::new_err(
-                "Each record must be a tuple of (key, bins)",
-            )
+            pyo3::exceptions::PyTypeError::new_err("Each record must be a tuple of (key, bins)")
         })?;
         if tuple.len() < 2 {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -648,16 +647,36 @@ pub fn prepare_batch_write_args(
         }
         let key = py_to_key(&tuple.get_item(0)?)?;
         let bins_obj = tuple.get_item(1)?;
-        let bins_dict = bins_obj.cast::<PyDict>().map_err(|_| {
-            pyo3::exceptions::PyTypeError::new_err("bins element must be a dict")
-        })?;
+        let bins_dict = bins_obj
+            .cast::<PyDict>()
+            .map_err(|_| pyo3::exceptions::PyTypeError::new_err("bins element must be a dict"))?;
         let bins = py_dict_to_bins(bins_dict)?;
-        rust_records.push((key, bins));
+
+        // Parse per-record meta from optional 3rd tuple element
+        let meta = if tuple.len() >= 3 {
+            let meta_obj = tuple.get_item(2)?;
+            Some(
+                meta_obj
+                    .cast::<PyDict>()
+                    .map_err(|_| {
+                        pyo3::exceptions::PyTypeError::new_err("meta element must be a dict")
+                    })?
+                    .clone(),
+            )
+        } else {
+            None
+        };
+
+        // Build per-record write policy: batch-level policy TTL as default,
+        // per-record meta TTL overrides
+        let write_policy = parse_batch_write_policy(policy, meta.as_ref())?;
+
+        rust_records.push((key, bins, write_policy));
     }
 
     let (batch_ns, batch_set) = rust_records
         .first()
-        .map(|(k, _)| (k.namespace.clone(), k.set_name.clone()))
+        .map(|(k, _, _)| (k.namespace.clone(), k.set_name.clone()))
         .unwrap_or_default();
 
     Ok(BatchWriteGenericArgs {

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -300,7 +300,11 @@ fn compute_backoff_ms(attempt: u32, base_ms: u64, cap_ms: u64) -> u64 {
 pub async fn do_batch_write(
     client: &AsClient,
     batch_policy: &aerospike_core::BatchPolicy,
-    records: &[(aerospike_core::Key, Vec<aerospike_core::Bin>)],
+    records: &[(
+        aerospike_core::Key,
+        Vec<aerospike_core::Bin>,
+        BatchWritePolicy,
+    )],
     ns: &str,
     set: &str,
     parent_ctx: client_common::ParentContext,
@@ -308,15 +312,13 @@ pub async fn do_batch_write(
     max_retries: u32,
     op_name: &str,
 ) -> PyResult<Vec<BatchRecord>> {
-    let write_policy = BatchWritePolicy::default();
-
-    // Build initial batch operations
+    // Build initial batch operations using per-record write policies
     let batch_ops: Vec<BatchOperation> = records
         .iter()
-        .map(|(key, bins)| {
+        .map(|(key, bins, write_policy)| {
             let ops: Vec<aerospike_core::operations::Operation> =
                 bins.iter().map(aerospike_core::operations::put).collect();
-            BatchOperation::write(&write_policy, key.clone(), ops)
+            BatchOperation::write(write_policy, key.clone(), ops)
         })
         .collect();
 
@@ -373,10 +375,10 @@ pub async fn do_batch_write(
         let retry_ops: Vec<BatchOperation> = retry_indices
             .iter()
             .map(|&i| {
-                let (key, bins) = &records[i];
+                let (key, bins, write_policy) = &records[i];
                 let ops: Vec<aerospike_core::operations::Operation> =
                     bins.iter().map(aerospike_core::operations::put).collect();
-                BatchOperation::write(&write_policy, key.clone(), ops)
+                BatchOperation::write(write_policy, key.clone(), ops)
             })
             .collect();
 
@@ -437,10 +439,7 @@ pub async fn do_info_all(
 
 /// Send an info command to a random node.
 pub async fn do_info_random_node(client: &AsClient, args: &InfoArgs) -> PyResult<String> {
-    let node = client
-        .cluster
-        .get_random_node()
-        .map_err(as_to_pyerr)?;
+    let node = client.cluster.get_random_node().map_err(as_to_pyerr)?;
     let map = node
         .info(&args.admin_policy, &[&args.command])
         .await
@@ -797,7 +796,10 @@ mod tests {
             let max_expected = std::cmp::min(10u64 * (1u64 << attempt), 500);
             for _ in 0..1000 {
                 let val = compute_backoff_ms(attempt, 10, 500);
-                assert!(val <= max_expected, "attempt={attempt}, val={val}, max={max_expected}");
+                assert!(
+                    val <= max_expected,
+                    "attempt={attempt}, val={val}, max={max_expected}"
+                );
             }
         }
     }

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -337,20 +337,18 @@ pub async fn do_batch_write(
     }
 
     // Retry loop: only retry records with retryable error codes
+    let mut retry_indices: Vec<usize> = Vec::new();
     for attempt in 0..max_retries {
         // Find indices of failed records that are retryable
-        let retry_indices: Vec<usize> = results
-            .iter()
-            .enumerate()
-            .filter_map(|(i, br)| {
-                if let Some(rc) = &br.result_code {
-                    if *rc != aerospike_core::ResultCode::Ok && is_retryable_result_code(rc) {
-                        return Some(i);
-                    }
+        retry_indices.clear();
+        retry_indices.extend(results.iter().enumerate().filter_map(|(i, br)| {
+            if let Some(rc) = &br.result_code {
+                if *rc != aerospike_core::ResultCode::Ok && is_retryable_result_code(rc) {
+                    return Some(i);
                 }
-                None
-            })
-            .collect();
+            }
+            None
+        }));
 
         if retry_indices.is_empty() {
             log::debug!(
@@ -411,10 +409,10 @@ pub async fn do_batch_write(
                 retry_results.len()
             );
         }
-        for (retry_pos, &original_idx) in retry_indices.iter().enumerate() {
-            if retry_pos < retry_results.len() {
-                results[original_idx] = retry_results[retry_pos].clone();
-            }
+        for (original_idx, retry_record) in
+            retry_indices.iter().copied().zip(retry_results.into_iter())
+        {
+            results[original_idx] = retry_record;
         }
     }
 

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -34,8 +34,10 @@ pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<B
 
 /// Parse a Python policy/meta dict into a [`BatchWritePolicy`] with TTL support.
 ///
-/// `meta` takes precedence over `policy_dict` for the `"ttl"` key, mirroring
-/// the behavior of [`parse_write_policy()`](super::write_policy::parse_write_policy).
+/// `policy_dict` provides the batch-level default TTL; `meta` (per-record)
+/// overrides it. Note: this is the **inverse** of
+/// [`parse_write_policy()`](super::write_policy::parse_write_policy), where
+/// `policy_dict` takes precedence over `meta`.
 pub fn parse_batch_write_policy(
     policy_dict: Option<&Bound<'_, PyDict>>,
     meta: Option<&Bound<'_, PyDict>>,

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -1,10 +1,11 @@
 //! Batch policy parsing from Python dicts.
 
-use aerospike_core::BatchPolicy;
+use aerospike_core::{BatchPolicy, BatchWritePolicy};
 use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use super::write_policy::parse_ttl;
 use super::{extract_filter_expression, extract_policy_fields};
 
 /// Parse a Python policy dict into a BatchPolicy
@@ -27,6 +28,34 @@ pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<B
     });
 
     policy.filter_expression = extract_filter_expression(dict)?;
+
+    Ok(policy)
+}
+
+/// Parse a Python policy/meta dict into a [`BatchWritePolicy`] with TTL support.
+///
+/// `meta` takes precedence over `policy_dict` for the `"ttl"` key, mirroring
+/// the behavior of [`parse_write_policy()`](super::write_policy::parse_write_policy).
+pub fn parse_batch_write_policy(
+    policy_dict: Option<&Bound<'_, PyDict>>,
+    meta: Option<&Bound<'_, PyDict>>,
+) -> PyResult<BatchWritePolicy> {
+    trace!("Parsing batch write policy");
+    let mut policy = BatchWritePolicy::default();
+
+    // Apply batch-level policy dict first (default for all records)
+    if let Some(dict) = policy_dict {
+        if let Some(val) = dict.get_item("ttl")? {
+            policy.expiration = parse_ttl(val.extract::<i64>()?)?;
+        }
+    }
+
+    // Apply per-record meta — overrides batch-level TTL
+    if let Some(meta_dict) = meta {
+        if let Some(ttl) = meta_dict.get_item("ttl")? {
+            policy.expiration = parse_ttl(ttl.extract::<i64>()?)?;
+        }
+    }
 
     Ok(policy)
 }

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -32,32 +32,34 @@ pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<B
     Ok(policy)
 }
 
-/// Parse a Python policy/meta dict into a [`BatchWritePolicy`] with TTL support.
+/// Parse the batch-level policy dict into a [`BatchWritePolicy`] with TTL.
 ///
-/// `policy_dict` provides the batch-level default TTL; `meta` (per-record)
-/// overrides it. Note: this is the **inverse** of
-/// [`parse_write_policy()`](super::write_policy::parse_write_policy), where
-/// `policy_dict` takes precedence over `meta`.
+/// Call once before iterating records. Use
+/// [`apply_record_meta`] to override per-record TTL on a clone of the result.
 pub fn parse_batch_write_policy(
     policy_dict: Option<&Bound<'_, PyDict>>,
-    meta: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<BatchWritePolicy> {
     trace!("Parsing batch write policy");
     let mut policy = BatchWritePolicy::default();
 
-    // Apply batch-level policy dict first (default for all records)
     if let Some(dict) = policy_dict {
         if let Some(val) = dict.get_item("ttl")? {
             policy.expiration = parse_ttl(val.extract::<i64>()?)?;
         }
     }
 
-    // Apply per-record meta — overrides batch-level TTL
-    if let Some(meta_dict) = meta {
-        if let Some(ttl) = meta_dict.get_item("ttl")? {
-            policy.expiration = parse_ttl(ttl.extract::<i64>()?)?;
-        }
-    }
+    Ok(policy)
+}
 
+/// Apply per-record meta TTL to a [`BatchWritePolicy`], overriding the
+/// batch-level default.
+pub fn apply_record_meta(
+    base: &BatchWritePolicy,
+    meta: &Bound<'_, PyDict>,
+) -> PyResult<BatchWritePolicy> {
+    let mut policy = base.clone();
+    if let Some(ttl) = meta.get_item("ttl")? {
+        policy.expiration = parse_ttl(ttl.extract::<i64>()?)?;
+    }
     Ok(policy)
 }

--- a/rust/src/policy/write_policy.rs
+++ b/rust/src/policy/write_policy.rs
@@ -15,7 +15,7 @@ pub static DEFAULT_WRITE_POLICY: LazyLock<WritePolicy> = LazyLock::new(WritePoli
 /// Convert a TTL integer value to an [`Expiration`] enum.
 ///
 /// Special values: `0` = namespace default, `-1` = never expire, `-2` = don't update.
-fn parse_ttl(ttl_val: i64) -> PyResult<Expiration> {
+pub(crate) fn parse_ttl(ttl_val: i64) -> PyResult<Expiration> {
     match ttl_val {
         0 => Ok(Expiration::NamespaceDefault),
         -1 => Ok(Expiration::Never),

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -651,9 +651,7 @@ class Client:
 
     def batch_write(
         self,
-        records: list[
-            tuple[Key, dict[str, Any]] | tuple[Key, dict[str, Any], WriteMeta]
-        ],
+        records: list[tuple[Key, dict[str, Any]] | tuple[Key, dict[str, Any], WriteMeta]],
         policy: Optional[dict[str, Any]] = None,
         retry: int = 0,
     ) -> BatchRecords:
@@ -1636,9 +1634,7 @@ class AsyncClient:
 
     async def batch_write(
         self,
-        records: list[
-            tuple[Key, dict[str, Any]] | tuple[Key, dict[str, Any], WriteMeta]
-        ],
+        records: list[tuple[Key, dict[str, Any]] | tuple[Key, dict[str, Any], WriteMeta]],
         policy: Optional[dict[str, Any]] = None,
         retry: int = 0,
     ) -> BatchRecords:

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -651,20 +651,31 @@ class Client:
 
     def batch_write(
         self,
-        records: list[tuple[Key, dict[str, Any]]],
+        records: list[
+            tuple[Key, dict[str, Any]] | tuple[Key, dict[str, Any], WriteMeta]
+        ],
         policy: Optional[dict[str, Any]] = None,
         retry: int = 0,
     ) -> BatchRecords:
         """Write multiple records with per-record bins in a single batch call.
 
-        Each record is a ``(key, bins)`` tuple where key is
-        ``(namespace, set, primary_key)`` and bins is a dict of bin
-        name-to-value mappings. Unlike ``batch_operate`` (which applies
-        the same operations to all keys), each record can have different bins.
+        Each record is a ``(key, bins)`` or ``(key, bins, meta)`` tuple where
+        key is ``(namespace, set, primary_key)``, bins is a dict of bin
+        name-to-value mappings, and meta is an optional
+        [`WriteMeta`](types.md#writemeta) dict (e.g. ``{"ttl": 300}``).
+        Unlike ``batch_operate`` (which applies the same operations to all
+        keys), each record can have different bins.
+
+        TTL can be set at two levels:
+
+        - **Batch-level**: ``policy={"ttl": N}`` applies to all records.
+        - **Per-record**: ``(key, bins, {"ttl": N})`` overrides the
+          batch-level TTL for that specific record.
 
         Args:
-            records: List of ``(key, bins)`` tuples.
+            records: List of ``(key, bins)`` or ``(key, bins, meta)`` tuples.
             policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict.
+                Supports ``"ttl"`` key for batch-level TTL (seconds).
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
@@ -675,14 +686,22 @@ class Client:
 
         Example:
             ```python
+            # Basic usage
             records = [
                 (("test", "demo", "user1"), {"name": "Alice", "age": 30}),
                 (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
             ]
             results = client.batch_write(records)
-            for br in results.batch_records:
-                if br.result != 0:
-                    print(f"Failed: {br.key}, code={br.result}, in_doubt={br.in_doubt}")
+
+            # With batch-level TTL (30 days)
+            results = client.batch_write(records, policy={"ttl": 2592000})
+
+            # With per-record TTL
+            records_with_ttl = [
+                (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 3600}),
+                (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
+            ]
+            results = client.batch_write(records_with_ttl)
             ```
         """
         ...
@@ -1617,19 +1636,29 @@ class AsyncClient:
 
     async def batch_write(
         self,
-        records: list[tuple[Key, dict[str, Any]]],
+        records: list[
+            tuple[Key, dict[str, Any]] | tuple[Key, dict[str, Any], WriteMeta]
+        ],
         policy: Optional[dict[str, Any]] = None,
         retry: int = 0,
     ) -> BatchRecords:
         """Write multiple records with per-record bins (async).
 
-        Each record is a ``(key, bins)`` tuple where key is
-        ``(namespace, set, primary_key)`` and bins is a dict of bin
-        name-to-value mappings.
+        Each record is a ``(key, bins)`` or ``(key, bins, meta)`` tuple where
+        key is ``(namespace, set, primary_key)``, bins is a dict of bin
+        name-to-value mappings, and meta is an optional
+        [`WriteMeta`](types.md#writemeta) dict (e.g. ``{"ttl": 300}``).
+
+        TTL can be set at two levels:
+
+        - **Batch-level**: ``policy={"ttl": N}`` applies to all records.
+        - **Per-record**: ``(key, bins, {"ttl": N})`` overrides the
+          batch-level TTL for that specific record.
 
         Args:
-            records: List of ``(key, bins)`` tuples.
+            records: List of ``(key, bins)`` or ``(key, bins, meta)`` tuples.
             policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict.
+                Supports ``"ttl"`` key for batch-level TTL (seconds).
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
@@ -1640,14 +1669,22 @@ class AsyncClient:
 
         Example:
             ```python
+            # Basic usage
             records = [
                 (("test", "demo", "user1"), {"name": "Alice", "age": 30}),
                 (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
             ]
             results = await client.batch_write(records)
-            for br in results.batch_records:
-                if br.result != 0:
-                    print(f"Failed: {br.key}, code={br.result}, in_doubt={br.in_doubt}")
+
+            # With batch-level TTL (30 days)
+            results = await client.batch_write(records, policy={"ttl": 2592000})
+
+            # With per-record TTL
+            records_with_ttl = [
+                (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 3600}),
+                (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
+            ]
+            results = await client.batch_write(records_with_ttl)
             ```
         """
         ...

--- a/tests/integration/test_async.py
+++ b/tests/integration/test_async.py
@@ -166,9 +166,7 @@ class TestAsyncBatchWriteTTL:
 
         ttl_seconds = 2592000  # 30 days
         records = [(k, {"val": i}) for i, k in enumerate(keys)]
-        results = await async_client.batch_write(
-            records, policy={"ttl": ttl_seconds}
-        )
+        results = await async_client.batch_write(records, policy={"ttl": ttl_seconds})
         for br in results.batch_records:
             assert br.result == 0
 
@@ -178,17 +176,13 @@ class TestAsyncBatchWriteTTL:
             assert meta.ttl > 0
             assert meta.ttl <= ttl_seconds
 
-    async def test_async_batch_write_per_record_meta_ttl(
-        self, async_client, async_cleanup
-    ):
+    async def test_async_batch_write_per_record_meta_ttl(self, async_client, async_cleanup):
         """Per-record TTL via (key, bins, meta) tuple."""
         key = ("test", "demo", "abw_ttl_meta")
         async_cleanup.append(key)
 
         ttl_seconds = 3600
-        results = await async_client.batch_write(
-            [(key, {"val": 1}, {"ttl": ttl_seconds})]
-        )
+        results = await async_client.batch_write([(key, {"val": 1}, {"ttl": ttl_seconds})])
         assert results.batch_records[0].result == 0
 
         _, meta, _ = await async_client.get(key)
@@ -196,9 +190,7 @@ class TestAsyncBatchWriteTTL:
         assert meta.ttl > 0
         assert meta.ttl <= ttl_seconds
 
-    async def test_async_batch_write_ttl_never_expire(
-        self, async_client, async_cleanup
-    ):
+    async def test_async_batch_write_ttl_never_expire(self, async_client, async_cleanup):
         """TTL_NEVER_EXPIRE via policy in async batch_write."""
         key = ("test", "demo", "abw_ttl_never")
         async_cleanup.append(key)

--- a/tests/integration/test_async.py
+++ b/tests/integration/test_async.py
@@ -150,3 +150,65 @@ class TestAsyncBatchWriteGeneric:
     async def test_async_batch_write_empty(self, async_client):
         results = await async_client.batch_write([])
         assert len(results.batch_records) == 0
+
+
+class TestAsyncBatchWriteTTL:
+    """Test async batch_write() TTL support."""
+
+    async def test_async_batch_write_policy_ttl(self, async_client, async_cleanup):
+        """Batch-level TTL via policy is applied to all records."""
+        keys = [
+            ("test", "demo", "abw_ttl_pol_1"),
+            ("test", "demo", "abw_ttl_pol_2"),
+        ]
+        for k in keys:
+            async_cleanup.append(k)
+
+        ttl_seconds = 2592000  # 30 days
+        records = [(k, {"val": i}) for i, k in enumerate(keys)]
+        results = await async_client.batch_write(
+            records, policy={"ttl": ttl_seconds}
+        )
+        for br in results.batch_records:
+            assert br.result == 0
+
+        for k in keys:
+            _, meta, _ = await async_client.get(k)
+            assert meta is not None
+            assert meta.ttl > 0
+            assert meta.ttl <= ttl_seconds
+
+    async def test_async_batch_write_per_record_meta_ttl(
+        self, async_client, async_cleanup
+    ):
+        """Per-record TTL via (key, bins, meta) tuple."""
+        key = ("test", "demo", "abw_ttl_meta")
+        async_cleanup.append(key)
+
+        ttl_seconds = 3600
+        results = await async_client.batch_write(
+            [(key, {"val": 1}, {"ttl": ttl_seconds})]
+        )
+        assert results.batch_records[0].result == 0
+
+        _, meta, _ = await async_client.get(key)
+        assert meta is not None
+        assert meta.ttl > 0
+        assert meta.ttl <= ttl_seconds
+
+    async def test_async_batch_write_ttl_never_expire(
+        self, async_client, async_cleanup
+    ):
+        """TTL_NEVER_EXPIRE via policy in async batch_write."""
+        key = ("test", "demo", "abw_ttl_never")
+        async_cleanup.append(key)
+
+        results = await async_client.batch_write(
+            [(key, {"val": 1})],
+            policy={"ttl": aerospike_py.TTL_NEVER_EXPIRE},
+        )
+        assert results.batch_records[0].result == 0
+
+        _, meta, _ = await async_client.get(key)
+        assert meta is not None
+        assert meta.ttl > 0

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -465,9 +465,7 @@ class TestBatchWriteTTL:
             cleanup.append(k)
 
         records = [(k, {"val": i}) for i, k in enumerate(keys)]
-        results = client.batch_write(
-            records, policy={"ttl": aerospike_py.TTL_NEVER_EXPIRE}
-        )
+        results = client.batch_write(records, policy={"ttl": aerospike_py.TTL_NEVER_EXPIRE})
         for br in results.batch_records:
             assert br.result == 0
 
@@ -481,9 +479,7 @@ class TestBatchWriteTTL:
         key = ("test", "demo", "bw_ttl_meta_never")
         cleanup.append(key)
 
-        results = client.batch_write(
-            [(key, {"val": 1}, {"ttl": aerospike_py.TTL_NEVER_EXPIRE})]
-        )
+        results = client.batch_write([(key, {"val": 1}, {"ttl": aerospike_py.TTL_NEVER_EXPIRE})])
         assert results.batch_records[0].result == 0
 
         _, meta, _ = client.get(key)
@@ -499,9 +495,7 @@ class TestBatchWriteTTL:
         client.put(key, {"val": 1}, meta={"ttl": 3600})
 
         # Step 2: update bins via batch_write with DONT_UPDATE
-        results = client.batch_write(
-            [(key, {"val": 2}, {"ttl": aerospike_py.TTL_DONT_UPDATE})]
-        )
+        results = client.batch_write([(key, {"val": 2}, {"ttl": aerospike_py.TTL_DONT_UPDATE})])
         assert results.batch_records[0].result == 0
 
         _, meta, bins = client.get(key)
@@ -517,9 +511,9 @@ class TestBatchWriteTTL:
             cleanup.append(k)
 
         records = [
-            (key_a, {"val": 1}, {"ttl": 3600}),   # 1 hour
-            (key_b, {"val": 2}, {"ttl": 86400}),   # 1 day
-            (key_c, {"val": 3}),                    # uses batch policy TTL
+            (key_a, {"val": 1}, {"ttl": 3600}),  # 1 hour
+            (key_b, {"val": 2}, {"ttl": 86400}),  # 1 day
+            (key_c, {"val": 3}),  # uses batch policy TTL
         ]
         results = client.batch_write(records, policy={"ttl": 300})
         for br in results.batch_records:

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -386,6 +386,76 @@ class TestBatchWriteGeneric:
         assert bins["val"] == 1
 
 
+class TestBatchWriteTTL:
+    """Test batch_write() TTL support via policy and per-record meta."""
+
+    def test_batch_write_policy_ttl(self, client, cleanup):
+        """Batch-level TTL via policy={"ttl": N} is applied to all records."""
+        keys = [
+            ("test", "demo", "bw_ttl_pol_1"),
+            ("test", "demo", "bw_ttl_pol_2"),
+        ]
+        for k in keys:
+            cleanup.append(k)
+
+        ttl_seconds = 2592000  # 30 days
+        records = [(k, {"val": i}) for i, k in enumerate(keys)]
+        results = client.batch_write(records, policy={"ttl": ttl_seconds})
+        for br in results.batch_records:
+            assert br.result == 0
+
+        # Verify TTL is set (not namespace default)
+        for k in keys:
+            _, meta, _ = client.get(k)
+            assert meta is not None
+            # TTL should be close to what we set (server may subtract a second)
+            assert meta.ttl > 0
+            assert meta.ttl <= ttl_seconds
+
+    def test_batch_write_per_record_meta_ttl(self, client, cleanup):
+        """Per-record TTL via (key, bins, {"ttl": N}) meta tuple."""
+        key = ("test", "demo", "bw_ttl_meta")
+        cleanup.append(key)
+
+        ttl_seconds = 3600  # 1 hour
+        results = client.batch_write([(key, {"val": 1}, {"ttl": ttl_seconds})])
+        assert results.batch_records[0].result == 0
+
+        _, meta, _ = client.get(key)
+        assert meta is not None
+        assert meta.ttl > 0
+        assert meta.ttl <= ttl_seconds
+
+    def test_batch_write_per_record_meta_overrides_policy_ttl(self, client, cleanup):
+        """Per-record meta TTL overrides batch-level policy TTL."""
+        key_policy = ("test", "demo", "bw_ttl_override_pol")
+        key_meta = ("test", "demo", "bw_ttl_override_meta")
+        cleanup.append(key_policy)
+        cleanup.append(key_meta)
+
+        policy_ttl = 86400  # 1 day
+        meta_ttl = 3600  # 1 hour
+
+        records = [
+            (key_policy, {"val": 1}),  # uses batch-level TTL
+            (key_meta, {"val": 2}, {"ttl": meta_ttl}),  # overrides with per-record TTL
+        ]
+        results = client.batch_write(records, policy={"ttl": policy_ttl})
+        for br in results.batch_records:
+            assert br.result == 0
+
+        # Record without meta should use batch-level TTL (~1 day)
+        _, meta_pol, _ = client.get(key_policy)
+        assert meta_pol is not None
+        assert meta_pol.ttl > 3600  # should be ~86400, definitely > 1 hour
+
+        # Record with meta should use per-record TTL (~1 hour)
+        _, meta_m, _ = client.get(key_meta)
+        assert meta_m is not None
+        assert meta_m.ttl <= meta_ttl
+        assert meta_m.ttl > 0
+
+
 class TestBatchRemove:
     def test_batch_remove(self, client):
         keys = [

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -455,6 +455,90 @@ class TestBatchWriteTTL:
         assert meta_m.ttl <= meta_ttl
         assert meta_m.ttl > 0
 
+    def test_batch_write_ttl_never_expire(self, client, cleanup):
+        """Batch-level TTL_NEVER_EXPIRE via policy."""
+        keys = [
+            ("test", "demo", "bw_ttl_never_1"),
+            ("test", "demo", "bw_ttl_never_2"),
+        ]
+        for k in keys:
+            cleanup.append(k)
+
+        records = [(k, {"val": i}) for i, k in enumerate(keys)]
+        results = client.batch_write(
+            records, policy={"ttl": aerospike_py.TTL_NEVER_EXPIRE}
+        )
+        for br in results.batch_records:
+            assert br.result == 0
+
+        for k in keys:
+            _, meta, _ = client.get(k)
+            assert meta is not None
+            assert meta.ttl > 0  # never expire returns a very large TTL
+
+    def test_batch_write_per_record_meta_never_expire(self, client, cleanup):
+        """Per-record meta TTL_NEVER_EXPIRE."""
+        key = ("test", "demo", "bw_ttl_meta_never")
+        cleanup.append(key)
+
+        results = client.batch_write(
+            [(key, {"val": 1}, {"ttl": aerospike_py.TTL_NEVER_EXPIRE})]
+        )
+        assert results.batch_records[0].result == 0
+
+        _, meta, _ = client.get(key)
+        assert meta is not None
+        assert meta.ttl > 0
+
+    def test_batch_write_ttl_dont_update(self, client, cleanup):
+        """TTL_DONT_UPDATE preserves original TTL while updating bins."""
+        key = ("test", "demo", "bw_ttl_dont_upd")
+        cleanup.append(key)
+
+        # Step 1: write with explicit TTL
+        client.put(key, {"val": 1}, meta={"ttl": 3600})
+
+        # Step 2: update bins via batch_write with DONT_UPDATE
+        results = client.batch_write(
+            [(key, {"val": 2}, {"ttl": aerospike_py.TTL_DONT_UPDATE})]
+        )
+        assert results.batch_records[0].result == 0
+
+        _, meta, bins = client.get(key)
+        assert bins["val"] == 2  # bins updated
+        assert meta.ttl > 3000  # TTL preserved (~3600, minus execution time)
+
+    def test_batch_write_mixed_ttl_in_batch(self, client, cleanup):
+        """Different TTL values per record in a single batch call."""
+        key_a = ("test", "demo", "bw_ttl_mix_a")
+        key_b = ("test", "demo", "bw_ttl_mix_b")
+        key_c = ("test", "demo", "bw_ttl_mix_c")
+        for k in (key_a, key_b, key_c):
+            cleanup.append(k)
+
+        records = [
+            (key_a, {"val": 1}, {"ttl": 3600}),   # 1 hour
+            (key_b, {"val": 2}, {"ttl": 86400}),   # 1 day
+            (key_c, {"val": 3}),                    # uses batch policy TTL
+        ]
+        results = client.batch_write(records, policy={"ttl": 300})
+        for br in results.batch_records:
+            assert br.result == 0
+
+        _, meta_a, _ = client.get(key_a)
+        _, meta_b, _ = client.get(key_b)
+        _, meta_c, _ = client.get(key_c)
+
+        # key_a: ~3600
+        assert meta_a.ttl > 300
+        assert meta_a.ttl <= 3600
+        # key_b: ~86400
+        assert meta_b.ttl > 3600
+        assert meta_b.ttl <= 86400
+        # key_c: ~300 (batch policy default)
+        assert meta_c.ttl > 0
+        assert meta_c.ttl <= 300
+
 
 class TestBatchRemove:
     def test_batch_remove(self, client):

--- a/tests/integration/test_numpy_batch_edge_cases.py
+++ b/tests/integration/test_numpy_batch_edge_cases.py
@@ -474,9 +474,7 @@ class TestBatchWriteNumpyTTL:
         data = np.array([(9901, 42), (9902, 84)], dtype=dtype)
         ttl_seconds = 2592000  # 30 days
 
-        results = client.batch_write_numpy(
-            data, NS, SET, dtype, policy={"ttl": ttl_seconds}
-        )
+        results = client.batch_write_numpy(data, NS, SET, dtype, policy={"ttl": ttl_seconds})
         keys = [(NS, SET, 9901), (NS, SET, 9902)]
         for k in keys:
             cleanup.append(k)

--- a/tests/integration/test_numpy_batch_edge_cases.py
+++ b/tests/integration/test_numpy_batch_edge_cases.py
@@ -460,3 +460,31 @@ class TestMetaAfterWrite:
         read = client.batch_read([(NS, SET, 8101)], _dtype=read_dtype)
         assert read.meta[0]["gen"] >= 2
         assert read.batch_records[0]["val"] == 2
+
+
+# ── batch_write_numpy TTL ────────────────────────────────────────────
+
+
+class TestBatchWriteNumpyTTL:
+    """Test batch_write_numpy() with policy TTL."""
+
+    def test_batch_write_numpy_policy_ttl(self, client, cleanup):
+        """Policy TTL is applied to all records written via batch_write_numpy."""
+        dtype = np.dtype([("_key", "i4"), ("val", "i4")])
+        data = np.array([(9901, 42), (9902, 84)], dtype=dtype)
+        ttl_seconds = 2592000  # 30 days
+
+        results = client.batch_write_numpy(
+            data, NS, SET, dtype, policy={"ttl": ttl_seconds}
+        )
+        keys = [(NS, SET, 9901), (NS, SET, 9902)]
+        for k in keys:
+            cleanup.append(k)
+        for br in results.batch_records:
+            assert br.result == 0
+
+        for k in keys:
+            _, meta, _ = client.get(k)
+            assert meta is not None
+            assert meta.ttl > 0
+            assert meta.ttl <= ttl_seconds

--- a/tests/unit/test_batch_write_generic.py
+++ b/tests/unit/test_batch_write_generic.py
@@ -96,6 +96,4 @@ class TestBatchWriteInputValidation:
     def test_meta_ttl_invalid_type_raises(self, client):
         """Non-integer TTL in meta raises an error."""
         with pytest.raises((TypeError, aerospike_py.InvalidArgError)):
-            client.batch_write(
-                [(("test", "demo", "k1"), {"a": 1}, {"ttl": "not_a_number"})]
-            )
+            client.batch_write([(("test", "demo", "k1"), {"a": 1}, {"ttl": "not_a_number"})])

--- a/tests/unit/test_batch_write_generic.py
+++ b/tests/unit/test_batch_write_generic.py
@@ -86,3 +86,16 @@ class TestBatchWriteInputValidation:
         key = ("test", "demo", "k_policy_ttl")
         result = client.batch_write([(key, {"a": 1})], policy={"ttl": 300})
         assert len(result.batch_records) == 1
+
+    def test_empty_meta_dict_accepted(self, client):
+        """3-element tuple with empty meta dict is accepted (same as 2-tuple)."""
+        key = ("test", "demo", "k_empty_meta")
+        result = client.batch_write([(key, {"a": 1}, {})])
+        assert len(result.batch_records) == 1
+
+    def test_meta_ttl_invalid_type_raises(self, client):
+        """Non-integer TTL in meta raises an error."""
+        with pytest.raises((TypeError, aerospike_py.InvalidArgError)):
+            client.batch_write(
+                [(("test", "demo", "k1"), {"a": 1}, {"ttl": "not_a_number"})]
+            )

--- a/tests/unit/test_batch_write_generic.py
+++ b/tests/unit/test_batch_write_generic.py
@@ -68,3 +68,21 @@ class TestBatchWriteInputValidation:
         """Non-dict bins element raises TypeError."""
         with pytest.raises(TypeError, match="must be a dict"):
             client.batch_write([(("test", "demo", "k1"), [("a", 1)])])
+
+    def test_3_tuple_meta_accepted(self, client):
+        """3-element tuple (key, bins, meta) is accepted without error."""
+        key = ("test", "demo", "k_meta_accept")
+        result = client.batch_write([(key, {"a": 1}, {"ttl": 300})])
+        # Should not raise; record may or may not exist depending on server state
+        assert len(result.batch_records) == 1
+
+    def test_3_tuple_meta_must_be_dict(self, client):
+        """Non-dict meta element raises TypeError."""
+        with pytest.raises(TypeError, match="meta element must be a dict"):
+            client.batch_write([(("test", "demo", "k1"), {"a": 1}, "not_a_dict")])
+
+    def test_policy_ttl_accepted(self, client):
+        """policy dict with 'ttl' key is accepted without error."""
+        key = ("test", "demo", "k_policy_ttl")
+        result = client.batch_write([(key, {"a": 1})], policy={"ttl": 300})
+        assert len(result.batch_records) == 1


### PR DESCRIPTION
## Summary

- **Fixed `batch_write` ignoring TTL** from both `policy={"ttl": N}` and `(key, bins, {"ttl": N})` per-record meta tuple
- **Root causes**: `parse_batch_policy()` never read TTL, `prepare_batch_write_args()` discarded the 3rd tuple element, and `do_batch_write()` hardcoded `BatchWritePolicy::default()`
- **Added per-record write policy support** — each record in `batch_write` now carries its own `BatchWritePolicy` with TTL, and per-record meta overrides batch-level policy

## Changes

| File | Description |
|------|-------------|
| `rust/src/policy/write_policy.rs` | Made `parse_ttl()` `pub(crate)` for reuse |
| `rust/src/policy/batch_policy.rs` | Added `parse_batch_write_policy()` for TTL parsing |
| `rust/src/client_common.rs` | Extended `BatchWriteGenericArgs` to carry per-record `BatchWritePolicy`; parse 3-element `(key, bins, meta)` tuples |
| `rust/src/client_ops.rs` | Use per-record write policy instead of hardcoded default |
| `rust/src/client.rs` | Updated `batch_write_numpy` to pass TTL-aware write policies |
| `rust/src/async_client.rs` | Same as above for async variant |
| `src/aerospike_py/__init__.pyi` | Updated type stubs with `WriteMeta` support and TTL docs |
| `tests/unit/test_batch_write_generic.py` | Added unit tests for 3-tuple meta and policy TTL acceptance |
| `tests/integration/test_batch.py` | Added integration tests for batch/per-record TTL verification |

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (88 tests)
- [ ] `make test-unit` — unit tests for input validation (3-tuple meta, policy TTL)
- [ ] `make test-integration` — TTL verification with Aerospike server

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)