### PR TITLE
fix(async): unify AsyncClient.close and __aexit__ via shared helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [Unreleased]: https://github.com/KimSoungRyoul/aerospike-py/compare/v0.0.1.beta2...HEAD
 
 ### Changed (BREAKING)
+- `AsyncClient.__aexit__` now raises `ClientError` when the client is in the `CONNECTING` state, matching the existing behaviour of `close()`. Previously it silently returned `False`, leaving a half-initialized client if the `async with` block exited while `connect()` was still in flight. Closes #293.
 - `BatchRecords` is now a `TypeAlias = dict[UserKey, AerospikeRecord]` (was a `NamedTuple` with a `batch_records` attribute). This is the return type of both `Client.batch_read` and `AsyncClient.batch_read`. Migration:
     ```python
     # Before

--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -17,6 +17,22 @@ const CONNECTING: u8 = 1;
 const CONNECTED: u8 = 2;
 const CLOSING: u8 = 3;
 
+/// Outcome of preparing a close transition — see [`PyAsyncClient::prepare_close`].
+///
+/// Computed synchronously while holding `&mut self` so the subsequent async
+/// future borrows no references from `self`.
+enum CloseOutcome {
+    /// Client was already disconnected or mid-close; caller should resolve
+    /// its Python awaitable with the idempotent no-op value.
+    Idempotent,
+    /// Client was connected; caller should drive `client.close()` in the
+    /// returned future and transition state to `DISCONNECTED` on completion.
+    Proceed {
+        client: Option<Arc<AsClient>>,
+        state: Arc<AtomicU8>,
+    },
+}
+
 use crate::batch_types::{PendingBatchRead, PendingBatchRecords};
 use crate::errors::as_to_pyerr;
 use crate::policy::admin_policy::{parse_privileges, role_to_py, user_to_py};
@@ -169,35 +185,19 @@ impl PyAsyncClient {
     /// Close connection (async).
     fn close<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         info!("Closing async client connection");
-        let current = self.state.load(Ordering::SeqCst);
-        if current == DISCONNECTED || current == CLOSING {
-            // Already disconnected or closing — idempotent no-op.
-            return future_into_py(py, async move { Ok(()) });
+        match self.prepare_close()? {
+            CloseOutcome::Idempotent => future_into_py(py, async move { Ok(()) }),
+            CloseOutcome::Proceed { client, state } => future_into_py(py, async move {
+                let result = if let Some(c) = client {
+                    c.close().await.map_err(as_to_pyerr)
+                } else {
+                    Ok(())
+                };
+                // Always transition to Disconnected — inner is already None.
+                state.store(DISCONNECTED, Ordering::SeqCst);
+                result
+            }),
         }
-        if current == CONNECTING {
-            return Err(crate::errors::ClientError::new_err(
-                "Cannot close: client is currently connecting.",
-            ));
-        }
-
-        self.state.store(CLOSING, Ordering::SeqCst);
-        let client = self.inner.swap(None);
-        let state = self.state.clone();
-
-        // Reset connection metadata and limiter to default.
-        self.connection_info = Arc::new(crate::tracing::ConnectionInfo::default());
-        self.limiter = Arc::new(OperationLimiter::new(0, 0));
-
-        future_into_py(py, async move {
-            let result = if let Some(c) = client {
-                c.close().await.map_err(as_to_pyerr)
-            } else {
-                Ok(())
-            };
-            // Always transition to Disconnected — inner is already None.
-            state.store(DISCONNECTED, Ordering::SeqCst);
-            result
-        })
     }
 
     /// Get node names (sync, no I/O, lock-free).
@@ -244,6 +244,11 @@ impl PyAsyncClient {
     }
 
     /// Async context manager exit.
+    ///
+    /// Shares the close path with `close()`. In particular, exiting the
+    /// `async with` block while `connect()` is still in flight raises a
+    /// `ClientError` — the same behaviour as calling `close()` explicitly —
+    /// rather than silently leaking a half-initialized client.
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __aexit__<'py>(
         &mut self,
@@ -252,28 +257,19 @@ impl PyAsyncClient {
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let current = self.state.load(Ordering::SeqCst);
-        if current != CONNECTED {
-            return future_into_py(py, async move { Ok(false) });
+        match self.prepare_close()? {
+            CloseOutcome::Idempotent => future_into_py(py, async move { Ok(false) }),
+            CloseOutcome::Proceed { client, state } => future_into_py(py, async move {
+                let result = if let Some(c) = client {
+                    c.close().await.map_err(as_to_pyerr)
+                } else {
+                    Ok(())
+                };
+                // Always transition to Disconnected — inner is already None.
+                state.store(DISCONNECTED, Ordering::SeqCst);
+                result.map(|()| false)
+            }),
         }
-        self.state.store(CLOSING, Ordering::SeqCst);
-        let client = self.inner.swap(None);
-        let state = self.state.clone();
-
-        // Reset connection metadata and limiter to default.
-        self.connection_info = Arc::new(crate::tracing::ConnectionInfo::default());
-        self.limiter = Arc::new(OperationLimiter::new(0, 0));
-
-        future_into_py(py, async move {
-            let result = if let Some(c) = client {
-                c.close().await.map_err(as_to_pyerr)
-            } else {
-                Ok(())
-            };
-            // Always transition to Disconnected — inner is already None.
-            state.store(DISCONNECTED, Ordering::SeqCst);
-            result.map(|()| false)
-        })
     }
 
     // ── CRUD ──────────────────────────────────────────────────
@@ -1361,6 +1357,41 @@ impl PyAsyncClient {
         self.inner.load_full().ok_or_else(|| {
             crate::errors::ClientError::new_err("Client is not connected. Call connect() first.")
         })
+    }
+
+    /// Shared pre-close step for `close()` and `__aexit__`.
+    ///
+    /// Atomically inspects state and, when CONNECTED, transitions to CLOSING,
+    /// swaps the inner `AsClient` out, and resets connection metadata and the
+    /// limiter. Returns:
+    ///
+    /// - `Ok(CloseOutcome::Idempotent)` when state is already `DISCONNECTED`
+    ///   or `CLOSING` — both `close()` and `__aexit__` treat this as a no-op.
+    /// - `Err(ClientError)` when state is `CONNECTING` — closing while an
+    ///   in-flight `connect()` may still be racing the inner `Arc` would leak
+    ///   a half-initialized client.
+    /// - `Ok(CloseOutcome::Proceed { client, state })` when state is
+    ///   `CONNECTED` — the caller drives `client.close()` and stores
+    ///   `DISCONNECTED` on completion.
+    fn prepare_close(&mut self) -> PyResult<CloseOutcome> {
+        let current = self.state.load(Ordering::SeqCst);
+        match current {
+            DISCONNECTED | CLOSING => Ok(CloseOutcome::Idempotent),
+            CONNECTING => Err(crate::errors::ClientError::new_err(
+                "Cannot close: client is currently connecting.",
+            )),
+            CONNECTED => {
+                self.state.store(CLOSING, Ordering::SeqCst);
+                let client = self.inner.swap(None);
+                self.connection_info = Arc::new(crate::tracing::ConnectionInfo::default());
+                self.limiter = Arc::new(OperationLimiter::new(0, 0));
+                Ok(CloseOutcome::Proceed {
+                    client,
+                    state: self.state.clone(),
+                })
+            }
+            _ => unreachable!("invalid AsyncClient state: {current}"),
+        }
     }
 
     /// Internal helper for index creation (async).

--- a/tests/concurrency/test_aexit_close_unification.py
+++ b/tests/concurrency/test_aexit_close_unification.py
@@ -18,6 +18,7 @@ is skipped rather than flaking.
 from __future__ import annotations
 
 import asyncio
+from typing import ClassVar
 
 import pytest
 
@@ -77,7 +78,7 @@ class TestConnectingStateRace:
 
     # Non-routable TEST-NET-1 address (RFC 5737). Guaranteed to make the
     # aerospike_core TCP connect hang until its default timeout.
-    UNREACHABLE_CONFIG = {
+    UNREACHABLE_CONFIG: ClassVar[dict] = {
         "hosts": [("192.0.2.1", 3000)],
         "cluster_name": "unreachable-test",
     }
@@ -105,7 +106,7 @@ class TestConnectingStateRace:
         task.cancel()
         try:
             await task
-        except (BaseException,):  # connect errors or CancelledError
+        except BaseException:  # connect errors or CancelledError
             pass
 
     async def test_aexit_during_connecting_raises(self):
@@ -122,5 +123,5 @@ class TestConnectingStateRace:
         task.cancel()
         try:
             await task
-        except (BaseException,):
+        except BaseException:
             pass

--- a/tests/concurrency/test_aexit_close_unification.py
+++ b/tests/concurrency/test_aexit_close_unification.py
@@ -1,0 +1,126 @@
+"""Regression tests for the close / __aexit__ unification (issue #293).
+
+Verifies that:
+
+- Both exits (`close()` and `__aexit__`) share the same state-machine semantics.
+- Calling `close()` on a never-connected or already-closed client is a no-op.
+- Calling `__aexit__` on a never-entered / already-closed client is a no-op.
+- Both exits raise `ClientError` when state is `CONNECTING` (previously
+  `__aexit__` silently returned `False`, leaving a half-initialized client).
+
+The CONNECTING-race test uses a non-routable host (TEST-NET-1, RFC 5737) so
+the underlying `AsClient::new()` blocks long enough to observe the transient
+CONNECTING state from a second coroutine. It is inherently timing-sensitive
+but tolerant of schedules: if the connect() somehow resolves first, the test
+is skipped rather than flaking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import aerospike_py
+from tests import AEROSPIKE_CONFIG
+
+
+class TestCloseIdempotent:
+    """Shared idempotent paths between close() and __aexit__."""
+
+    async def test_close_on_never_connected_is_noop(self):
+        client = aerospike_py.AsyncClient(AEROSPIKE_CONFIG)
+        # Never called connect().
+        await client.close()
+        assert client.is_connected() is False
+        # Calling again also a no-op.
+        await client.close()
+
+    async def test_close_twice_is_noop(self):
+        client = aerospike_py.AsyncClient(AEROSPIKE_CONFIG)
+        await client.connect()
+        await client.close()
+        # Second call must not raise and must not re-run close().
+        await client.close()
+        assert client.is_connected() is False
+
+    async def test_aexit_without_enter_is_noop(self):
+        """__aexit__ on an AsyncClient that was never entered returns False."""
+        client = aerospike_py.AsyncClient(AEROSPIKE_CONFIG)
+        suppressed = await client.__aexit__(None, None, None)
+        assert suppressed is False
+        assert client.is_connected() is False
+
+    async def test_aexit_after_close_is_noop(self):
+        client = aerospike_py.AsyncClient(AEROSPIKE_CONFIG)
+        await client.connect()
+        await client.close()
+        suppressed = await client.__aexit__(None, None, None)
+        assert suppressed is False
+
+    async def test_async_with_exits_cleanly(self):
+        async with aerospike_py.AsyncClient(AEROSPIKE_CONFIG) as client:
+            await client.connect()
+            assert client.is_connected() is True
+        # Out of `async with`, client should be disconnected.
+        assert client.is_connected() is False
+
+
+class TestConnectingStateRace:
+    """close() and __aexit__ both raise ClientError while CONNECTING.
+
+    Prior to the unification, `__aexit__` silently no-op'd on CONNECTING,
+    leaving a client that the connect future still held alive. Both exits
+    must now raise so callers can't accidentally leak a half-initialized
+    client by exiting the `async with` block during an in-flight connect.
+    """
+
+    # Non-routable TEST-NET-1 address (RFC 5737). Guaranteed to make the
+    # aerospike_core TCP connect hang until its default timeout.
+    UNREACHABLE_CONFIG = {
+        "hosts": [("192.0.2.1", 3000)],
+        "cluster_name": "unreachable-test",
+    }
+
+    async def _start_connecting(self, client: aerospike_py.AsyncClient) -> asyncio.Task:
+        """Kick off connect() as a background task and yield long enough
+        for the Rust state machine to transition to CONNECTING."""
+        task = asyncio.create_task(client.connect())
+        # A few event-loop turns give the Rust code time to CAS into CONNECTING.
+        for _ in range(20):
+            await asyncio.sleep(0)
+        return task
+
+    async def test_close_during_connecting_raises(self):
+        client = aerospike_py.AsyncClient(self.UNREACHABLE_CONFIG)
+        task = await self._start_connecting(client)
+
+        if task.done():
+            pytest.skip("connect() resolved before we could observe CONNECTING state")
+
+        with pytest.raises(aerospike_py.ClientError, match="currently connecting"):
+            await client.close()
+
+        # Clean up the outstanding connect task so the test doesn't leak it.
+        task.cancel()
+        try:
+            await task
+        except (BaseException,):  # connect errors or CancelledError
+            pass
+
+    async def test_aexit_during_connecting_raises(self):
+        """Regression for #293 — previously this silently returned False."""
+        client = aerospike_py.AsyncClient(self.UNREACHABLE_CONFIG)
+        task = await self._start_connecting(client)
+
+        if task.done():
+            pytest.skip("connect() resolved before we could observe CONNECTING state")
+
+        with pytest.raises(aerospike_py.ClientError, match="currently connecting"):
+            await client.__aexit__(None, None, None)
+
+        task.cancel()
+        try:
+            await task
+        except (BaseException,):
+            pass


### PR DESCRIPTION
## Summary

Fixes #293. Unifies the close path between `AsyncClient.close()` and `AsyncClient.__aexit__` via a shared `prepare_close()` helper, removing duplicated state-machine + inner-swap + metadata-reset logic.

Previously the two exits diverged on the `CONNECTING` state:

| Exit | Behaviour before | Behaviour after |
|---|---|---|
| `close()` | Raise `ClientError("Cannot close: client is currently connecting.")` | Unchanged |
| `__aexit__` | Silently return `False` | **Raise** `ClientError` (symmetric with `close()`) |

The silent no-op in `__aexit__` left a half-initialized client alive if the `async with` block exited during an in-flight `connect()` — the outer connect future kept the inner `Arc<AsClient>` but the state machine never cleaned up. Now both exits refuse to close while `CONNECTING` so callers can't accidentally leak a mid-init client.

## Breaking change

`AsyncClient.__aexit__` now raises `ClientError` when the client is `CONNECTING` at exit time. Code that relied on the silent no-op will see an exception propagated out of the `async with` block. CHANGELOG updated under `[Unreleased] → Changed (BREAKING)`.

## Implementation

- New `CloseOutcome` enum (`rust/src/async_client.rs`): `Idempotent` | `Proceed { client, state }`.
- New private helper `PyAsyncClient::prepare_close(&mut self) -> PyResult<CloseOutcome>` atomically transitions `CONNECTED → CLOSING`, swaps `self.inner` out, and resets `connection_info` + `limiter`. Returns `Idempotent` for `DISCONNECTED`/`CLOSING` and raises for `CONNECTING`.
- `close()` and `__aexit__` become thin wrappers that branch on the `CloseOutcome` and drive the async `client.close()` future; they differ only in the final return value (`()` vs `false`).

## Tests

New `tests/concurrency/test_aexit_close_unification.py` with seven cases:

**Idempotent paths (5):**
- `test_close_on_never_connected_is_noop`
- `test_close_twice_is_noop`
- `test_aexit_without_enter_is_noop`
- `test_aexit_after_close_is_noop`
- `test_async_with_exits_cleanly`

**CONNECTING race (2):**
- `test_close_during_connecting_raises`
- `test_aexit_during_connecting_raises` — regression for #293

The CONNECTING-race tests use a non-routable TEST-NET-1 address (`192.0.2.1:3000`, RFC 5737) so the underlying `AsClient::new()` blocks long enough to observe the transient state from a second coroutine. If `connect()` resolves before the second coroutine runs, the test `pytest.skip()`s rather than flaking.

## Test plan

- [x] `cargo fmt + clippy -D warnings` clean
- [x] `make build` succeeds
- [x] New tests: 7/7 pass
- [x] `pytest tests/concurrency -q`: 58 passed / 1 skipped (free-threading OFF in this build)
- [x] `pytest tests/unit tests/integration -q`: 1158 passed / 8 skipped (security/fastapi optional) / 1 deselected (`test_touch` pre-existing flaky, unrelated)
- [ ] CI matrix (6 Python versions + 3.14t free-threaded) — will run on PR

Closes #293.
