### PR TITLE
feat(batch): expose all BatchWritePolicy fields in batch_write (#303)

### DIFF
--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -1,12 +1,15 @@
 //! Batch policy parsing from Python dicts.
 
-use aerospike_core::{BatchPolicy, BatchWritePolicy};
+use aerospike_core::{BatchPolicy, BatchWritePolicy, GenerationPolicy};
 use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use super::write_policy::parse_ttl;
-use super::{extract_filter_expression, extract_policy_fields};
+use super::{
+    extract_filter_expression, extract_policy_fields, parse_commit_level, parse_generation_policy,
+    parse_record_exists_action,
+};
 
 /// Parse a Python policy dict into a BatchPolicy
 pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<BatchPolicy> {
@@ -32,38 +35,239 @@ pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<B
     Ok(policy)
 }
 
-/// Parse the batch-level policy dict into a [`BatchWritePolicy`] with TTL.
+/// Parse the batch-level policy dict into a [`BatchWritePolicy`].
 ///
-/// Call once before iterating records. Use
-/// [`apply_record_meta`] to override per-record TTL on a clone of the result.
+/// Mirrors [`super::write_policy::parse_write_policy`] for the write-related
+/// fields exposed by `aerospike-core`'s `BatchWritePolicy` struct. Per-record
+/// overrides are applied later via [`apply_record_meta`].
 pub fn parse_batch_write_policy(
     policy_dict: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<BatchWritePolicy> {
     trace!("Parsing batch write policy");
     let mut policy = BatchWritePolicy::default();
 
-    if let Some(dict) = policy_dict {
-        if let Some(val) = dict.get_item("ttl")? {
-            policy.expiration = parse_ttl(val.extract::<i64>()?)?;
-        }
+    let dict = match policy_dict {
+        Some(d) => d,
+        None => return Ok(policy),
+    };
+
+    extract_policy_fields!(dict, {
+        "durable_delete" => policy.durable_delete
+    });
+
+    // Key (send_key) — POLICY_KEY_DIGEST(0) | POLICY_KEY_SEND(1)
+    if let Some(val) = dict.get_item("key")? {
+        policy.send_key = val.extract::<i32>()? == 1;
     }
+
+    // Exists (record_exists_action) — POLICY_EXISTS_*
+    if let Some(val) = dict.get_item("exists")? {
+        policy.record_exists_action = parse_record_exists_action(val.extract::<i32>()?);
+    }
+
+    // Generation policy — POLICY_GEN_*
+    if let Some(val) = dict.get_item("gen")? {
+        policy.generation_policy = parse_generation_policy(val.extract::<i32>()?);
+    }
+
+    // Commit level — POLICY_COMMIT_LEVEL_*
+    if let Some(val) = dict.get_item("commit_level")? {
+        policy.commit_level = parse_commit_level(val.extract::<i32>()?);
+    }
+
+    // TTL / expiration
+    if let Some(val) = dict.get_item("ttl")? {
+        policy.expiration = parse_ttl(val.extract::<i64>()?)?;
+    }
+
+    // Filter expression
+    policy.filter_expression = extract_filter_expression(dict)?;
 
     Ok(policy)
 }
 
-/// Apply per-record meta (TTL, generation) to a [`BatchWritePolicy`],
-/// overriding the batch-level default.
+/// Apply per-record meta to a [`BatchWritePolicy`], overriding the batch-level
+/// default. Per-record settings always win.
+///
+/// Supported meta keys mirror the write fields of `BatchWritePolicy`: `ttl`,
+/// `gen` (sets `generation` + `GenerationPolicy::ExpectGenEqual`, matching
+/// the existing `WriteMeta` semantics for `put`), `key`, `exists`,
+/// `commit_level`, `durable_delete`.
 pub fn apply_record_meta(
     base: &BatchWritePolicy,
     meta: &Bound<'_, PyDict>,
 ) -> PyResult<BatchWritePolicy> {
     let mut policy = base.clone();
+
     if let Some(ttl) = meta.get_item("ttl")? {
         policy.expiration = parse_ttl(ttl.extract::<i64>()?)?;
     }
     if let Some(gen) = meta.get_item("gen")? {
         policy.generation = gen.extract::<u32>()?;
-        policy.generation_policy = aerospike_core::GenerationPolicy::ExpectGenEqual;
+        policy.generation_policy = GenerationPolicy::ExpectGenEqual;
     }
+    if let Some(key) = meta.get_item("key")? {
+        policy.send_key = key.extract::<i32>()? == 1;
+    }
+    if let Some(exists) = meta.get_item("exists")? {
+        policy.record_exists_action = parse_record_exists_action(exists.extract::<i32>()?);
+    }
+    if let Some(commit_level) = meta.get_item("commit_level")? {
+        policy.commit_level = parse_commit_level(commit_level.extract::<i32>()?);
+    }
+    if let Some(durable_delete) = meta.get_item("durable_delete")? {
+        policy.durable_delete = durable_delete.extract::<bool>()?;
+    }
+
     Ok(policy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aerospike_core::{CommitLevel, Expiration, RecordExistsAction};
+
+    /// Build a Python dict from `(key, value)` pairs for testing.
+    fn build_dict<'py>(
+        py: Python<'py>,
+        build: impl FnOnce(&Bound<'py, PyDict>),
+    ) -> Bound<'py, PyDict> {
+        let d = PyDict::new(py);
+        build(&d);
+        d
+    }
+
+    #[test]
+    fn parse_batch_write_policy_with_send_key() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("key", 1i32).unwrap();
+            });
+            let p = parse_batch_write_policy(Some(&d)).expect("parse ok");
+            assert!(p.send_key, "key=1 must enable send_key");
+        });
+    }
+
+    #[test]
+    fn parse_batch_write_policy_send_key_zero_means_digest() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("key", 0i32).unwrap();
+            });
+            let p = parse_batch_write_policy(Some(&d)).expect("parse ok");
+            assert!(!p.send_key, "key=0 must keep digest-only behavior");
+        });
+    }
+
+    #[test]
+    fn parse_batch_write_policy_with_exists_create_only() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("exists", 4i32).unwrap();
+            });
+            let p = parse_batch_write_policy(Some(&d)).expect("parse ok");
+            assert_eq!(p.record_exists_action, RecordExistsAction::CreateOnly);
+        });
+    }
+
+    #[test]
+    fn parse_batch_write_policy_with_commit_level_master() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("commit_level", 1i32).unwrap();
+            });
+            let p = parse_batch_write_policy(Some(&d)).expect("parse ok");
+            assert_eq!(p.commit_level, CommitLevel::CommitMaster);
+        });
+    }
+
+    #[test]
+    fn parse_batch_write_policy_with_durable_delete() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("durable_delete", true).unwrap();
+            });
+            let p = parse_batch_write_policy(Some(&d)).expect("parse ok");
+            assert!(p.durable_delete);
+        });
+    }
+
+    #[test]
+    fn parse_batch_write_policy_default_when_dict_is_none() {
+        let p = parse_batch_write_policy(None).expect("parse ok");
+        assert!(!p.send_key);
+        assert!(!p.durable_delete);
+        assert_eq!(p.record_exists_action, RecordExistsAction::Update);
+        assert_eq!(p.commit_level, CommitLevel::CommitAll);
+        assert!(matches!(p.expiration, Expiration::NamespaceDefault));
+    }
+
+    #[test]
+    fn apply_record_meta_overrides_send_key() {
+        Python::initialize();
+        Python::attach(|py| {
+            let base = BatchWritePolicy::default(); // send_key = false
+            let meta = build_dict(py, |d| {
+                d.set_item("key", 1i32).unwrap();
+            });
+            let overridden = apply_record_meta(&base, &meta).expect("apply ok");
+            assert!(overridden.send_key);
+        });
+    }
+
+    #[test]
+    fn apply_record_meta_overrides_exists() {
+        Python::initialize();
+        Python::attach(|py| {
+            let base = BatchWritePolicy::default();
+            let meta = build_dict(py, |d| {
+                d.set_item("exists", 4i32).unwrap();
+            });
+            let overridden = apply_record_meta(&base, &meta).expect("apply ok");
+            assert_eq!(
+                overridden.record_exists_action,
+                RecordExistsAction::CreateOnly
+            );
+        });
+    }
+
+    #[test]
+    fn apply_record_meta_preserves_unrelated_fields() {
+        Python::initialize();
+        Python::attach(|py| {
+            let mut base = BatchWritePolicy::default();
+            base.send_key = true;
+            base.commit_level = CommitLevel::CommitMaster;
+
+            // Meta only sets ttl — other fields must come from base.
+            let meta = build_dict(py, |d| {
+                d.set_item("ttl", 3600i64).unwrap();
+            });
+            let overridden = apply_record_meta(&base, &meta).expect("apply ok");
+            assert!(overridden.send_key, "send_key must be inherited from base");
+            assert_eq!(overridden.commit_level, CommitLevel::CommitMaster);
+            assert!(matches!(overridden.expiration, Expiration::Seconds(3600)));
+        });
+    }
+
+    #[test]
+    fn apply_record_meta_per_record_wins_over_base() {
+        Python::initialize();
+        Python::attach(|py| {
+            let mut base = BatchWritePolicy::default();
+            base.send_key = false; // batch policy = DIGEST
+
+            // Per-record meta = SEND must override.
+            let meta = build_dict(py, |d| {
+                d.set_item("key", 1i32).unwrap();
+            });
+            let overridden = apply_record_meta(&base, &meta).expect("apply ok");
+            assert!(overridden.send_key, "per-record key must override base");
+        });
+    }
 }

--- a/rust/src/policy/mod.rs
+++ b/rust/src/policy/mod.rs
@@ -6,6 +6,7 @@ pub mod read_policy;
 pub mod write_policy;
 
 use aerospike_core::expressions::Expression;
+use aerospike_core::{CommitLevel, GenerationPolicy, RecordExistsAction};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -36,4 +37,42 @@ pub fn extract_filter_expression(dict: &Bound<'_, PyDict>) -> PyResult<Option<Ex
         }
     }
     Ok(None)
+}
+
+/// Map a `POLICY_EXISTS_*` integer constant to a [`RecordExistsAction`].
+///
+/// Unknown values fall back to [`RecordExistsAction::Update`] to mirror
+/// pre-existing behavior in `parse_write_policy`.
+pub(crate) fn parse_record_exists_action(val: i32) -> RecordExistsAction {
+    match val {
+        0 => RecordExistsAction::Update,
+        1 => RecordExistsAction::UpdateOnly,
+        2 => RecordExistsAction::Replace,
+        3 => RecordExistsAction::ReplaceOnly,
+        4 => RecordExistsAction::CreateOnly,
+        _ => RecordExistsAction::Update,
+    }
+}
+
+/// Map a `POLICY_GEN_*` integer constant to a [`GenerationPolicy`].
+///
+/// Unknown values fall back to [`GenerationPolicy::None`].
+pub(crate) fn parse_generation_policy(val: i32) -> GenerationPolicy {
+    match val {
+        0 => GenerationPolicy::None,
+        1 => GenerationPolicy::ExpectGenEqual,
+        2 => GenerationPolicy::ExpectGenGreater,
+        _ => GenerationPolicy::None,
+    }
+}
+
+/// Map a `POLICY_COMMIT_LEVEL_*` integer constant to a [`CommitLevel`].
+///
+/// Unknown values fall back to [`CommitLevel::CommitAll`].
+pub(crate) fn parse_commit_level(val: i32) -> CommitLevel {
+    match val {
+        0 => CommitLevel::CommitAll,
+        1 => CommitLevel::CommitMaster,
+        _ => CommitLevel::CommitAll,
+    }
 }

--- a/rust/src/policy/write_policy.rs
+++ b/rust/src/policy/write_policy.rs
@@ -2,12 +2,15 @@
 
 use std::sync::LazyLock;
 
-use aerospike_core::{CommitLevel, Expiration, GenerationPolicy, RecordExistsAction, WritePolicy};
+use aerospike_core::{Expiration, GenerationPolicy, WritePolicy};
 use log::trace;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use super::{extract_filter_expression, extract_policy_fields};
+use super::{
+    extract_filter_expression, extract_policy_fields, parse_commit_level, parse_generation_policy,
+    parse_record_exists_action,
+};
 
 /// Lazily-initialized default write policy used when no policy dict is provided.
 pub static DEFAULT_WRITE_POLICY: LazyLock<WritePolicy> = LazyLock::new(WritePolicy::default);
@@ -64,42 +67,22 @@ pub fn parse_write_policy(
 
     // Key (send_key)
     if let Some(val) = dict.get_item("key")? {
-        let key_val: i32 = val.extract()?;
-        policy.send_key = key_val == 1;
+        policy.send_key = val.extract::<i32>()? == 1;
     }
 
     // Exists (record_exists_action)
     if let Some(val) = dict.get_item("exists")? {
-        let exists_val: i32 = val.extract()?;
-        policy.record_exists_action = match exists_val {
-            0 => RecordExistsAction::Update,
-            1 => RecordExistsAction::UpdateOnly,
-            2 => RecordExistsAction::Replace,
-            3 => RecordExistsAction::ReplaceOnly,
-            4 => RecordExistsAction::CreateOnly,
-            _ => RecordExistsAction::Update,
-        };
+        policy.record_exists_action = parse_record_exists_action(val.extract::<i32>()?);
     }
 
     // Gen policy
     if let Some(val) = dict.get_item("gen")? {
-        let gen_val: i32 = val.extract()?;
-        policy.generation_policy = match gen_val {
-            0 => GenerationPolicy::None,
-            1 => GenerationPolicy::ExpectGenEqual,
-            2 => GenerationPolicy::ExpectGenGreater,
-            _ => GenerationPolicy::None,
-        };
+        policy.generation_policy = parse_generation_policy(val.extract::<i32>()?);
     }
 
     // Commit level
     if let Some(val) = dict.get_item("commit_level")? {
-        let commit_val: i32 = val.extract()?;
-        policy.commit_level = match commit_val {
-            0 => CommitLevel::CommitAll,
-            1 => CommitLevel::CommitMaster,
-            _ => CommitLevel::CommitAll,
-        };
+        policy.commit_level = parse_commit_level(val.extract::<i32>()?);
     }
 
     // TTL / expiration

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -674,16 +674,27 @@ class Client:
         Unlike ``batch_operate`` (which applies the same operations to all
         keys), each record can have different bins.
 
-        TTL can be set at two levels:
+        Write fields can be set at two levels and follow a uniform precedence
+        rule — **per-record meta always overrides the batch-level policy**.
+        The fields below mirror the corresponding [`WritePolicy`](types.md#writepolicy)
+        keys used by :meth:`put`:
 
-        - **Batch-level**: ``policy={"ttl": N}`` applies to all records.
-        - **Per-record**: ``(key, bins, {"ttl": N})`` overrides the
-          batch-level TTL for that specific record.
+        | Field            | Batch-level (``policy``) | Per-record (``meta``) | Notes                                            |
+        |------------------|--------------------------|-----------------------|--------------------------------------------------|
+        | ``ttl``          | ✅                       | ✅                    | Seconds, or ``TTL_NEVER_EXPIRE`` / ``TTL_DONT_UPDATE``. |
+        | ``key``          | ✅                       | ✅                    | ``POLICY_KEY_DIGEST`` (default) / ``POLICY_KEY_SEND``. |
+        | ``exists``       | ✅                       | ✅                    | ``POLICY_EXISTS_*`` (UPDATE / CREATE_ONLY / etc.). |
+        | ``gen``          | ✅ (enum index)          | ✅ (expected value)   | Batch-level: ``POLICY_GEN_*``. Per-record: int forces ``POLICY_GEN_EQ`` with this generation. |
+        | ``commit_level`` | ✅                       | ✅                    | ``POLICY_COMMIT_LEVEL_ALL`` (default) / ``_MASTER``. |
+        | ``durable_delete`` | ✅                     | ✅                    | EE 3.10+ tombstone semantics.                    |
 
         Args:
             records: List of ``(key, bins)`` or ``(key, bins, meta)`` tuples.
             policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict.
-                Supports ``"ttl"`` key for batch-level TTL (seconds).
+                Accepts the write fields above plus standard batch transport
+                keys (``socket_timeout``, ``total_timeout``, ``max_retries``,
+                ``filter_expression``, ``allow_inline``, ``allow_inline_ssd``,
+                ``respond_all_keys``).
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
@@ -717,6 +728,26 @@ class Client:
                 (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
             ]
             results = client.batch_write(records_with_ttl)
+
+            # Persist user keys server-side (POLICY_KEY_SEND) — visible via
+            # ``scan`` / ``query`` / ``aql SELECT *``.
+            results = client.batch_write(
+                records,
+                policy={"key": aerospike_py.POLICY_KEY_SEND},
+            )
+
+            # Mix per-record overrides: only ``user1`` stores its key.
+            results = client.batch_write([
+                (("test", "demo", "user1"), {"name": "Alice"},
+                 {"key": aerospike_py.POLICY_KEY_SEND}),
+                (("test", "demo", "user2"), {"name": "Bob"}),
+            ])
+
+            # CREATE_ONLY semantics — fail per-record if it already exists.
+            results = client.batch_write(
+                records,
+                policy={"exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY},
+            )
             ```
         """
         ...
@@ -1672,21 +1703,15 @@ class AsyncClient:
     ) -> BatchWriteResult:
         """Write multiple records with per-record bins (async).
 
-        Each record is a ``(key, bins)`` or ``(key, bins, meta)`` tuple where
-        key is ``(namespace, set, primary_key)``, bins is a dict of bin
-        name-to-value mappings, and meta is an optional
-        [`WriteMeta`](types.md#writemeta) dict (e.g. ``{"ttl": 300}``).
-
-        TTL can be set at two levels:
-
-        - **Batch-level**: ``policy={"ttl": N}`` applies to all records.
-        - **Per-record**: ``(key, bins, {"ttl": N})`` overrides the
-          batch-level TTL for that specific record.
+        See :meth:`Client.batch_write` for the full description of write
+        fields supported at both batch-level (``policy``) and per-record
+        (``meta``) levels — ``ttl``, ``key`` (send_key), ``exists``, ``gen``,
+        ``commit_level``, ``durable_delete``. Per-record meta always
+        overrides the batch-level policy.
 
         Args:
             records: List of ``(key, bins)`` or ``(key, bins, meta)`` tuples.
             policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict.
-                Supports ``"ttl"`` key for batch-level TTL (seconds).
             retry: Maximum number of retries for failed records (default ``0``).
                 When > 0, records that fail with transient errors (timeout,
                 device overload, key busy) are automatically retried with
@@ -1704,22 +1729,25 @@ class AsyncClient:
 
         Example:
             ```python
-            # Basic usage
             records = [
                 (("test", "demo", "user1"), {"name": "Alice", "age": 30}),
                 (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
             ]
             results = await client.batch_write(records)
 
-            # With batch-level TTL (30 days)
-            results = await client.batch_write(records, policy={"ttl": 2592000})
+            # Persist user keys server-side
+            results = await client.batch_write(
+                records,
+                policy={"key": aerospike_py.POLICY_KEY_SEND},
+            )
 
-            # With per-record TTL
-            records_with_ttl = [
-                (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 3600}),
+            # Per-record overrides
+            records_with_meta = [
+                (("test", "demo", "user1"), {"name": "Alice"},
+                 {"ttl": 3600, "key": aerospike_py.POLICY_KEY_SEND}),
                 (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
             ]
-            results = await client.batch_write(records_with_ttl)
+            results = await client.batch_write(records_with_meta)
             ```
         """
         ...

--- a/src/aerospike_py/types.py
+++ b/src/aerospike_py/types.py
@@ -128,6 +128,18 @@ class BatchPolicy(TypedDict, total=False):
     total_timeout: int
     max_retries: int
     filter_expression: Any
+    allow_inline: bool
+    allow_inline_ssd: bool
+    respond_all_keys: bool
+    # Batch-level write defaults — used by ``batch_write``. Per-record
+    # ``WriteMeta`` entries override these fields (matching the existing
+    # ``ttl``/``gen`` precedence rule).
+    key: int
+    exists: int
+    gen: int
+    commit_level: int
+    durable_delete: bool
+    ttl: int
 
 
 class AdminPolicy(TypedDict, total=False):
@@ -147,6 +159,10 @@ class QueryPolicy(TypedDict, total=False):
 class WriteMeta(TypedDict, total=False):
     gen: int
     ttl: int
+    key: int
+    exists: int
+    commit_level: int
+    durable_delete: bool
 
 
 class ClientConfig(TypedDict, total=False):

--- a/tests/compatibility/test_policy_combinations.py
+++ b/tests/compatibility/test_policy_combinations.py
@@ -300,6 +300,47 @@ class TestPolicySendKey:
 
         assert r_key[2] == o_key[2] == 12345
 
+    def test_batch_send_key_via_policy(self, rust_client, official_client, cleanup):
+        """``batch_write(policy={'key': SEND})`` persists user keys (issue #303)."""
+        key = (NS, SET, "pol_batch_sendkey_pol")
+        cleanup.append(key)
+
+        rust_client.batch_write(
+            [(key, {"val": 1})],
+            policy={"key": aerospike_py.POLICY_KEY_SEND},
+        )
+
+        r_key, _, _ = rust_client.get(key, policy={"key": aerospike_py.POLICY_KEY_SEND})
+        o_key, _, _ = official_client.get(key, policy={"key": aerospike.POLICY_KEY_SEND})
+
+        assert r_key[2] == "pol_batch_sendkey_pol"
+        assert o_key[2] == "pol_batch_sendkey_pol"
+
+    def test_batch_send_key_via_per_record_meta(self, rust_client, official_client, cleanup):
+        """``(key, bins, {'key': SEND})`` persists user key for that record only."""
+        key = (NS, SET, "pol_batch_sendkey_meta")
+        cleanup.append(key)
+
+        rust_client.batch_write([(key, {"val": 1}, {"key": aerospike_py.POLICY_KEY_SEND})])
+
+        r_key, _, _ = rust_client.get(key, policy={"key": aerospike_py.POLICY_KEY_SEND})
+        o_key, _, _ = official_client.get(key, policy={"key": aerospike.POLICY_KEY_SEND})
+
+        assert r_key[2] == "pol_batch_sendkey_meta"
+        assert o_key[2] == "pol_batch_sendkey_meta"
+
+    def test_batch_send_key_default_digest_only(self, rust_client, official_client, cleanup):
+        """Without policy/meta, batch_write stores digest only — official client confirms no user key."""
+        key = (NS, SET, "pol_batch_sendkey_none")
+        cleanup.append(key)
+
+        rust_client.batch_write([(key, {"val": 1})])
+
+        # The official C client does not echo the request user_key back, so its
+        # response is the source of truth for what the server actually stored.
+        o_key, _, _ = official_client.get(key)
+        assert o_key[2] is None
+
 
 # ── CREATE_ONLY Policy ─────────────────────────────────────────────
 

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -560,6 +560,164 @@ class TestBatchWriteGen:
         assert meta2.ttl <= 3600
 
 
+class TestBatchWriteSendKey:
+    """Test batch_write() POLICY_KEY_SEND support (issue #303).
+
+    With ``key=POLICY_KEY_SEND``, the original user-supplied primary key is
+    persisted on the server alongside the digest. The presence of a stored
+    user key is verified via ``query().results()`` — unlike ``get()``, a
+    query scan does not echo the request user key, so ``record.key.user_key``
+    is populated only when the server has it.
+    """
+
+    @staticmethod
+    def _scan_user_keys(client_, ns: str, set_name: str) -> list[str | int | bytes | None]:
+        """Return the server-stored user keys for every record in the set."""
+        records = client_.query(ns, set_name).results()
+        return [r.key.user_key for r in records if r.key is not None]
+
+    def test_batch_write_policy_send_key(self, client, cleanup):
+        """Batch-level ``policy={"key": POLICY_KEY_SEND}`` applies to all records."""
+        keys = [
+            ("test", "bw_sendkey_pol", "bw_sendkey_pol_1"),
+            ("test", "bw_sendkey_pol", "bw_sendkey_pol_2"),
+        ]
+        for k in keys:
+            cleanup.append(k)
+
+        records = [(k, {"val": i}) for i, k in enumerate(keys)]
+        results = client.batch_write(records, policy={"key": aerospike_py.POLICY_KEY_SEND})
+        for br in results.batch_records:
+            assert br.result == 0
+
+        scanned = self._scan_user_keys(client, "test", "bw_sendkey_pol")
+        assert sorted(str(v) for v in scanned) == ["bw_sendkey_pol_1", "bw_sendkey_pol_2"]
+
+    def test_batch_write_per_record_send_key(self, client, cleanup):
+        """Per-record meta ``{"key": POLICY_KEY_SEND}`` persists user key."""
+        key = ("test", "bw_sendkey_meta", "bw_sendkey_meta_user")
+        cleanup.append(key)
+
+        results = client.batch_write([(key, {"val": 1}, {"key": aerospike_py.POLICY_KEY_SEND})])
+        assert results.batch_records[0].result == 0
+
+        scanned = self._scan_user_keys(client, "test", "bw_sendkey_meta")
+        assert scanned == ["bw_sendkey_meta_user"]
+
+    def test_batch_write_per_record_overrides_policy(self, client, cleanup):
+        """Per-record meta send_key overrides batch-level policy.
+
+        Batch policy = DIGEST, but the first record's meta = SEND. Only the
+        first record's user key should be persisted server-side.
+        """
+        key_send = ("test", "bw_sendkey_override", "override_send")
+        key_digest = ("test", "bw_sendkey_override", "override_digest")
+        cleanup.append(key_send)
+        cleanup.append(key_digest)
+
+        records = [
+            (key_send, {"val": 1}, {"key": aerospike_py.POLICY_KEY_SEND}),
+            (key_digest, {"val": 2}),
+        ]
+        results = client.batch_write(records, policy={"key": aerospike_py.POLICY_KEY_DIGEST})
+        for br in results.batch_records:
+            assert br.result == 0
+
+        scanned = self._scan_user_keys(client, "test", "bw_sendkey_override")
+        # Exactly one record has a stored user key; the other is None.
+        stored = [v for v in scanned if v is not None]
+        assert stored == ["override_send"]
+        assert sum(1 for v in scanned if v is None) == 1
+
+    def test_batch_write_send_key_default_is_digest(self, client, cleanup):
+        """Without policy/meta, batch_write defaults to digest-only (no user key stored)."""
+        key = ("test", "bw_sendkey_default", "bw_sendkey_default_user")
+        cleanup.append(key)
+
+        results = client.batch_write([(key, {"val": 1})])
+        assert results.batch_records[0].result == 0
+
+        scanned = self._scan_user_keys(client, "test", "bw_sendkey_default")
+        assert scanned == [None]
+
+
+class TestBatchWriteWriteFields:
+    """Test batch_write() parity with put() for the remaining BatchWritePolicy fields."""
+
+    def test_batch_write_exists_create_only_new_record(self, client, cleanup):
+        """``exists=POLICY_EXISTS_CREATE_ONLY`` succeeds when the record does not exist."""
+        key = ("test", "demo", "bw_exists_create_new")
+        cleanup.append(key)
+
+        results = client.batch_write(
+            [(key, {"val": 1})],
+            policy={"exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY},
+        )
+        assert results.batch_records[0].result == 0
+
+    def test_batch_write_exists_create_only_existing_record(self, client, cleanup):
+        """``exists=POLICY_EXISTS_CREATE_ONLY`` fails when the record already exists."""
+        key = ("test", "demo", "bw_exists_create_existing")
+        cleanup.append(key)
+        client.put(key, {"val": 1})
+
+        results = client.batch_write(
+            [(key, {"val": 2})],
+            policy={"exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY},
+        )
+        # KEY_EXISTS_ERROR (server result code 5) — non-zero is sufficient here.
+        assert results.batch_records[0].result != 0
+
+        # Original value preserved.
+        _, _, bins = client.get(key)
+        assert bins["val"] == 1
+
+    def test_batch_write_exists_per_record_override(self, client, cleanup):
+        """Per-record ``exists`` overrides batch-level."""
+        key_existing = ("test", "demo", "bw_exists_per_rec_existing")
+        key_new = ("test", "demo", "bw_exists_per_rec_new")
+        cleanup.append(key_existing)
+        cleanup.append(key_new)
+
+        client.put(key_existing, {"val": 1})
+
+        # Batch policy = UPDATE (default), per-record meta = CREATE_ONLY.
+        records = [
+            (
+                key_existing,
+                {"val": 2},
+                {"exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY},
+            ),
+            (
+                key_new,
+                {"val": 99},
+                {"exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY},
+            ),
+        ]
+        results = client.batch_write(records)
+        assert results.batch_records[0].result != 0  # CREATE_ONLY on existing → fail
+        assert results.batch_records[1].result == 0  # CREATE_ONLY on new → succeed
+
+    def test_batch_write_commit_level_master(self, client, cleanup):
+        """``commit_level=POLICY_COMMIT_LEVEL_MASTER`` is accepted at batch level."""
+        key = ("test", "demo", "bw_commit_master")
+        cleanup.append(key)
+
+        results = client.batch_write(
+            [(key, {"val": 1})],
+            policy={"commit_level": aerospike_py.POLICY_COMMIT_LEVEL_MASTER},
+        )
+        assert results.batch_records[0].result == 0
+
+    def test_batch_write_durable_delete_accepted(self, client, cleanup):
+        """``durable_delete`` is accepted (no-op on writes / CE; must not be rejected)."""
+        key = ("test", "demo", "bw_durable_delete")
+        cleanup.append(key)
+
+        results = client.batch_write([(key, {"val": 1})], policy={"durable_delete": True})
+        assert results.batch_records[0].result == 0
+
+
 class TestBatchRemove:
     def test_batch_remove(self, client):
         keys = [


### PR DESCRIPTION
## Summary

- Closes #303 by wiring `send_key` (`POLICY_KEY_SEND`) through both batch-level `BatchPolicy` and per-record `WriteMeta` for `batch_write()`.
- Bundles the remaining write fields that `aerospike-core 2.0`'s `BatchWritePolicy` already supports — `exists`, `commit_level`, `durable_delete`, `filter_expression`, plus `gen` at batch-level — restoring full feature parity with `put()`.
- Per-record `WriteMeta` always overrides batch-level `BatchPolicy`, matching the existing `ttl`/`gen` precedence rule.

## Why this gap existed

`rust/src/policy/batch_policy.rs::parse_batch_write_policy` only parsed `ttl`, and `apply_record_meta` only applied `ttl`/`gen`. The underlying Rust crate's `BatchWritePolicy` struct already supports `send_key`, `record_exists_action`, `commit_level`, `generation`, `expiration`, `durable_delete`, `filter_expression` — but the Python parsing layer simply did not forward them. Records inserted via `batch_write` had only their digest stored, so scan/query/`aql SELECT *` could not recover the original primary key.

## Reproduction (before → after)

```python
import aerospike_py
client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()

# Before this PR: 'key' option is silently ignored — server stores digest only.
# After this PR:  user_key is persisted server-side.
client.batch_write(
    [(("test", "demo", "alice"), {"name": "Alice"})],
    policy={"key": aerospike_py.POLICY_KEY_SEND},
)

# Per-record granularity now also works — matches the existing ttl/gen pattern.
client.batch_write([
    (("test", "demo", "bob"), {"name": "Bob"}, {"key": aerospike_py.POLICY_KEY_SEND}),
])

for rec in client.query("test", "demo").results():
    print(rec.key.user_key, rec.bins)
# alice Alice
# bob   Bob
```

## Changes

| Area | File | Change |
|------|------|--------|
| Rust | `rust/src/policy/mod.rs` | Extract `parse_record_exists_action`, `parse_generation_policy`, `parse_commit_level` helpers — single source of truth for `POLICY_*` integer-to-enum mapping. |
| Rust | `rust/src/policy/batch_policy.rs` | `parse_batch_write_policy` parses `key`, `exists`, `gen`, `commit_level`, `durable_delete`, `filter_expression` in addition to `ttl`. `apply_record_meta` mirrors per-record overrides. 10 new `#[cfg(test)]` unit tests. |
| Rust | `rust/src/policy/write_policy.rs` | Refactor inline `match` blocks to use the new helpers. |
| Python types | `src/aerospike_py/types.py` | Extend `WriteMeta` (`key`, `exists`, `commit_level`, `durable_delete`) and `BatchPolicy` (write defaults + previously-undocumented `allow_inline`/`allow_inline_ssd`/`respond_all_keys`). |
| Stubs | `src/aerospike_py/__init__.pyi` | Document new policy/meta keys with examples in sync and async `batch_write` docstrings. |
| Tests | `tests/integration/test_batch.py` | `TestBatchWriteSendKey` (4 tests) and `TestBatchWriteWriteFields` (5 tests) cover batch-level + per-record overrides. Server-stored user keys verified via `query().results()` (which, unlike `get()`, does not echo the request key). |
| Tests | `tests/compatibility/test_policy_combinations.py` | 3 cross-client send_key tests on the batch path against the official `aerospike` C client. |

## Test plan

- [x] `cargo test --manifest-path rust/Cargo.toml` — 110 passed (10 new in `batch_policy::tests`).
- [x] `make typecheck` — 0 errors / 0 warnings.
- [x] `make lint` — ruff + clippy clean.
- [x] `make fmt --check` — formatted.
- [x] `make validate` — fmt + lint + typecheck + 877 unit tests pass.
- [x] `pytest tests/integration/test_batch.py` — 38 passed (29 existing + 9 new).
- [x] `pytest tests/compatibility/test_policy_combinations.py` — 22 passed (19 existing + 3 new).
- [x] Manual `aql SELECT *` reproduction confirms `user_key` is persisted only when SEND is set.

## Out of scope (follow-up)

The wider `WritePolicy`/`ReadPolicy` gaps surfaced during analysis — `ReadPolicy.replica`/`read_mode_ap`/`read_mode_sc`, `QueryPolicy.expected_duration`/`partition_filter`, separate `ScanPolicy`/`BatchReadPolicy`/`BatchApplyPolicy`/`BatchRemovePolicy`, `BasePolicy.consistency_level`/`read_touch_ttl`, the legacy `expressions` alias — are all separate read-path/query-path work and are not in this PR. They will be tracked as follow-up issues.