### PR TITLE
chore(gitignore): ignore OS / Claude / hypothesis caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,10 @@ docs/node_modules/
 docs/build/
 docs/.docusaurus/
 docs/src/pages/releases.mdx
+
+# OS / agent / test caches that should never be committed
+.DS_Store
+**/.DS_Store
+.hypothesis/
+.claude/reviews/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Add `.DS_Store` (macOS Finder metadata) — root + `**/.DS_Store` so subdirectory copies are also ignored.
- Add `.hypothesis/` (hypothesis-python example database, auto-generated by property-based tests).
- Add `.claude/reviews/` and `.claude/scheduled_tasks.lock` (Claude Code agent runtime state — tracked components like skills, settings, and plan templates remain unaffected).

## Why
Every developer running the test suite or using the Claude Code IDE integration ends up with these untracked files polluting `git status`, and `git add .` would silently include them. None of them belong in the repo.

## Test plan
- [x] `git status` is clean of OS/agent caches after this commit (only meaningful work-in-progress shows up)
- [x] Tracked files under `.claude/` (skills/, settings, etc.) are unaffected — the entries are surgical, not blanket