### PR TITLE
fix(docs): point release fetcher and site config to new repo path

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -42,10 +42,10 @@ const config: Config = {
   },
   themes: ['@docusaurus/theme-mermaid'],
 
-  url: 'https://kimsoungryoul.github.io',
+  url: 'https://aerospike-ce-ecosystem.github.io',
   baseUrl: '/aerospike-py/',
 
-  organizationName: 'KimSoungRyoul',
+  organizationName: 'aerospike-ce-ecosystem',
   projectName: 'aerospike-py',
 
   onBrokenLinks: 'throw',
@@ -90,7 +90,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl:
-            'https://github.com/KimSoungRyoul/aerospike-py/tree/main/docs/',
+            'https://github.com/aerospike-ce-ecosystem/aerospike-py/tree/main/docs/',
           showLastUpdateTime: true,
           // Versioning: managed via versions-config.json
           // Automatically updated by the docs-version.yaml workflow on release
@@ -136,7 +136,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://github.com/KimSoungRyoul/aerospike-py',
+          href: 'https://github.com/aerospike-ce-ecosystem/aerospike-py',
           label: 'GitHub',
           position: 'right',
         },
@@ -175,7 +175,7 @@ const config: Config = {
             },
             {
               label: 'GitHub',
-              href: 'https://github.com/KimSoungRyoul/aerospike-py',
+              href: 'https://github.com/aerospike-ce-ecosystem/aerospike-py',
             },
           ],
         },

--- a/docs/scripts/fetch-releases.mjs
+++ b/docs/scripts/fetch-releases.mjs
@@ -10,7 +10,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO = 'KimSoungRyoul/aerospike-py';
+const REPO = 'aerospike-ce-ecosystem/aerospike-py';
 const API_URL = `https://api.github.com/repos/${REPO}/releases`;
 const OUTPUT = join(__dirname, '..', 'src', 'pages', 'releases.mdx');
 


### PR DESCRIPTION
## Summary
- `fetch-releases.mjs`의 `REPO` 상수를 구 저장소 `KimSoungRyoul/aerospike-py`에서 `aerospike-ce-ecosystem/aerospike-py`로 변경
- GitHub API는 이동된 저장소에 301을 반환하는데 `node fetch`는 redirect를 따르지 않아 항상 빈 배열을 받았고, 그 결과 `releases.mdx`가 placeholder로 생성되어 `/releases` 페이지에 릴리즈 이력이 보이지 않음
- `docusaurus.config.ts`의 `url`, `organizationName`, edit URL, navbar/footer GitHub 링크도 동일하게 신규 경로로 업데이트

## Test plan
- [x] 로컬에서 `node scripts/fetch-releases.mjs` 실행 → `Found 30 release(s).` 확인, `src/pages/releases.mdx` 정상 생성