### PR TITLE
docs: correct post-#291 CHANGELOG claim and fix async troubleshooting snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 [Unreleased]: https://github.com/KimSoungRyoul/aerospike-py/compare/v0.0.1.beta2...HEAD
 
 ### Changed (BREAKING)
-- `AsyncClient.__aexit__` now raises `ClientError` when the client is in the `CONNECTING` state, matching the existing behaviour of `close()`. Previously it silently returned `False`, leaving a half-initialized client if the `async with` block exited while `connect()` was still in flight. Closes #293.
 - `BatchRecords` is now a `TypeAlias = dict[UserKey, AerospikeRecord]` (was a `NamedTuple` with a `batch_records` attribute). This is the return type of both `Client.batch_read` and `AsyncClient.batch_read`. Migration:
     ```python
     # Before
@@ -22,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `Client.batch_operate`, `Client.batch_remove`, `AsyncClient.batch_operate`, `AsyncClient.batch_remove` now declare their return type as `BatchWriteResult` in the type stubs (previously `BatchRecords`). Runtime shape is unchanged — `BatchWriteResult` is a NamedTuple with `.batch_records: list[BatchRecord]`. Typecheckers may flag code that still expects the old annotation.
 - `BatchRecord` (used inside `BatchWriteResult`) now carries an `in_doubt: bool = False` field indicating whether a transport-level ambiguity occurred. Positional unpacking (`key, result, record = br`) breaks; switch to attribute access.
 - New top-level exports in `aerospike_py.__all__`: `BatchWriteResult`, `UserKey`, `AerospikeRecord`. Previously only `BatchRecord` and `BatchRecords` were exported.
+
+### Changed
+- Internal: `PyAsyncClient::close` and `PyAsyncClient::__aexit__` (Rust, PyO3) share a new `prepare_close()` helper. Python users of `aerospike_py.AsyncClient` see no behaviour change — the Python wrapper's `__aexit__` already delegated to `close()`, so `async with` exiting during an in-flight `connect()` has always raised `ClientError`. The refactor removes a dead-code divergence at the native layer. Closes #293.
 
 ### Added
 - `Client.batch_write` / `AsyncClient.batch_write` — per-record bins with optional per-record TTL via `WriteMeta`. Each entry is `(key, bins)` or `(key, bins, meta)`.

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -156,7 +156,14 @@ aerospike_py.ClientError: Client is not connected
    try:
        record = await client.get(key)
    finally:
-       client.close()
+       await client.close()
+   ```
+
+   Or use the async context manager, which awaits `close()` for you:
+   ```python
+   async with aerospike_py.AsyncClient(config) as client:
+       await client.connect()
+       record = await client.get(key)
    ```
 
 ## Build and Installation Issues

--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -245,10 +245,18 @@ impl PyAsyncClient {
 
     /// Async context manager exit.
     ///
-    /// Shares the close path with `close()`. In particular, exiting the
-    /// `async with` block while `connect()` is still in flight raises a
+    /// Shares the close path with `close()` via `prepare_close()`. In
+    /// particular, exiting while `connect()` is still in flight raises
     /// `ClientError` — the same behaviour as calling `close()` explicitly —
     /// rather than silently leaking a half-initialized client.
+    ///
+    /// **Note:** the Python wrapper in `src/aerospike_py/_async_client.py`
+    /// defines its own `__aexit__` that delegates to `self.close()`, so
+    /// Python user code going through `aerospike_py.AsyncClient` never
+    /// reaches this native method. It is kept consistent with `close()`
+    /// for callers that interact with the PyO3 class directly (e.g. via
+    /// `client._inner`) and to avoid a latent behaviour divergence if the
+    /// Python wrapper's delegation is ever removed.
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __aexit__<'py>(
         &mut self,


### PR DESCRIPTION
## Summary

Three small, independent doc-and-comment corrections spotted while auditing the PR #291/#295/#296 trio:

### 1. CHANGELOG: soften #295's "BREAKING" claim

The `Changed (BREAKING)` entry for `__aexit__` overstated impact. Tracing the call chain:

1. User: `async with client:` exit
2. `src/aerospike_py/_async_client.py:83-85` — Python `AsyncClient.__aexit__` → `await self.close()`
3. `src/aerospike_py/_async_client.py:114-123` — Python `close()` → `self._inner.close()` (Rust `close()`)
4. Rust `close()` — **was already raising** on `CONNECTING` before #295

Python users of `aerospike_py.AsyncClient` therefore see no behaviour change from #295. The native-Rust `__aexit__` that #295 unified is unreachable from the wrapper (the wrapper defines its own `__aexit__` rather than inheriting the PyO3 one).

Moving the entry from **Changed (BREAKING)** → plain **Changed**, reframed as an internal dead-code consolidation. #295 remains valuable as a refactor (`prepare_close` helper, consistency between the two native close paths), just not user-visible.

### 2. `troubleshooting.md` — missing `await` in async snippet

`docs/docs/guides/troubleshooting.md:159` showed:

```python
finally:
    client.close()  # coroutine never awaited
```

Fixed to `await client.close()` and added an `async with` alternative.

### 3. Source-level note on the native `__aexit__`

Added a comment on `PyAsyncClient::__aexit__` pointing at the Python wrapper that bypasses it, so future readers following the call chain don't rediscover the dead-code property the hard way.

## Changes

| File | Change |
|---|---|
| `CHANGELOG.md` | Remove misleading BREAKING entry, add accurate internal-refactor entry |
| `docs/docs/guides/troubleshooting.md` | Add missing `await`, add `async with` alternative |
| `rust/src/async_client.rs` | Doc-comment note on `__aexit__` |

3 files / +21 / -4.

## Test plan

- [x] `cargo fmt` + `cargo check` clean (no runtime change)
- [x] `pre-commit run --all-files` clean
- [x] `cd docs && npm run build` — Docusaurus build succeeds
- [ ] CI — will run on PR

## Not in scope

- The PR #295 Rust refactor itself stands. The native-Rust `__aexit__` now consistently raises on `CONNECTING` via the shared helper, so if the Python wrapper's delegation to `close()` is ever removed, the native method will do the right thing without further work.
