### PR TITLE
fix(ci): grant workflow permissions to docs-version and security jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -341,6 +341,14 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # rustsec/audit-check creates a check-run summarizing the audit result.
+    # Workflow-level permission is `contents: read`, so this job needs an
+    # explicit elevation for `checks: write` — otherwise it fails with
+    # HTTP 403 "Resource not accessible by integration".
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -348,6 +356,13 @@ jobs:
         uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # RUSTSEC-2026-0097: `rand` is unsound only when a custom logger
+          # defined by the application itself calls `rand::rng()` while
+          # reseeding. aerospike-py's custom log bridge (rust/src/logging.rs)
+          # does not touch `rand`; thread_rng usage is confined to
+          # exponential-backoff jitter in rust/src/client_ops.rs.
+          # The unsound trigger cannot be reached through public API.
+          ignore: RUSTSEC-2026-0097
 
   compatibility:
     name: Compatibility Tests

--- a/.github/workflows/docs-version.yaml
+++ b/.github/workflows/docs-version.yaml
@@ -12,6 +12,11 @@ on:
 
 permissions:
   contents: write
+  # actions: write is required for the trailing "Trigger docs publish" step
+  # which dispatches the Publish Docs workflow via `gh workflow run`.
+  # Without this, dispatch returns HTTP 403:
+  # "Resource not accessible by integration".
+  actions: write
 
 concurrency:
   group: docs-version


### PR DESCRIPTION
## Summary

Fix two latent `GITHUB_TOKEN` scope gaps surfaced by the v0.5.6 release run. Both jobs ran to completion on their happy path but exited non-zero on trailing API calls that needed higher permission scopes than the workflow granted.

## Problems

### 1. `docs-version.yaml` — "Trigger docs publish" returns HTTP 403

\`\`\`
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
\`\`\`

The workflow grants only `contents: write`, but the trailing step calls \`gh workflow run "Publish Docs"\` which dispatches a `workflow_dispatch` event — this requires `actions: write`. The actual docs freeze commit (\`docs: freeze version 0.5.6\`, `3f8172b`) succeeded; only the trailing publish-docs trigger failed.

### 2. `ci.yaml` Security Audit — HTTP 403 on check-run creation + false-positive RUSTSEC-2026-0097

\`\`\`
##[warning]2 warnings found!
Found 2 unsound
##[error]Resource not accessible by integration - https://docs.github.com/rest/checks/runs#create-a-check-run
\`\`\`

Two separate issues:
- `rustsec/audit-check` creates a check-run summarising the audit result. The workflow-level permission is `contents: read`, and the security job has no job-level permissions block, so the action can't create the check-run.
- The audit reports RUSTSEC-2026-0097 (`rand` v0.8.5 / v0.9.2 unsound) as two informational warnings. `audit-check` treats informational warnings as a failure signal.

## Fixes

### `docs-version.yaml`
Add `actions: write` to the workflow-level permissions block so `gh workflow run` can dispatch the Publish Docs workflow.

### `ci.yaml` (Security Audit job)
- Add a job-scoped `permissions:` block with `contents: read`, `checks: write`, `issues: write` so `audit-check` can create a check-run and open/close advisory issues.
- Add `ignore: RUSTSEC-2026-0097` to the audit-check step with a comment explaining the analysis.

### Why ignoring RUSTSEC-2026-0097 is safe

The advisory flags `rand` as unsound **only** under this combination of conditions:
1. The **application itself defines a custom `log` logger**
2. The custom logger calls `rand::rng()` (or `rand::thread_rng()`) internally
3. The call happens while `ThreadRng` is reseeding (every 64 kB of generated data)
4. Trace-level logging is enabled, or warn-level logging is enabled and the OS can't provide entropy

aerospike-py:
- `rust/src/logging.rs` — custom log bridge. Inspected: **does not call `rand` at all**.
- `rust/src/client_ops.rs:290` — `rand::thread_rng().gen_range(0..=max_backoff)` for exponential-backoff jitter. Not called from any logger path.

The advisory's trigger **cannot be reached through any public aerospike-py API**. The `ignore` is documented in-line with the file paths and line numbers of the analysis so a future maintainer can re-verify.

## Also affected

v0.5.6 release is already published (wheels built by publish.yaml; docs frozen as `docs: freeze version 0.5.6`). Only the "Publish Docs" dispatch was missed — that workflow needs a one-time manual run for v0.5.6 to go live on the docs site. Starting with v0.5.7, the chain will be self-healing.

## Test plan

- [x] Verify `rand::thread_rng()` is not called from any log-bridge path (grep confirms)
- [ ] After merge, manually trigger "Publish Docs" for v0.5.6 one time
- [ ] Next release chain runs end-to-end with no 403 in Freeze Docs
- [ ] CI Security Audit passes on this PR

No runtime or source-code change.