### PR TITLE
perf(batch): intern bin names in batch_to_dict_py to reduce GIL hold time

### DIFF
--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -5,12 +5,13 @@
 //! Python until the user accesses `br.record`. This reduces GIL hold time by
 //! 70-80% for large batches where not all records' bins are accessed.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use aerospike_core::{BatchRecord, Record, ResultCode};
 use log::trace;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyString};
 
 use crate::errors::result_code_to_int;
 use crate::types::key::key_to_py;
@@ -303,15 +304,21 @@ fn single_batch_record_to_py(py: Python<'_>, br: &BatchRecord) -> PyResult<Py<Py
 /// Skips all intermediate objects (BatchRecord wrapper, key tuple, meta dict,
 /// record tuple). Only creates bins dicts + the outer dict.
 ///
-/// Allocation count for N records with B bins each:
-/// - Standard path: N × (5 key + 1 meta + 1 bins + B values + 1 tuple + 1 wrapper) = N×(9+B)
-/// - AsDict path:   N × (1 bins + B values) + 1 outer dict = N×(1+B) + 1
-///   → Savings: N × 8 allocations (e.g., 1800 × 8 = 14,400 alloc saved)
+/// Allocation count for N records with B bins each and U unique bin names:
+/// - Standard path:      N × (5 key + 1 meta + 1 bins + B values + 1 tuple + 1 wrapper) = N×(9+B)
+/// - AsDict path:        N × (1 bins + B values) + 1 outer dict = N×(1+B) + 1
+/// - AsDict+NameCache:   N × (1 bins + B values) + U name strings + 1 outer dict
+///   → Bin name allocations: N×B → U (typical schemas reuse names, so U ≪ N×B).
 pub fn batch_to_dict_py<'py>(
     py: Python<'py>,
     results: &[BatchRecord],
 ) -> PyResult<Bound<'py, PyDict>> {
     use crate::types::value::value_to_py;
+
+    // Per-call PyString cache for bin names. Typical workloads reuse the same
+    // schema (e.g., "impCnt", "clkCnt") across records, so N×B allocations
+    // collapse to U (unique bin count). Cache lives only for this call.
+    let mut name_cache: HashMap<&str, Bound<'py, PyString>> = HashMap::new();
 
     let dict = PyDict::new(py);
     for br in results {
@@ -327,7 +334,11 @@ pub fn batch_to_dict_py<'py>(
         if let Some(record) = &br.record {
             let bins = PyDict::new(py);
             for (name, value) in &record.bins {
-                bins.set_item(name, value_to_py(py, value)?)?;
+                let py_name = name_cache
+                    .entry(name.as_str())
+                    .or_insert_with(|| PyString::new(py, name))
+                    .clone();
+                bins.set_item(&py_name, value_to_py(py, value)?)?;
             }
             dict.set_item(&key_str, &bins)?;
         }


### PR DESCRIPTION
## Summary

Implements the optimization proposed in #281: cache bin-name → `PyString` mapping per call in `batch_to_dict_py` so that repeated bin names (typical Aerospike schema reuse) are allocated only once per call instead of N×B times.

- **Allocation reduction:** N×B → U (unique bin count). For the issue's 200 keys × 7 bins case, 1,400 PyString allocations collapse to ≤7.
- **No functional change:** return type remains `dict[user_key, dict[bin_name, value]]`; all existing assertions on bin-name dict keys continue to hold.
- **Scope:** limited to `batch_to_dict_py` (per issue + planning decision). The same `for (name, value) in &record.bins` pattern exists in `record_to_py_inner` (`rust/src/types/record.rs:67-70`) and `value_to_py` HashMap/OrderedMap branches (`rust/src/types/value.rs:90-102`); those are deferred to separate follow-up issues.

## Implementation

Single file: `rust/src/batch_types.rs` (+17 / -6).

\`\`\`rust
let mut name_cache: HashMap<&str, Bound<'py, PyString>> = HashMap::new();
// ...
let py_name = name_cache
    .entry(name.as_str())
    .or_insert_with(|| PyString::new(py, name))
    .clone();
bins.set_item(&py_name, value_to_py(py, value)?)?;
\`\`\`

- Per-call cache (no pollution of Python's global intern table).
- `Bound<'py, PyString>::clone()` is a cheap refcount bump.
- Cache lifetime is scoped to the function call — GIL is held throughout, so no thread-safety concerns.

## Performance

Measured locally with 10 concurrent VUs × 30 rounds × 200 keys × 7 bins via `asyncio.gather`, podman Aerospike CE 8.1.0.3:

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| p50 per-request | 5.86 ms | **4.99 ms** | -14.8% |
| p95 per-request | 7.63 ms | 7.64 ms | ±0% |
| p99 per-request | 11.07 ms | **9.02 ms** | -18.5% |
| mean per-request | 5.79 ms | **5.18 ms** | -10.5% |
| round wall-clock | 7.38 ms | 6.82 ms | -7.6% |

Absolute numbers are smaller than the issue's 145 ms figure because the local test environment differs (no FastAPI layer, no containerized network stack), but the relative improvement validates GIL hold-time reduction.

## Call sites affected

Both paths now benefit (return type unchanged):
1. `Client.batch_read()` sync fast path — `rust/src/client.rs:1138`
2. `AsyncClient.batch_read()` → `PyBatchReadHandle.as_dict()` — `rust/src/batch_types.rs:209`

## Test plan

- [x] \`make test-unit\` — 841 passed / 8 skipped
- [x] \`tests/integration/test_batch.py\` — 29 passed
- [x] \`tests/integration/test_batch_handle.py\` — 8 passed (dict key access, bin filtering, missing record exclusion)
- [x] \`tests/compatibility/test_batch.py\` — 6 passed (official C client interop)
- [x] \`tests/concurrency/\` — 51 passed / 1 skipped
- [x] \`cargo check --manifest-path rust/Cargo.toml\` — clean
- [x] \`cargo clippy --manifest-path rust/Cargo.toml --lib -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] 10 VU concurrency reproducer — before/after shown above

Closes #281