### PR TITLE
feat: surface QueryPolicy fields (expected_duration, replica, include_bin_data, partition_filter) (#306)

### DIFF
--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -149,6 +149,11 @@ pub fn register_constants(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("READ_TOUCH_TTL_PERCENT_SERVER_DEFAULT", 0)?;
     m.add("READ_TOUCH_TTL_PERCENT_DONT_RESET", -1)?;
 
+    // --- Query Duration ---
+    m.add("QUERY_DURATION_LONG", 0)?;
+    m.add("QUERY_DURATION_SHORT", 1)?;
+    m.add("QUERY_DURATION_LONG_RELAX_AP", 2)?;
+
     // --- TTL Constants ---
     m.add("TTL_NAMESPACE_DEFAULT", 0)?;
     m.add("TTL_NEVER_EXPIRE", -1)?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -94,6 +94,7 @@ fn _aerospike(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<client::PyClient>()?;
     m.add_class::<async_client::PyAsyncClient>()?;
     m.add_class::<query::PyQuery>()?;
+    m.add_class::<types::partition_filter::PyPartitionFilter>()?;
     m.add_class::<batch_types::PyBatchRecord>()?;
     m.add_class::<batch_types::PyBatchRecords>()?;
     m.add_class::<batch_types::PyBatchReadHandle>()?;
@@ -105,6 +106,18 @@ fn _aerospike(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(set_internal_stage_metrics_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(is_internal_stage_metrics_enabled, m)?)?;
     m.add_function(wrap_pyfunction!(dropped_log_count, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        types::partition_filter::partition_filter_all,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        types::partition_filter::partition_filter_by_id,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        types::partition_filter::partition_filter_by_range,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(tracing::init_tracing, m)?)?;
     m.add_function(wrap_pyfunction!(tracing::shutdown_tracing, m)?)?;
 

--- a/rust/src/policy/mod.rs
+++ b/rust/src/policy/mod.rs
@@ -6,7 +6,8 @@ pub mod read_policy;
 pub mod write_policy;
 
 use aerospike_core::expressions::Expression;
-use aerospike_core::policy::Replica;
+use aerospike_core::policy::{QueryDuration, Replica};
+use aerospike_core::query::PartitionFilter;
 use aerospike_core::{
     CommitLevel, ConsistencyLevel, GenerationPolicy, ReadTouchTTL, RecordExistsAction,
 };
@@ -14,6 +15,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 use crate::expressions::{is_expression, py_to_expression};
+use crate::types::partition_filter::PyPartitionFilter;
 
 /// Extract simple typed fields from a Python dict into a policy struct.
 ///
@@ -102,6 +104,36 @@ pub(crate) fn parse_consistency_level(val: i32) -> ConsistencyLevel {
         1 => ConsistencyLevel::ConsistencyAll,
         _ => ConsistencyLevel::ConsistencyOne,
     }
+}
+
+/// Map a `QUERY_DURATION_*` integer constant to a [`QueryDuration`].
+///
+/// Unknown values fall back to [`QueryDuration::Long`].
+pub(crate) fn parse_query_duration(val: i32) -> QueryDuration {
+    match val {
+        0 => QueryDuration::Long,
+        1 => QueryDuration::Short,
+        2 => QueryDuration::LongRelaxAP,
+        _ => QueryDuration::Long,
+    }
+}
+
+/// Extract a `PartitionFilter` from a query policy dict.
+///
+/// Returns `Ok(None)` when the key is absent. Returns `Err` when the value is
+/// present but not a `PyPartitionFilter` instance. We clone the inner filter
+/// so the user's handle is not mutated by query execution.
+pub fn parse_partition_filter(dict: &Bound<'_, PyDict>) -> PyResult<Option<PartitionFilter>> {
+    let Some(val) = dict.get_item("partition_filter")? else {
+        return Ok(None);
+    };
+    let pf: PyPartitionFilter = val.extract().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err(
+            "policy['partition_filter'] must be a PartitionFilter instance \
+             returned by aerospike_py.partition_filter_all/_by_id/_by_range",
+        )
+    })?;
+    Ok(Some(pf.clone_inner()))
 }
 
 /// Convert a `read_touch_ttl_percent` integer to a [`ReadTouchTTL`] enum.

--- a/rust/src/policy/query_policy.rs
+++ b/rust/src/policy/query_policy.rs
@@ -1,5 +1,6 @@
 //! Query/scan policy parsing from Python dicts.
 
+use aerospike_core::query::PartitionFilter;
 use aerospike_core::QueryPolicy;
 use log::trace;
 use pyo3::prelude::*;
@@ -7,17 +8,24 @@ use pyo3::types::PyDict;
 
 use super::{
     extract_filter_expression, extract_policy_fields, parse_consistency_level,
-    parse_read_touch_ttl, parse_replica,
+    parse_partition_filter, parse_query_duration, parse_read_touch_ttl, parse_replica,
 };
 
-/// Parse a Python policy dict into a QueryPolicy
-pub fn parse_query_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<QueryPolicy> {
+/// Parse a Python policy dict into a `(QueryPolicy, PartitionFilter)` pair.
+///
+/// `PartitionFilter` is a positional argument to
+/// `aerospike_core::Client::query()`, not a `QueryPolicy` field, so we return
+/// it alongside. When `policy["partition_filter"]` is absent we default to
+/// `PartitionFilter::all()`, matching the prior behavior.
+pub fn parse_query_policy(
+    policy_dict: Option<&Bound<'_, PyDict>>,
+) -> PyResult<(QueryPolicy, PartitionFilter)> {
     trace!("Parsing query policy");
     let mut policy = QueryPolicy::default();
 
     let dict = match policy_dict {
         Some(d) => d,
-        None => return Ok(policy),
+        None => return Ok((policy, PartitionFilter::all())),
     };
 
     extract_policy_fields!(dict, {
@@ -27,7 +35,8 @@ pub fn parse_query_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<Q
         "max_records" => policy.max_records;
         "records_per_second" => policy.records_per_second;
         "max_concurrent_nodes" => policy.max_concurrent_nodes;
-        "record_queue_size" => policy.record_queue_size
+        "record_queue_size" => policy.record_queue_size;
+        "include_bin_data" => policy.include_bin_data
     });
 
     if let Some(val) = dict.get_item("replica")? {
@@ -39,16 +48,22 @@ pub fn parse_query_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<Q
     if let Some(val) = dict.get_item("read_touch_ttl_percent")? {
         policy.base_policy.read_touch_ttl = parse_read_touch_ttl(val.extract::<i64>()?)?;
     }
+    if let Some(val) = dict.get_item("expected_duration")? {
+        policy.expected_duration = parse_query_duration(val.extract::<i32>()?);
+    }
 
     policy.base_policy.filter_expression = extract_filter_expression(dict)?;
 
-    Ok(policy)
+    let partition_filter = parse_partition_filter(dict)?.unwrap_or_else(PartitionFilter::all);
+
+    Ok((policy, partition_filter))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aerospike_core::policy::Replica;
+    use crate::types::partition_filter::partition_filter_by_range;
+    use aerospike_core::policy::{QueryDuration, Replica};
     use aerospike_core::{ConsistencyLevel, ReadTouchTTL};
 
     fn build_dict<'py>(
@@ -61,13 +76,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_query_policy_default_when_dict_none() {
+        let (policy, pf) = parse_query_policy(None).unwrap();
+        assert_eq!(pf.begin, 0);
+        assert_eq!(pf.count, 4096);
+        assert!(policy.include_bin_data);
+    }
+
+    #[test]
     fn parse_query_policy_with_replica() {
         Python::initialize();
         Python::attach(|py| {
             let d = build_dict(py, |d| {
                 d.set_item("replica", 2i32).unwrap();
             });
-            let p = parse_query_policy(Some(&d)).unwrap();
+            let (p, _) = parse_query_policy(Some(&d)).unwrap();
             assert_eq!(p.replica, Replica::PreferRack);
         });
     }
@@ -80,7 +103,7 @@ mod tests {
                 d.set_item("read_mode_ap", 1i32).unwrap();
                 d.set_item("read_touch_ttl_percent", 75i64).unwrap();
             });
-            let p = parse_query_policy(Some(&d)).unwrap();
+            let (p, _) = parse_query_policy(Some(&d)).unwrap();
             assert_eq!(
                 p.base_policy.consistency_level,
                 ConsistencyLevel::ConsistencyAll
@@ -89,6 +112,56 @@ mod tests {
                 p.base_policy.read_touch_ttl,
                 ReadTouchTTL::Percent(75)
             ));
+        });
+    }
+
+    #[test]
+    fn parse_query_policy_expected_duration_short() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("expected_duration", 1i32).unwrap();
+            });
+            let (p, _) = parse_query_policy(Some(&d)).unwrap();
+            assert_eq!(p.expected_duration, QueryDuration::Short);
+        });
+    }
+
+    #[test]
+    fn parse_query_policy_expected_duration_unknown_falls_back() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("expected_duration", 99i32).unwrap();
+            });
+            let (p, _) = parse_query_policy(Some(&d)).unwrap();
+            assert_eq!(p.expected_duration, QueryDuration::Long);
+        });
+    }
+
+    #[test]
+    fn parse_query_policy_include_bin_data_false() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("include_bin_data", false).unwrap();
+            });
+            let (p, _) = parse_query_policy(Some(&d)).unwrap();
+            assert!(!p.include_bin_data);
+        });
+    }
+
+    #[test]
+    fn parse_query_policy_partition_filter_round_trip() {
+        Python::initialize();
+        Python::attach(|py| {
+            let pf = partition_filter_by_range(100, 256).unwrap();
+            let pf_obj = Py::new(py, pf).unwrap();
+            let dict = PyDict::new(py);
+            dict.set_item("partition_filter", pf_obj).unwrap();
+            let (_p, partition_filter) = parse_query_policy(Some(&dict)).unwrap();
+            assert_eq!(partition_filter.begin, 100);
+            assert_eq!(partition_filter.count, 256);
         });
     }
 }

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 
 use aerospike_core::query::Filter;
 use aerospike_core::{
-    Bins, Client as AsClient, CollectionIndexType, Error as AsError, PartitionFilter, Statement,
-    Value,
+    Bins, Client as AsClient, CollectionIndexType, Error as AsError, Statement, Value,
 };
 use futures::StreamExt;
 use log::{debug, trace};
@@ -210,7 +209,7 @@ fn execute_query_collect(
     conn_info: &crate::tracing::ConnectionInfo,
 ) -> PyResult<Vec<aerospike_core::Record>> {
     let client = client.clone();
-    let query_policy = parse_query_policy(policy)?;
+    let (query_policy, partition_filter) = parse_query_policy(policy)?;
     debug!("Executing {}", op_name);
 
     let timer = crate::metrics::OperationTimer::start(op_name, namespace, set_name);
@@ -223,7 +222,7 @@ fn execute_query_collect(
         Ok(py.detach(|| {
             RUNTIME.block_on(async {
                 let rs = client
-                    .query(&query_policy, PartitionFilter::all(), statement)
+                    .query(&query_policy, partition_filter, statement)
                     .await?;
                 let mut stream = rs.into_stream();
                 let mut results = Vec::new();

--- a/rust/src/types/mod.rs
+++ b/rust/src/types/mod.rs
@@ -9,5 +9,6 @@
 pub mod bin;
 pub mod host;
 pub mod key;
+pub mod partition_filter;
 pub mod record;
 pub mod value;

--- a/rust/src/types/partition_filter.rs
+++ b/rust/src/types/partition_filter.rs
@@ -1,0 +1,146 @@
+//! PyO3 wrapper around `aerospike_core::PartitionFilter`.
+//!
+//! Exposed to Python via three module-level free functions
+//! (`partition_filter_all`, `partition_filter_by_id`, `partition_filter_by_range`).
+//! The wrapper is opaque from Python — users hold the handle and pass it as
+//! `policy={"partition_filter": handle}`. Internally we clone the inner
+//! `PartitionFilter` before handing it to `aerospike_core::Client::query()`
+//! because the underlying struct holds `Arc<Mutex<Vec<PartitionStatus>>>`
+//! whose state mutates during query execution; cloning isolates the user's
+//! handle from any in-flight state changes.
+
+use aerospike_core::query::PartitionFilter as CorePartitionFilter;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Total number of partitions in an Aerospike cluster.
+const PARTITIONS: usize = 4096;
+
+/// Opaque PyO3 wrapper around `aerospike_core::PartitionFilter`.
+///
+/// Construct via `partition_filter_all()`, `partition_filter_by_id(id)`, or
+/// `partition_filter_by_range(begin, count)`. Pass the resulting handle to
+/// `Query.results(policy={"partition_filter": handle})`.
+#[pyclass(
+    name = "PartitionFilter",
+    module = "aerospike_py",
+    frozen,
+    from_py_object
+)]
+#[derive(Clone, Debug)]
+pub struct PyPartitionFilter {
+    pub(crate) inner: CorePartitionFilter,
+}
+
+impl PyPartitionFilter {
+    /// Return a clone of the inner `aerospike_core::PartitionFilter`.
+    ///
+    /// Cloning is cheap (the struct holds `Arc<Mutex<...>>` and `AtomicBool`)
+    /// and isolates the user's Python handle from in-flight query state mutations.
+    pub fn clone_inner(&self) -> CorePartitionFilter {
+        self.inner.clone()
+    }
+}
+
+#[pymethods]
+impl PyPartitionFilter {
+    fn __repr__(&self) -> String {
+        format!(
+            "PartitionFilter(begin={}, count={})",
+            self.inner.begin, self.inner.count
+        )
+    }
+}
+
+/// Build a filter that scans/queries every partition (0..4096).
+#[pyfunction]
+pub fn partition_filter_all() -> PyPartitionFilter {
+    PyPartitionFilter {
+        inner: CorePartitionFilter::all(),
+    }
+}
+
+/// Build a filter targeting a single partition (0..=4095).
+#[pyfunction]
+pub fn partition_filter_by_id(partition_id: usize) -> PyResult<PyPartitionFilter> {
+    if partition_id >= PARTITIONS {
+        return Err(PyValueError::new_err(format!(
+            "partition_id must be in [0, {PARTITIONS}), got {partition_id}"
+        )));
+    }
+    Ok(PyPartitionFilter {
+        inner: CorePartitionFilter::by_id(partition_id),
+    })
+}
+
+/// Build a filter targeting `count` partitions starting at `begin`.
+///
+/// `begin` must be in `[0, 4096)` and `begin + count` must be `<= 4096`.
+/// `count == 0` is permitted (yields an empty filter).
+#[pyfunction]
+pub fn partition_filter_by_range(begin: usize, count: usize) -> PyResult<PyPartitionFilter> {
+    if begin >= PARTITIONS && count > 0 {
+        return Err(PyValueError::new_err(format!(
+            "begin must be in [0, {PARTITIONS}), got {begin}"
+        )));
+    }
+    if begin
+        .checked_add(count)
+        .map(|s| s > PARTITIONS)
+        .unwrap_or(true)
+    {
+        return Err(PyValueError::new_err(format!(
+            "begin + count must be <= {PARTITIONS}, got begin={begin}, count={count}"
+        )));
+    }
+    Ok(PyPartitionFilter {
+        inner: CorePartitionFilter::by_range(begin, count),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::Python;
+
+    #[test]
+    fn test_all_covers_4096_partitions() {
+        let pf = partition_filter_all();
+        assert_eq!(pf.inner.begin, 0);
+        assert_eq!(pf.inner.count, PARTITIONS);
+    }
+
+    #[test]
+    fn test_by_id_in_range() {
+        let pf = partition_filter_by_id(42).unwrap();
+        assert_eq!(pf.inner.begin, 42);
+        assert_eq!(pf.inner.count, 1);
+    }
+
+    #[test]
+    fn test_by_id_out_of_range_raises() {
+        Python::initialize();
+        Python::attach(|_py| {
+            let err = partition_filter_by_id(PARTITIONS).unwrap_err();
+            assert!(err.to_string().contains("partition_id must be"));
+        });
+    }
+
+    #[test]
+    fn test_by_range_validates_overflow() {
+        Python::initialize();
+        Python::attach(|_py| {
+            assert!(partition_filter_by_range(4000, 1000).is_err());
+            assert!(partition_filter_by_range(0, 4096).is_ok());
+            assert!(partition_filter_by_range(0, 0).is_ok());
+        });
+    }
+
+    #[test]
+    fn test_clone_preserves_begin_count() {
+        let pf = partition_filter_by_range(100, 200).unwrap();
+        let cloned = pf.clone();
+        assert_eq!(cloned.inner.begin, 100);
+        assert_eq!(cloned.inner.count, 200);
+    }
+}

--- a/src/aerospike_py/__init__.py
+++ b/src/aerospike_py/__init__.py
@@ -12,6 +12,13 @@ from aerospike_py.types import BatchRecord, BatchRecords, BatchWriteResult, User
 
 # Import all exceptions from native module
 from aerospike_py._aerospike import (  # noqa: F401
+    PartitionFilter,
+    partition_filter_all,
+    partition_filter_by_id,
+    partition_filter_by_range,
+)
+
+from aerospike_py._aerospike import (  # noqa: F401
     AerospikeError,
     ClientError,
     ClusterError,
@@ -70,6 +77,10 @@ from aerospike_py._aerospike import (  # noqa: F401
     # Read Touch TTL Percent (server v8+)
     READ_TOUCH_TTL_PERCENT_SERVER_DEFAULT,
     READ_TOUCH_TTL_PERCENT_DONT_RESET,
+    # Query Duration
+    QUERY_DURATION_LONG,
+    QUERY_DURATION_SHORT,
+    QUERY_DURATION_LONG_RELAX_AP,
     # TTL Constants
     TTL_NAMESPACE_DEFAULT,
     TTL_NEVER_EXPIRE,
@@ -454,6 +465,15 @@ __all__ = [
     # Read Touch TTL Percent (server v8+)
     "READ_TOUCH_TTL_PERCENT_SERVER_DEFAULT",
     "READ_TOUCH_TTL_PERCENT_DONT_RESET",
+    # Query Duration
+    "QUERY_DURATION_LONG",
+    "QUERY_DURATION_SHORT",
+    "QUERY_DURATION_LONG_RELAX_AP",
+    # PartitionFilter helpers
+    "PartitionFilter",
+    "partition_filter_all",
+    "partition_filter_by_id",
+    "partition_filter_by_range",
     # TTL Constants
     "TTL_NAMESPACE_DEFAULT",
     "TTL_NEVER_EXPIRE",

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -2098,6 +2098,54 @@ class AsyncClient:
         policy: Optional[dict[str, Any]] = None,
     ) -> None: ...
 
+class PartitionFilter:
+    """Opaque handle representing a subset of partitions for query/scan.
+
+    Construct via :func:`partition_filter_all`, :func:`partition_filter_by_id`,
+    or :func:`partition_filter_by_range`. Pass to
+    ``Query.results(policy={"partition_filter": handle})`` to scope a query
+    to a subset of partitions.
+
+    The underlying ``aerospike_core::PartitionFilter`` holds mutable state
+    (``Arc<Mutex<Vec<PartitionStatus>>>``). Reusing the same handle across
+    two ``results()`` calls would cause the second call to resume from where
+    the first left off; aerospike-py mitigates this by cloning the inner
+    filter at parse time, isolating the user's handle.
+    """
+
+    def __repr__(self) -> str: ...
+
+def partition_filter_all() -> PartitionFilter:
+    """Build a :class:`PartitionFilter` covering all 4096 partitions.
+
+    Equivalent to omitting ``partition_filter`` from the policy entirely.
+    """
+    ...
+
+def partition_filter_by_id(partition_id: int) -> PartitionFilter:
+    """Build a :class:`PartitionFilter` targeting a single partition.
+
+    Args:
+        partition_id: Partition index in ``[0, 4095]``.
+
+    Raises:
+        ValueError: If ``partition_id`` is outside the valid range.
+    """
+    ...
+
+def partition_filter_by_range(begin: int, count: int) -> PartitionFilter:
+    """Build a :class:`PartitionFilter` targeting ``count`` partitions from ``begin``.
+
+    Args:
+        begin: First partition (``[0, 4095]``).
+        count: Number of partitions; ``begin + count <= 4096``. ``0`` is allowed
+            and yields an empty filter.
+
+    Raises:
+        ValueError: If the range overflows 4096.
+    """
+    ...
+
 class Query:
     """Secondary index query object.
 
@@ -2543,6 +2591,15 @@ POLICY_READ_MODE_AP_ALL: int
 #   - integer 1..100: reset TTL on read when within N% of original write TTL
 READ_TOUCH_TTL_PERCENT_SERVER_DEFAULT: int
 READ_TOUCH_TTL_PERCENT_DONT_RESET: int
+
+# Query Duration (hint to the server about expected query duration).
+# Use ``QUERY_DURATION_LONG`` (default) for long-running queries with many
+# records per node, ``QUERY_DURATION_SHORT`` for low-latency queries with
+# few records, and ``QUERY_DURATION_LONG_RELAX_AP`` for long queries that
+# can relax AP consistency.
+QUERY_DURATION_LONG: int
+QUERY_DURATION_SHORT: int
+QUERY_DURATION_LONG_RELAX_AP: int
 
 # TTL
 TTL_NAMESPACE_DEFAULT: int

--- a/src/aerospike_py/types.py
+++ b/src/aerospike_py/types.py
@@ -160,6 +160,12 @@ class QueryPolicy(TypedDict, total=False):
     replica: int
     read_mode_ap: int
     read_touch_ttl_percent: int
+    max_concurrent_nodes: int
+    record_queue_size: int
+    expected_duration: int
+    include_bin_data: bool
+    # PartitionFilter handle returned by partition_filter_all / _by_id / _by_range
+    partition_filter: Any
 
 
 class WriteMeta(TypedDict, total=False):

--- a/tests/integration/test_query_scan.py
+++ b/tests/integration/test_query_scan.py
@@ -75,6 +75,78 @@ class TestQuery:
         assert len(collected) >= 10
 
 
+class TestPartitionFilter:
+    """Validates PartitionFilter / expected_duration / include_bin_data on QueryPolicy.
+
+    Closes #306. ``PartitionFilter`` scopes a query to a subset of partitions;
+    ``expected_duration`` hints query length to the server; ``include_bin_data``
+    suppresses bin payload in results.
+    """
+
+    @pytest.fixture(scope="class")
+    def partitioned_data(self, client):
+        keys = []
+        for i in range(2000):
+            key = ("test", "pf_test", f"pf_key_{i}")
+            client.put(key, {"i": i, "name": f"row_{i}"})
+            keys.append(key)
+        yield keys
+        for key in keys:
+            try:
+                client.remove(key)
+            except Exception:
+                pass
+
+    def test_partition_filter_all_matches_default(self, client, partitioned_data):
+        all_default = client.query("test", "pf_test").results()
+        all_explicit = client.query("test", "pf_test").results(
+            policy={"partition_filter": aerospike_py.partition_filter_all()}
+        )
+        assert len(all_default) == len(all_explicit) == len(partitioned_data)
+
+    def test_partition_filter_by_range_quarter(self, client, partitioned_data):
+        pf = aerospike_py.partition_filter_by_range(0, 1024)  # 1/4 of partitions
+        records = client.query("test", "pf_test").results(policy={"partition_filter": pf})
+        n = len(records)
+        # Expect ~500 records (2000 * 1024/4096); allow ±25% jitter from hash distribution.
+        assert 350 <= n <= 650, f"expected ~500, got {n}"
+
+    def test_partition_filter_by_range_zero_rejected_by_server(self, client, partitioned_data):
+        """``count=0`` is accepted at the helper level but rejected by the server.
+
+        Confirms the value flows through to the server validation rather than
+        being silently swallowed.
+        """
+        pf = aerospike_py.partition_filter_by_range(0, 0)
+        with pytest.raises(aerospike_py.InvalidArgError):
+            client.query("test", "pf_test").results(policy={"partition_filter": pf})
+
+    def test_partition_filter_by_id_4095_succeeds(self, client, partitioned_data):
+        pf = aerospike_py.partition_filter_by_id(4095)
+        records = client.query("test", "pf_test").results(policy={"partition_filter": pf})
+        assert isinstance(records, list)
+
+    def test_partition_filter_by_id_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="partition_id must be"):
+            aerospike_py.partition_filter_by_id(4096)
+
+    def test_partition_filter_by_range_overflow_raises(self):
+        with pytest.raises(ValueError, match="begin \\+ count must be"):
+            aerospike_py.partition_filter_by_range(4000, 1000)
+
+    def test_expected_duration_short_runs(self, client, partitioned_data):
+        records = client.query("test", "pf_test").results(
+            policy={"expected_duration": aerospike_py.QUERY_DURATION_SHORT}
+        )
+        assert len(records) == len(partitioned_data)
+
+    def test_expected_duration_long_relax_ap_runs(self, client, partitioned_data):
+        records = client.query("test", "pf_test").results(
+            policy={"expected_duration": aerospike_py.QUERY_DURATION_LONG_RELAX_AP}
+        )
+        assert len(records) == len(partitioned_data)
+
+
 class TestIndex:
     def test_index_string_create_remove(self, client, seed_data):
         try:


### PR DESCRIPTION
## Summary

Closes #306. Wires up four previously-unparsed `QueryPolicy` fields and adds an opaque `PartitionFilter` PyO3 wrapper.

| Field | Type | Notes |
|---|---|---|
| `expected_duration` | int (`QUERY_DURATION_*`) | new constants `QUERY_DURATION_LONG=0`, `_SHORT=1`, `_LONG_RELAX_AP=2` |
| `replica` | int (`POLICY_REPLICA_*`) | reuses `parse_replica` from #305 |
| `include_bin_data` | bool | suppresses bin payload in results |
| `partition_filter` | `PartitionFilter` handle | new opaque PyO3 class |

Three new module-level constructors:

- `aerospike_py.partition_filter_all()` — covers all 4096 partitions.
- `aerospike_py.partition_filter_by_id(partition_id)` — single partition `[0, 4095]`.
- `aerospike_py.partition_filter_by_range(begin, count)` — range, `begin + count <= 4096`.

## Architectural note

`aerospike_core::query::PartitionFilter` is a **positional argument** to `Client::query()` in aerospike-core 2.0.0, not a `QueryPolicy` field (verified at `aerospike-core/src/client.rs:1193-1198`). Therefore `parse_query_policy` now returns `(QueryPolicy, PartitionFilter)` and `query.rs::execute_query_collect` consumes both. When `policy[\"partition_filter\"]` is absent the call defaults to `PartitionFilter::all()`, preserving prior behavior.

## Mutability caveat

`PartitionFilter` carries `Arc<Mutex<Vec<PartitionStatus>>>` and `AtomicBool` for resumable scans. Reusing the same handle across two `results()` calls would cause the second to resume from where the first left off — surprising for casual users. We mitigate this by cloning the inner filter at parse time (cheap — Arc clones plus two AtomicBool loads), isolating the user's handle. Documented in the `PartitionFilter` docstring.

## Test plan

- [x] `cargo test --tests --lib partition_filter query_policy` — 12 new Rust unit tests pass.
- [x] `make validate` — fmt/lint/typecheck/877 unit tests pass.
- [x] `pytest tests/integration/test_query_scan.py::TestPartitionFilter -v` — 8 integration tests pass against local Aerospike CE.
- [ ] CI green.

## Edge cases verified

- `partition_filter_by_range(0, 4096)` ≡ `partition_filter_all()` — same record count.
- `partition_filter_by_range(0, 1024)` returns ~1/4 of records (hash distribution; ±25% jitter accepted).
- `partition_filter_by_id(4095)` — last valid partition succeeds.
- `partition_filter_by_id(4096)` — `ValueError` from PyO3 guard.
- `partition_filter_by_range(4000, 1000)` — `ValueError` (overflow).
- `partition_filter_by_range(0, 0)` — accepted at helper level, server rejects with `InvalidArgError` (verified — confirms wire path is plumbed).
- `expected_duration=QUERY_DURATION_SHORT` and `_LONG_RELAX_AP` execute successfully.
- Unknown `expected_duration` value falls back to `Long` (matches existing helper convention).