### PR TITLE
perf(batch): share one BatchWritePolicy via Arc across batch_write records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Renamed `TimeoutError`/`IndexError` to avoid shadowing Python builtins
 
 ### Performance
+- `batch_write` / `batch_write_numpy` now share a single `Arc<BatchWritePolicy>` across all records instead of deep-cloning the policy per record. Per-record meta still allocates a fresh `Arc`, but the common no-meta path (the whole numpy hot path) drops to a refcount bump. Closes #294.
 - PyO3 binding CPU overhead reduced via OTel fast-path and type conversion optimizations
 - Cargo release profile with LTO and single codegen unit for smaller, faster binaries
 - Cached default policies eliminate repeated allocation on `put()`/`get()`/`select()`/`exists()`

--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -871,10 +871,15 @@ impl PyAsyncClient {
         let raw_records = crate::numpy_support::numpy_to_records(
             py, data, _dtype, namespace, set_name, key_field,
         )?;
-        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy)?;
+        // Share one BatchWritePolicy allocation across every record via Arc;
+        // `numpy_to_records` never emits per-record meta, so the same policy
+        // applies to all N rows.
+        let write_policy = Arc::new(crate::policy::batch_policy::parse_batch_write_policy(
+            policy,
+        )?);
         let records: Vec<_> = raw_records
             .into_iter()
-            .map(|(k, b)| (k, b, write_policy.clone()))
+            .map(|(k, b)| (k, b, Arc::clone(&write_policy)))
             .collect();
 
         let ns = namespace.to_string();

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1245,10 +1245,15 @@ impl PyClient {
         let raw_records = crate::numpy_support::numpy_to_records(
             py, data, _dtype, namespace, set_name, key_field,
         )?;
-        let write_policy = crate::policy::batch_policy::parse_batch_write_policy(policy)?;
+        // Share one BatchWritePolicy allocation across every record via Arc;
+        // `numpy_to_records` never emits per-record meta, so the same policy
+        // applies to all N rows.
+        let write_policy = Arc::new(crate::policy::batch_policy::parse_batch_write_policy(
+            policy,
+        )?);
         let records: Vec<_> = raw_records
             .into_iter()
-            .map(|(k, b)| (k, b, write_policy.clone()))
+            .map(|(k, b)| (k, b, Arc::clone(&write_policy)))
             .collect();
 
         let ns = namespace.to_string();

--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -618,7 +618,7 @@ impl BatchRemoveArgs {
 // ── batch_write (generic) ───────────────────────────────────────────────────
 
 pub struct BatchWriteGenericArgs {
-    pub records: Vec<(Key, Vec<Bin>, BatchWritePolicy)>,
+    pub records: Vec<(Key, Vec<Bin>, Arc<BatchWritePolicy>)>,
     pub batch_policy: aerospike_core::BatchPolicy,
     pub batch_ns: String,
     pub batch_set: String,
@@ -634,8 +634,11 @@ pub fn prepare_batch_write_args(
     conn_info: &Arc<ConnectionInfo>,
 ) -> PyResult<BatchWriteGenericArgs> {
     let batch_policy = parse_batch_policy(policy)?;
-    // Parse batch-level write policy once (TTL default for all records)
-    let base_write_policy = parse_batch_write_policy(policy)?;
+    // Parse batch-level write policy once (TTL default for all records).
+    // Wrap in Arc so the common "all records share the batch policy" path
+    // reuses a single allocation via Arc::clone (refcount bump) rather than
+    // a deep BatchWritePolicy clone per record.
+    let base_write_policy = Arc::new(parse_batch_write_policy(policy)?);
     let mut rust_records = Vec::with_capacity(records.len());
 
     for item in records.iter() {
@@ -654,15 +657,17 @@ pub fn prepare_batch_write_args(
             .map_err(|_| pyo3::exceptions::PyTypeError::new_err("bins element must be a dict"))?;
         let bins = py_dict_to_bins(bins_dict)?;
 
-        // Per-record meta (3rd tuple element) overrides batch-level TTL
+        // Per-record meta (3rd tuple element) overrides batch-level TTL.
+        // When present we allocate a fresh Arc; without meta all records
+        // share a refcounted clone of the base policy.
         let write_policy = if tuple.len() >= 3 {
             let meta_obj = tuple.get_item(2)?;
             let meta_dict = meta_obj.cast::<PyDict>().map_err(|_| {
                 pyo3::exceptions::PyTypeError::new_err("meta element must be a dict")
             })?;
-            apply_record_meta(&base_write_policy, meta_dict)?
+            Arc::new(apply_record_meta(&base_write_policy, meta_dict)?)
         } else {
-            base_write_policy.clone()
+            Arc::clone(&base_write_policy)
         };
 
         rust_records.push((key, bins, write_policy));

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -330,7 +330,7 @@ pub async fn do_batch_write(
     records: &[(
         aerospike_core::Key,
         Vec<aerospike_core::Bin>,
-        BatchWritePolicy,
+        Arc<BatchWritePolicy>,
     )],
     ns: &str,
     set: &str,


### PR DESCRIPTION
## Summary

Fixes #294. Removes per-record `BatchWritePolicy` deep-clones from the batch_write hot path by wrapping the shared policy in `Arc<BatchWritePolicy>`.

## Problem

All three batch_write entry points called `.clone()` on the parsed policy once per record:

- `rust/src/client.rs:1251` — sync `Client.batch_write_numpy`
- `rust/src/async_client.rs:877` — async `AsyncClient.batch_write_numpy`
- `rust/src/client_common.rs:665` — generic `prepare_batch_write_args` (backing both clients' `batch_write`)

For a 10k-record batch that's 10k deep clones of a struct that may carry a boxed `FilterExpression` AST — pure allocator pressure with no semantic benefit, since the policy is logically immutable for the call.

## Fix

Wrap the parsed policy in `Arc<BatchWritePolicy>` once. Each record gets an `Arc::clone` (single atomic refcount bump).

The generic path preserves per-record meta overrides: when `(key, bins, meta)` is supplied, `apply_record_meta` still returns a fresh `BatchWritePolicy` that gets boxed into its own `Arc`. Only the no-meta branch — the common case for `batch_write` and the only case for `batch_write_numpy` — benefits from the refcounted sharing, which is exactly where the cost was.

### Signature changes

- `BatchWriteGenericArgs.records`: `Vec<(Key, Vec<Bin>, BatchWritePolicy)>` → `Vec<(Key, Vec<Bin>, Arc<BatchWritePolicy>)>`
- `do_batch_write(records: &[(Key, Vec<Bin>, BatchWritePolicy)], ...)` → `do_batch_write(records: &[(Key, Vec<Bin>, Arc<BatchWritePolicy>)], ...)`

All call sites of `BatchOperation::write(write_policy, ...)` inside `do_batch_write` stay unchanged — deref coercion handles `&Arc<BatchWritePolicy>` → `&BatchWritePolicy` transparently.

## Test plan

- [x] `cargo fmt` + `cargo clippy --lib -- -D warnings` clean
- [x] `maturin develop --release` builds
- [x] Full suite on a live Aerospike: `pytest tests/unit tests/integration tests/concurrency -q` → **1216 passed**, 9 skipped (fastapi optional / security off / free-threading off), 1 deselected (`test_touch` pre-existing flaky, unrelated)
- [ ] CI matrix (6 Python versions + 3.14t free-threaded) — runs on PR
- [ ] Benchmark gate (10k-record `batch_write_numpy` before/after) — deferred; the change is provably equivalent at the struct level, but a follow-up benchmark run will confirm the expected p95 improvement on the ingestion hot path.

## Related

- Follow-up to the PR #291 ultrareview.
- Pairs with #295 (`close`/`__aexit__` unification); same async_client.rs but disjoint sections.

Closes #294.
