### PR TITLE
revert: bin name interning in batch_to_dict_py (production regression)

### DIFF
--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -5,13 +5,12 @@
 //! Python until the user accesses `br.record`. This reduces GIL hold time by
 //! 70-80% for large batches where not all records' bins are accessed.
 
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use aerospike_core::{BatchRecord, Record, ResultCode};
 use log::trace;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyString};
+use pyo3::types::{PyDict, PyList};
 
 use crate::errors::result_code_to_int;
 use crate::types::key::key_to_py;
@@ -304,21 +303,15 @@ fn single_batch_record_to_py(py: Python<'_>, br: &BatchRecord) -> PyResult<Py<Py
 /// Skips all intermediate objects (BatchRecord wrapper, key tuple, meta dict,
 /// record tuple). Only creates bins dicts + the outer dict.
 ///
-/// Allocation count for N records with B bins each and U unique bin names:
-/// - Standard path:      N × (5 key + 1 meta + 1 bins + B values + 1 tuple + 1 wrapper) = N×(9+B)
-/// - AsDict path:        N × (1 bins + B values) + 1 outer dict = N×(1+B) + 1
-/// - AsDict+NameCache:   N × (1 bins + B values) + U name strings + 1 outer dict
-///   → Bin name allocations: N×B → U (typical schemas reuse names, so U ≪ N×B).
+/// Allocation count for N records with B bins each:
+/// - Standard path: N × (5 key + 1 meta + 1 bins + B values + 1 tuple + 1 wrapper) = N×(9+B)
+/// - AsDict path:   N × (1 bins + B values) + 1 outer dict = N×(1+B) + 1
+///   → Savings: N × 8 allocations (e.g., 1800 × 8 = 14,400 alloc saved)
 pub fn batch_to_dict_py<'py>(
     py: Python<'py>,
     results: &[BatchRecord],
 ) -> PyResult<Bound<'py, PyDict>> {
     use crate::types::value::value_to_py;
-
-    // Per-call PyString cache for bin names. Typical workloads reuse the same
-    // schema (e.g., "impCnt", "clkCnt") across records, so N×B allocations
-    // collapse to U (unique bin count). Cache lives only for this call.
-    let mut name_cache: HashMap<&str, Bound<'py, PyString>> = HashMap::new();
 
     let dict = PyDict::new(py);
     for br in results {
@@ -334,11 +327,7 @@ pub fn batch_to_dict_py<'py>(
         if let Some(record) = &br.record {
             let bins = PyDict::new(py);
             for (name, value) in &record.bins {
-                let py_name = name_cache
-                    .entry(name.as_str())
-                    .or_insert_with(|| PyString::new(py, name))
-                    .clone();
-                bins.set_item(&py_name, value_to_py(py, value)?)?;
+                bins.set_item(name, value_to_py(py, value)?)?;
             }
             dict.set_item(&key_str, &bins)?;
         }


### PR DESCRIPTION
## Summary

**Revert PR #282** (bin name interning in \`batch_to_dict_py\`). Production measurement against a real FastAPI + Aerospike serving stack shows a ~2x regression on the batch_read path and — critically — a ~7.5x regression on non-aerospike code sharing the same event loop, indicating extended GIL hold time.

## Evidence: 0.5.5 vs 0.5.6 production benchmark (10 VU)

Between 0.5.5 and 0.5.6, only two PRs landed. #286 is CI-only (no runtime change). So the delta is entirely from PR #282.

| Section (p90) | 0.5.5 | 0.5.6 | Change |
|---|---:|---:|---:|
| batch_read per-set | ~60 ms | 108-134 ms | **~2x slower** |
| \`aerospike_batch_read_all\` | 145 ms | 255 ms | ~1.8x slower |
| \`feature_extraction\` | 10 ms | 9 ms | same |
| **\`inference\` (non-aerospike)** | **8 ms** | **60 ms** | **~7.5x slower** |
| E2E p50 | 155 ms | 296 ms | ~1.9x slower |
| RPS | 60.9 | 34.7 | −43% |

The \`inference\` regression is the conclusive signal: that code path does not call aerospike-py at all. The only way this PR can slow it down is by holding the GIL longer during batch_read conversion, serializing other Python work in the same event loop.

## Why the local benchmark was misleading

The benchmark that validated PR #282 (10 VUs × 30 rounds × 200 keys × 7 bins via raw \`asyncio.gather\`) showed a modest improvement (p50 −14.8%, p99 −18.5%). It missed the regression because:

- **Single tight-loop workload**. No other CPU-bound Python code competing for the GIL on the same event loop — so extended GIL hold time had no victim to surface against.
- **Scale mismatch**. Local p50 was ~5 ms; production p50 is ~150-300 ms. The HashMap overhead is a constant that is proportionally tiny at 5 ms total but material at 150 ms total.
- **No FastAPI/Pydantic layer**. Real-world stacks do serialization and validation between batch_read calls; their GIL share matters.

## Root cause

Per-call \`HashMap<&str, Bound<PyString>>\` adds CPU-bound work on the GIL-holding thread:

- SipHash per bin lookup (N×B hashes per call)
- HashMap bucket traversal + entry API
- \`Bound<PyString>::clone\` refcount bump per hit

The intended saving — avoiding PyString allocation for repeated bin names — is already largely free in CPython:

- \`PyUnicode_FromStringAndSize\` hits the small-string internal cache for short strings
- CPython interns short ASCII identifiers at string creation

So we moved work from a fast C path into a slower Rust HashMap path. Net: longer GIL hold, slower end-to-end throughput.

## Scope

- \`rust/src/batch_types.rs\` returns to the pre-#282 implementation.
- **Unaffected**: PR #286 (Python 3.14 / 3.14t wheel support) stays in.
- **Follow-up issues opened based on #282**:
  - #283 (\`.clone()\` removal) — premise gone, should be closed.
  - #284 (extend pattern to \`record_to_py_inner\` / \`value_to_py\`) — premise gone, should be closed.
  - #285 (permanent concurrent microbench) — **still valuable, keep open**. The next optimization attempt must be validated against a FastAPI-like load before merging.

## Test plan

- [x] \`cargo check\` clean
- [ ] Existing integration + compatibility + concurrency tests pass (CI)
- [ ] Release v0.5.7 restores 0.5.5 production performance

## Follow-up (not in this PR)

\`PyString::intern\` as an alternative that leverages CPython's own intern table (instead of a Rust-side HashMap) can be explored. Must be validated with a production-like benchmark including competing Python work on the same loop **before** any PR is merged. Opening a new issue to track.

Closes the regression. Does not close #281 — the original performance concern is still valid; we just need a different approach.