### PR TITLE
chore(types): drop legacy expressions alias from policy TypedDicts (#308)

### DIFF
--- a/src/aerospike_py/types.py
+++ b/src/aerospike_py/types.py
@@ -104,7 +104,6 @@ class ReadPolicy(TypedDict, total=False):
     max_retries: int
     sleep_between_retries: int
     filter_expression: Any
-    expressions: Any
     replica: int
     read_mode_ap: int
 
@@ -120,7 +119,6 @@ class WritePolicy(TypedDict, total=False):
     commit_level: int
     ttl: int
     filter_expression: Any
-    expressions: Any
 
 
 class BatchPolicy(TypedDict, total=False):
@@ -153,7 +151,6 @@ class QueryPolicy(TypedDict, total=False):
     max_records: int
     records_per_second: int
     filter_expression: Any
-    expressions: Any
 
 
 class WriteMeta(TypedDict, total=False):


### PR DESCRIPTION
## Summary

- Removes the `expressions: Any` field from `ReadPolicy`, `WritePolicy`, `QueryPolicy` TypedDict declarations in `src/aerospike_py/types.py`.
- Closes #308.

## Why

The alias was a dead key. No Rust parser (`rust/src/policy/*.rs`) ever read `"expressions"` — only `filter_expression` is wired through `extract_filter_expression`. The TypedDict declaration created a false promise: users who passed `policy={"expressions": ...}` had it silently ignored.

## Impact

- Users who passed `expressions=` to aerospike-py policy dicts (if any) will now get a pyright type error. However that code was never functional — the value was discarded — so there is no behavioral regression. Migration: rename to `filter_expression`.
- `tests/compatibility/test_expression_filters.py` calls `official_client.get(..., policy={"expressions": ...})` — the official aerospike C client uses its own dict (not aerospike-py's TypedDict), so those tests are unaffected.

## Test plan

- [x] `make validate` — fmt + lint + typecheck + 877 unit tests pass.
- [ ] CI green (lint, typecheck, build, integration, compatibility, concurrency).
- [x] Manual grep: `grep -rn "\"expressions\"" rust/ src/aerospike_py tests/integration tests/unit tests/concurrency` returns 0 hits (confirmed).