### PR TITLE
fix(batch): add gen support, remove deep clone, improve docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,27 +169,33 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, running tests, and
 
 ## Code stats
 
-[tokei](https://github.com/XAMPPRocky/tokei) 기반. 설정: `tokei.toml` + `.tokeignore`
+[tokei](https://github.com/XAMPPRocky/tokei) 기반 (`tokei.toml` + `.tokeignore`).
+
+### 코드 규모
+
+| 레이어 | 파일 수 | 코드 라인 | 역할 |
+|--------|--------:|----------:|------|
+| **aerospike-core** (Rust) | 100 | 19,635 | Aerospike 프로토콜, 클러스터 관리, 명령 실행 |
+| **rust/src** (PyO3 바인딩) | 32 | 9,582 | Python ↔ Rust 변환, async/sync 클라이언트, 정책 파싱 |
+| **src/aerospike_py** (Python) | 24 | 6,877 | 타입 스텁(.pyi), NamedTuple 래퍼, 헬퍼 |
+| **합계** | **156** | **36,094** | Rust 81% · Python 19% |
+
+### 타 DB 클라이언트 대비
+
+| 클라이언트 | 구현 코드 | 비고 |
+|-----------|----------:|------|
+| **aerospike-py** (Rust+Python) | ~36K | 프로토콜 자체 구현 |
+| aerospike-client-python (공식) | ~15K | C client(100K+) 래핑, C 코드 별도 |
+| redis-rs (Rust) | ~15K | 프로토콜이 훨씬 단순 (텍스트 기반) |
+| pymongo (Python) | ~40-50K | 순수 Python, 프로토콜 자체 구현 |
+| psycopg3 (Python) | ~25-30K | libpq(C) 래핑 |
 
 ```bash
 # 순수 구현 코드만 (tests, examples, benchmark 제외)
 tokei
 
-# 테스트 + 벤치마크 + 샘플 포함
-tokei src rust/src tests benchmark examples
-```
-
-순수 구현 코드 (tests, examples, benchmark 제외):
-```
-$ tokei -C
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Language                                 Files        Lines         Code     Comments       Blanks
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Rust                                        34         9729         8581          260          888
- Python                                      25         8116         6754          238         1124
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Total                                       59        18511        15335         1067         2109
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# aerospike-core 포함
+tokei rust/src/ src/aerospike_py/
 ```
 
 ## License

--- a/examples/sample-fastapi/app/routers/batch.py
+++ b/examples/sample-fastapi/app/routers/batch.py
@@ -19,15 +19,23 @@ router = APIRouter(prefix="/batch", tags=["batch"])
 
 @router.post("/read", response_model=BatchRecordsResponse)
 async def batch_read(body: BatchReadRequest, client: AsyncClient = Depends(get_client)):
-    """Read multiple records in a single batch call."""
+    """Read multiple records in a single batch call.
+
+    Since v0.4.0, ``AsyncClient.batch_read()`` returns
+    ``dict[UserKey, AerospikeRecord]`` — only successful reads are included.
+    We reconstruct per-key results by checking dict membership.
+    """
     keys = [k.to_tuple() for k in body.keys]
     result = await client.batch_read(keys, bins=body.bins)
     records = []
-    for br in result.batch_records:
-        rec = None
-        if br.record is not None:
-            rec = RecordResponse(key=br.record.key, meta=br.record.meta, bins=br.record.bins)
-        records.append(BatchRecordResponse(key=br.key, result=br.result, record=rec))
+    for key_tuple in keys:
+        user_key = key_tuple[2]
+        if user_key in result:
+            bins_dict = result[user_key]
+            rec = RecordResponse(key=list(key_tuple), meta=None, bins=bins_dict)
+            records.append(BatchRecordResponse(key=list(key_tuple), result=0, record=rec))
+        else:
+            records.append(BatchRecordResponse(key=list(key_tuple), result=2, record=None))
     return BatchRecordsResponse(batch_records=records)
 
 

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -25,10 +25,7 @@ use crate::types::record::record_to_py_with_key;
 /// In practice, all access is single-threaded (GIL held), so contention is zero.
 enum LazyRecordCell {
     /// Raw Rust Record awaiting lazy conversion.
-    Pending {
-        record: Record,
-        key_py: Py<PyAny>,
-    },
+    Pending { record: Record, key_py: Py<PyAny> },
     /// Already converted to Python `(key, meta, bins)` tuple — cached.
     Converted(Py<PyAny>),
     /// Record not found (None).
@@ -217,8 +214,10 @@ impl PyBatchReadHandle {
     /// Each `BatchRecord`'s `.record` field is lazily converted on first access.
     #[getter]
     fn batch_records(&self, py: Python<'_>) -> PyResult<Vec<Py<PyBatchRecord>>> {
-        let br = batch_to_batch_records_py(py, (*self.inner).clone())?;
-        Ok(br.batch_records)
+        self.inner
+            .iter()
+            .map(|br| single_batch_record_to_py(py, br))
+            .collect()
     }
 
     /// Count of records with successful result code (no conversion needed).
@@ -240,9 +239,7 @@ impl PyBatchReadHandle {
                     aerospike_core::Value::String(s) => {
                         s.into_pyobject(py).map(|o| o.into_any()).ok()
                     }
-                    aerospike_core::Value::Int(i) => {
-                        i.into_pyobject(py).map(|o| o.into_any()).ok()
-                    }
+                    aerospike_core::Value::Int(i) => i.into_pyobject(py).map(|o| o.into_any()).ok(),
                     v => value_to_py(py, v).ok().map(|o| o.into_bound(py)),
                 })
             })

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -290,12 +290,39 @@ fn compute_backoff_ms(attempt: u32, base_ms: u64, cap_ms: u64) -> u64 {
     rand::thread_rng().gen_range(0..=max_backoff)
 }
 
+/// Collect indices of batch records with retryable error codes into `out`.
+///
+/// Clears `out` first, then appends indices of records whose `result_code`
+/// is both non-Ok and retryable (timeout, device overload, key busy,
+/// server memory error, partition unavailable).
+fn collect_retryable_indices(results: &[BatchRecord], out: &mut Vec<usize>) {
+    out.clear();
+    out.extend(results.iter().enumerate().filter_map(|(i, br)| {
+        if let Some(rc) = &br.result_code {
+            if *rc != aerospike_core::ResultCode::Ok && is_retryable_result_code(rc) {
+                return Some(i);
+            }
+        }
+        None
+    }));
+}
+
 /// Write multiple records from pre-parsed (key, bins) pairs with optional retry.
 ///
 /// When `max_retries > 0`, failed records with retryable error codes are
 /// re-submitted in subsequent batch calls, up to `max_retries` attempts.
 /// A Full Jitter exponential backoff (`random_between(0, min(cap, base * 2^attempt))`)
 /// is applied between retries to avoid thundering-herd effects.
+///
+/// **Retry behavior notes:**
+/// - If a transport-level error occurs during a retry attempt, retries stop
+///   immediately and the function returns partial results. Records that were
+///   being retried retain their previous (failed) result codes.
+/// - The elapsed time guard prevents retries when `elapsed + backoff >= total_timeout`,
+///   but does not account for the actual batch operation time. Total wall-clock
+///   time may exceed `total_timeout` by up to one additional timeout window.
+/// - Callers should always check per-record `result_code` values regardless of
+///   the overall `Ok` return status.
 #[allow(clippy::too_many_arguments)]
 pub async fn do_batch_write(
     client: &AsClient,
@@ -323,7 +350,11 @@ pub async fn do_batch_write(
             })
             .collect();
         return traced_op!(
-            op_name, ns, set, parent_ctx, conn_info,
+            op_name,
+            ns,
+            set,
+            parent_ctx,
+            conn_info,
             client.batch(batch_policy, &batch_ops).await
         );
     }
@@ -358,15 +389,7 @@ pub async fn do_batch_write(
     let mut retry_indices: Vec<usize> = Vec::new();
     for attempt in 0..max_retries {
         // Find indices of failed records that are retryable
-        retry_indices.clear();
-        retry_indices.extend(results.iter().enumerate().filter_map(|(i, br)| {
-            if let Some(rc) = &br.result_code {
-                if *rc != aerospike_core::ResultCode::Ok && is_retryable_result_code(rc) {
-                    return Some(i);
-                }
-            }
-            None
-        }));
+        collect_retryable_indices(&results, &mut retry_indices);
 
         if retry_indices.is_empty() {
             log::debug!(
@@ -849,5 +872,96 @@ mod tests {
         assert!(val <= 500);
         let val = compute_backoff_ms(u32::MAX, 10, 500);
         assert!(val <= 500);
+    }
+
+    // ── collect_retryable_indices tests ────────────────────────────────────
+
+    /// Create a minimal `BatchRecord` for testing.
+    ///
+    /// `BatchRecord::new` is `pub(crate)` in `aerospike_core`, so we build
+    /// an instance by cloning a layout-compatible repr and overwriting the
+    /// public `result_code` field.  The private `has_write: bool` field is
+    /// irrelevant to `collect_retryable_indices`.
+    fn make_batch_record(result_code: Option<ResultCode>) -> BatchRecord {
+        /// Layout-compatible mirror used solely to construct test fixtures.
+        #[repr(C)]
+        struct BatchRecordMirror {
+            key: aerospike_core::Key,
+            record: Option<Record>,
+            result_code: Option<ResultCode>,
+            in_doubt: bool,
+            has_write: bool,
+        }
+
+        let mirror = BatchRecordMirror {
+            key: aerospike_core::Key::new("test", "demo", Value::from("k1".to_string())).unwrap(),
+            record: None,
+            result_code,
+            in_doubt: false,
+            has_write: false,
+        };
+        // SAFETY: `BatchRecordMirror` has the identical field types and order
+        // as `BatchRecord`. This is only used in unit tests.
+        unsafe { std::mem::transmute(mirror) }
+    }
+
+    #[test]
+    fn test_collect_retryable_indices_all_ok() {
+        let results = vec![
+            make_batch_record(Some(ResultCode::Ok)),
+            make_batch_record(Some(ResultCode::Ok)),
+            make_batch_record(None), // None means Ok
+        ];
+        let mut indices = Vec::new();
+        collect_retryable_indices(&results, &mut indices);
+        assert!(indices.is_empty());
+    }
+
+    #[test]
+    fn test_collect_retryable_indices_retryable_only() {
+        let results = vec![
+            make_batch_record(Some(ResultCode::Ok)),
+            make_batch_record(Some(ResultCode::Timeout)),
+            make_batch_record(Some(ResultCode::Ok)),
+            make_batch_record(Some(ResultCode::KeyBusy)),
+        ];
+        let mut indices = Vec::new();
+        collect_retryable_indices(&results, &mut indices);
+        assert_eq!(indices, vec![1, 3]);
+    }
+
+    #[test]
+    fn test_collect_retryable_indices_non_retryable_excluded() {
+        let results = vec![
+            make_batch_record(Some(ResultCode::KeyExistsError)),
+            make_batch_record(Some(ResultCode::RecordTooBig)),
+            make_batch_record(Some(ResultCode::Timeout)),
+        ];
+        let mut indices = Vec::new();
+        collect_retryable_indices(&results, &mut indices);
+        assert_eq!(indices, vec![2]); // Only Timeout is retryable
+    }
+
+    #[test]
+    fn test_collect_retryable_indices_mixed() {
+        let results = vec![
+            make_batch_record(Some(ResultCode::Ok)),             // ok
+            make_batch_record(Some(ResultCode::Timeout)),        // retryable
+            make_batch_record(Some(ResultCode::KeyExistsError)), // non-retryable
+            make_batch_record(Some(ResultCode::DeviceOverload)), // retryable
+            make_batch_record(None),                             // ok (None)
+            make_batch_record(Some(ResultCode::ServerMemError)), // retryable
+        ];
+        let mut indices = Vec::new();
+        collect_retryable_indices(&results, &mut indices);
+        assert_eq!(indices, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn test_collect_retryable_indices_clears_output() {
+        let results = vec![make_batch_record(Some(ResultCode::Timeout))];
+        let mut indices = vec![99, 100]; // pre-populated
+        collect_retryable_indices(&results, &mut indices);
+        assert_eq!(indices, vec![0]); // old values cleared
     }
 }

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -51,8 +51,8 @@ pub fn parse_batch_write_policy(
     Ok(policy)
 }
 
-/// Apply per-record meta TTL to a [`BatchWritePolicy`], overriding the
-/// batch-level default.
+/// Apply per-record meta (TTL, generation) to a [`BatchWritePolicy`],
+/// overriding the batch-level default.
 pub fn apply_record_meta(
     base: &BatchWritePolicy,
     meta: &Bound<'_, PyDict>,
@@ -60,6 +60,10 @@ pub fn apply_record_meta(
     let mut policy = base.clone();
     if let Some(ttl) = meta.get_item("ttl")? {
         policy.expiration = parse_ttl(ttl.extract::<i64>()?)?;
+    }
+    if let Some(gen) = meta.get_item("gen")? {
+        policy.generation = gen.extract::<u32>()?;
+        policy.generation_policy = aerospike_core::GenerationPolicy::ExpectGenEqual;
     }
     Ok(policy)
 }

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -635,6 +635,11 @@ class Client:
                 exponential backoff (Full Jitter, max 500ms). Retries stop
                 early if the elapsed time approaches ``total_timeout``.
 
+                **Note:** If a transport error occurs during retry, retries
+                stop and partial results are returned. Always check each
+                ``BatchRecord.result`` code. Total wall-clock time may exceed
+                ``total_timeout`` by up to one additional timeout window.
+
         Returns:
             A list of ``BatchRecord`` NamedTuples with per-record result codes.
 
@@ -682,6 +687,11 @@ class Client:
                 device overload, key busy) are automatically retried with
                 exponential backoff (Full Jitter, max 500ms). Retries stop
                 early if the elapsed time approaches ``total_timeout``.
+
+                **Note:** If a transport error occurs during retry, retries
+                stop and partial results are returned. Always check each
+                ``BatchRecord.result`` code. Total wall-clock time may exceed
+                ``total_timeout`` by up to one additional timeout window.
 
         Returns:
             A ``BatchRecords`` containing per-record result codes.
@@ -1626,6 +1636,11 @@ class AsyncClient:
                 exponential backoff (Full Jitter, max 500ms). Retries stop
                 early if the elapsed time approaches ``total_timeout``.
 
+                **Note:** If a transport error occurs during retry, retries
+                stop and partial results are returned. Always check each
+                ``BatchRecord.result`` code. Total wall-clock time may exceed
+                ``total_timeout`` by up to one additional timeout window.
+
         Returns:
             A list of ``BatchRecord`` NamedTuples with per-record result codes.
 
@@ -1671,6 +1686,11 @@ class AsyncClient:
                 device overload, key busy) are automatically retried with
                 exponential backoff (Full Jitter, max 500ms). Retries stop
                 early if the elapsed time approaches ``total_timeout``.
+
+                **Note:** If a transport error occurs during retry, retries
+                stop and partial results are returned. Always check each
+                ``BatchRecord.result`` code. Total wall-clock time may exceed
+                ``total_timeout`` by up to one additional timeout window.
 
         Returns:
             A ``BatchRecords`` containing per-record result codes.

--- a/tests/integration/test_async.py
+++ b/tests/integration/test_async.py
@@ -204,3 +204,113 @@ class TestAsyncBatchWriteTTL:
         _, meta, _ = await async_client.get(key)
         assert meta is not None
         assert meta.ttl > 0
+
+    async def test_async_batch_write_per_record_meta_overrides_policy_ttl(self, async_client, async_cleanup):
+        """Per-record meta TTL overrides batch-level policy TTL."""
+        key_policy = ("test", "demo", "abw_ttl_override_pol")
+        key_meta = ("test", "demo", "abw_ttl_override_meta")
+        async_cleanup.append(key_policy)
+        async_cleanup.append(key_meta)
+
+        policy_ttl = 86400  # 1 day
+        meta_ttl = 3600  # 1 hour
+
+        records = [
+            (key_policy, {"val": 1}),  # uses batch-level TTL
+            (key_meta, {"val": 2}, {"ttl": meta_ttl}),  # overrides with per-record TTL
+        ]
+        results = await async_client.batch_write(records, policy={"ttl": policy_ttl})
+        for br in results.batch_records:
+            assert br.result == 0
+
+        _, meta_pol, _ = await async_client.get(key_policy)
+        assert meta_pol is not None
+        assert meta_pol.ttl > 3600
+
+        _, meta_m, _ = await async_client.get(key_meta)
+        assert meta_m is not None
+        assert meta_m.ttl <= meta_ttl
+        assert meta_m.ttl > 0
+
+    async def test_async_batch_write_ttl_dont_update(self, async_client, async_cleanup):
+        """TTL_DONT_UPDATE preserves original TTL while updating bins."""
+        key = ("test", "demo", "abw_ttl_dont_upd")
+        async_cleanup.append(key)
+
+        await async_client.put(key, {"val": 1}, meta={"ttl": 3600})
+
+        results = await async_client.batch_write([(key, {"val": 2}, {"ttl": aerospike_py.TTL_DONT_UPDATE})])
+        assert results.batch_records[0].result == 0
+
+        _, meta, bins = await async_client.get(key)
+        assert bins["val"] == 2
+        assert meta.ttl > 3000
+
+    async def test_async_batch_write_mixed_ttl_in_batch(self, async_client, async_cleanup):
+        """Different TTL values per record in a single batch call."""
+        key_a = ("test", "demo", "abw_ttl_mix_a")
+        key_b = ("test", "demo", "abw_ttl_mix_b")
+        key_c = ("test", "demo", "abw_ttl_mix_c")
+        for k in (key_a, key_b, key_c):
+            async_cleanup.append(k)
+
+        records = [
+            (key_a, {"val": 1}, {"ttl": 3600}),
+            (key_b, {"val": 2}, {"ttl": 86400}),
+            (key_c, {"val": 3}),
+        ]
+        results = await async_client.batch_write(records, policy={"ttl": 300})
+        for br in results.batch_records:
+            assert br.result == 0
+
+        _, meta_a, _ = await async_client.get(key_a)
+        _, meta_b, _ = await async_client.get(key_b)
+        _, meta_c, _ = await async_client.get(key_c)
+
+        assert meta_a.ttl > 300
+        assert meta_a.ttl <= 3600
+        assert meta_b.ttl > 3600
+        assert meta_b.ttl <= 86400
+        assert meta_c.ttl > 0
+        assert meta_c.ttl <= 300
+
+
+class TestAsyncBatchWriteGen:
+    """Test async batch_write() generation (CAS) support via per-record meta."""
+
+    async def test_async_batch_write_gen_check_success(self, async_client, async_cleanup):
+        """Per-record gen check succeeds when generation matches."""
+        key = ("test", "demo", "abw_gen_ok")
+        async_cleanup.append(key)
+        await async_client.put(key, {"val": 1})
+        _, meta, _ = await async_client.get(key)
+        current_gen = meta.gen
+
+        results = await async_client.batch_write([(key, {"val": 2}, {"gen": current_gen})])
+        assert results.batch_records[0].result == 0
+        _, _, bins = await async_client.get(key)
+        assert bins["val"] == 2
+
+    async def test_async_batch_write_gen_check_mismatch(self, async_client, async_cleanup):
+        """Per-record gen check fails when generation does not match."""
+        key = ("test", "demo", "abw_gen_mismatch")
+        async_cleanup.append(key)
+        await async_client.put(key, {"val": 1})
+
+        results = await async_client.batch_write([(key, {"val": 2}, {"gen": 999})])
+        assert results.batch_records[0].result != 0
+
+    async def test_async_batch_write_gen_and_ttl_combined(self, async_client, async_cleanup):
+        """Gen and TTL can be used together in WriteMeta."""
+        key = ("test", "demo", "abw_gen_ttl")
+        async_cleanup.append(key)
+        await async_client.put(key, {"val": 1})
+        _, meta, _ = await async_client.get(key)
+        current_gen = meta.gen
+
+        results = await async_client.batch_write([(key, {"val": 2}, {"gen": current_gen, "ttl": 3600})])
+        assert results.batch_records[0].result == 0
+        _, meta2, bins = await async_client.get(key)
+        assert bins["val"] == 2
+        assert meta2.ttl > 0
+        assert meta2.ttl <= 3600

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -518,6 +518,48 @@ class TestBatchWriteTTL:
         assert meta_c.ttl <= 300
 
 
+class TestBatchWriteGen:
+    """Test batch_write() generation (CAS) support via per-record meta."""
+
+    def test_batch_write_gen_check_success(self, client, cleanup):
+        """Per-record gen check succeeds when generation matches."""
+        key = ("test", "demo", "bw_gen_ok")
+        cleanup.append(key)
+        client.put(key, {"val": 1})
+        _, meta, _ = client.get(key)
+        current_gen = meta.gen
+
+        results = client.batch_write([(key, {"val": 2}, {"gen": current_gen})])
+        assert results.batch_records[0].result == 0
+        _, _, bins = client.get(key)
+        assert bins["val"] == 2
+
+    def test_batch_write_gen_check_mismatch(self, client, cleanup):
+        """Per-record gen check fails when generation does not match."""
+        key = ("test", "demo", "bw_gen_mismatch")
+        cleanup.append(key)
+        client.put(key, {"val": 1})
+
+        # stale generation = 999
+        results = client.batch_write([(key, {"val": 2}, {"gen": 999})])
+        assert results.batch_records[0].result != 0  # GENERATION_ERROR
+
+    def test_batch_write_gen_and_ttl_combined(self, client, cleanup):
+        """Gen and TTL can be used together in WriteMeta."""
+        key = ("test", "demo", "bw_gen_ttl")
+        cleanup.append(key)
+        client.put(key, {"val": 1})
+        _, meta, _ = client.get(key)
+        current_gen = meta.gen
+
+        results = client.batch_write([(key, {"val": 2}, {"gen": current_gen, "ttl": 3600})])
+        assert results.batch_records[0].result == 0
+        _, meta2, bins = client.get(key)
+        assert bins["val"] == 2
+        assert meta2.ttl > 0
+        assert meta2.ttl <= 3600
+
+
 class TestBatchRemove:
     def test_batch_remove(self, client):
         keys = [


### PR DESCRIPTION
## Summary

PR #277, #275, #264, #263 코드 리뷰에서 발견된 이슈들을 수정합니다.

- **[P0] WriteMeta.gen 지원 추가**: `apply_record_meta()`가 `ttl`만 처리하고 `gen`을 무시하던 버그 수정. `batch_write`에서 per-record generation CAS 지원 (`batch_policy.rs`)
- **[P0] batch_records deep clone 제거**: `PyBatchReadHandle.batch_records` getter가 `(*self.inner).clone()`으로 전체 `Vec<BatchRecord>`를 deep clone하던 것을 `single_batch_record_to_py()` 직접 호출로 변경 (`batch_types.rs`)
- **[P1] Retry 문서화**: transport 에러 시 partial results 반환 동작과 elapsed time guard 한계를 Rust docstring + `.pyi` 타입 스텁에 명시 (`client_ops.rs`, `__init__.pyi`)
- **[P1] Async TTL 테스트 parity**: sync에만 있던 3개 TTL 테스트를 async로 추가 (`test_async.py`)
- **[P1] Gen 통합 테스트**: sync/async 각 3개씩 generation CAS 테스트 추가 (`test_batch.py`, `test_async.py`)
- **[P2] collect_retryable_indices 헬퍼 추출**: retry loop 내 인라인 로직을 테스트 가능한 함수로 추출 + 단위 테스트 5개 (`client_ops.rs`)

## Test plan

- [x] `cargo check` — 컴파일 통과
- [x] `cargo test` — Rust 93개 테스트 통과 (새로 5개 추가)
- [x] `make validate` (fmt + lint + typecheck + unit) — Python 849개 테스트 통과
- [ ] `make test-integration` — gen CAS 테스트 서버 필요 (CI에서 검증)