### PR TITLE
perf(batch): cache ops Vec for retry reuse and add elapsed time guard

### DIFF
--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -312,13 +312,28 @@ pub async fn do_batch_write(
     max_retries: u32,
     op_name: &str,
 ) -> PyResult<Vec<BatchRecord>> {
-    // Pre-build ops once per record; reused on retry via clone
+    // Fast path: no retry — build ops directly, no cache overhead
+    if max_retries == 0 {
+        let batch_ops: Vec<BatchOperation> = records
+            .iter()
+            .map(|(key, bins, write_policy)| {
+                let ops: Vec<aerospike_core::operations::Operation> =
+                    bins.iter().map(aerospike_core::operations::put).collect();
+                BatchOperation::write(write_policy, key.clone(), ops)
+            })
+            .collect();
+        return traced_op!(
+            op_name, ns, set, parent_ctx, conn_info,
+            client.batch(batch_policy, &batch_ops).await
+        );
+    }
+
+    // Retry path: pre-build ops once per record, reuse via clone on retry
     let cached_ops: Vec<Vec<aerospike_core::operations::Operation>> = records
         .iter()
         .map(|(_, bins, _)| bins.iter().map(aerospike_core::operations::put).collect())
         .collect();
 
-    // Build initial batch operations using cached ops
     let batch_ops: Vec<BatchOperation> = records
         .iter()
         .zip(cached_ops.iter())
@@ -336,10 +351,6 @@ pub async fn do_batch_write(
         conn_info,
         client.batch(batch_policy, &batch_ops).await
     )?;
-
-    if max_retries == 0 {
-        return Ok(results);
-    }
 
     // Retry loop: only retry records with retryable error codes
     let start = std::time::Instant::now();

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -312,13 +312,18 @@ pub async fn do_batch_write(
     max_retries: u32,
     op_name: &str,
 ) -> PyResult<Vec<BatchRecord>> {
-    // Build initial batch operations using per-record write policies
+    // Pre-build ops once per record; reused on retry via clone
+    let cached_ops: Vec<Vec<aerospike_core::operations::Operation>> = records
+        .iter()
+        .map(|(_, bins, _)| bins.iter().map(aerospike_core::operations::put).collect())
+        .collect();
+
+    // Build initial batch operations using cached ops
     let batch_ops: Vec<BatchOperation> = records
         .iter()
-        .map(|(key, bins, write_policy)| {
-            let ops: Vec<aerospike_core::operations::Operation> =
-                bins.iter().map(aerospike_core::operations::put).collect();
-            BatchOperation::write(write_policy, key.clone(), ops)
+        .zip(cached_ops.iter())
+        .map(|((key, _, write_policy), ops)| {
+            BatchOperation::write(write_policy, key.clone(), ops.clone())
         })
         .collect();
 
@@ -337,6 +342,8 @@ pub async fn do_batch_write(
     }
 
     // Retry loop: only retry records with retryable error codes
+    let start = std::time::Instant::now();
+    let timeout_ms = batch_policy.base_policy.total_timeout as u64;
     let mut retry_indices: Vec<usize> = Vec::new();
     for attempt in 0..max_retries {
         // Find indices of failed records that are retryable
@@ -360,6 +367,21 @@ pub async fn do_batch_write(
 
         // Full Jitter backoff: random_between(0, min(500ms, 10ms * 2^attempt))
         let backoff_ms = compute_backoff_ms(attempt, 10, 500);
+
+        // Elapsed time guard: stop retries if remaining time is insufficient
+        if timeout_ms > 0 {
+            let elapsed_ms = start.elapsed().as_millis() as u64;
+            if elapsed_ms + backoff_ms >= timeout_ms {
+                log::warn!(
+                    "batch_write retry: elapsed {}ms + backoff {}ms >= timeout {}ms, stopping",
+                    elapsed_ms,
+                    backoff_ms,
+                    timeout_ms
+                );
+                break;
+            }
+        }
+
         log::info!(
             "batch_write retry: {} failed records, attempt {}/{}, backoff {}ms",
             retry_indices.len(),
@@ -369,14 +391,12 @@ pub async fn do_batch_write(
         );
         tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
 
-        // Build retry batch from failed records only
+        // Build retry batch from cached ops (avoids rebuilding from bins)
         let retry_ops: Vec<BatchOperation> = retry_indices
             .iter()
             .map(|&i| {
-                let (key, bins, write_policy) = &records[i];
-                let ops: Vec<aerospike_core::operations::Operation> =
-                    bins.iter().map(aerospike_core::operations::put).collect();
-                BatchOperation::write(write_policy, key.clone(), ops)
+                let (key, _, write_policy) = &records[i];
+                BatchOperation::write(write_policy, key.clone(), cached_ops[i].clone())
             })
             .collect();
 

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -630,7 +630,8 @@ class Client:
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
-                exponential backoff.
+                exponential backoff (Full Jitter, max 500ms). Retries stop
+                early if the elapsed time approaches ``total_timeout``.
 
         Returns:
             A list of ``BatchRecord`` NamedTuples with per-record result codes.
@@ -677,7 +678,8 @@ class Client:
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
-                exponential backoff.
+                exponential backoff (Full Jitter, max 500ms). Retries stop
+                early if the elapsed time approaches ``total_timeout``.
 
         Returns:
             A ``BatchRecords`` containing per-record result codes.
@@ -1613,7 +1615,8 @@ class AsyncClient:
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
-                exponential backoff.
+                exponential backoff (Full Jitter, max 500ms). Retries stop
+                early if the elapsed time approaches ``total_timeout``.
 
         Returns:
             A list of ``BatchRecord`` NamedTuples with per-record result codes.
@@ -1658,7 +1661,8 @@ class AsyncClient:
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
-                exponential backoff.
+                exponential backoff (Full Jitter, max 500ms). Retries stop
+                early if the elapsed time approaches ``total_timeout``.
 
         Returns:
             A ``BatchRecords`` containing per-record result codes.


### PR DESCRIPTION
## Summary

- Pre-build per-record `Vec<Operation>` once in `do_batch_write()`, reuse via `.clone()` on retry instead of rebuilding from bins via `put()` each attempt
- Add elapsed time tracking (`Instant::now()`) to retry loop: break early if `elapsed + backoff >= total_timeout` (no-op when timeout=0)
- Update `batch_write` retry docstring with Full Jitter details and timeout interaction

## Test plan

- [x] `cargo check` + `cargo clippy -- -D warnings` pass
- [x] 36 batch_write tests pass (unit + integration + TTL)
- [x] No external API changes — internal optimization only

Closes #276