### PR TITLE
docs: fix QueryPolicy default and restore batch_remove sync/async tabs (follow-up to #321)

### DIFF
--- a/docs/docs/api/client.md
+++ b/docs/docs/api/client.md
@@ -971,6 +971,9 @@ Delete multiple records in a single batch call.
     Each ``BatchRecord`` also includes an ``in_doubt`` flag
     (see :meth:`batch_write` for details).
 
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
 ```python
 # Legacy: bare keys.
 keys = [("test", "demo", f"user_{i}") for i in range(10)]
@@ -983,6 +986,25 @@ results = client.batch_remove([
     ("test", "demo", "user_2"),  # bare key, no CAS
 ])
 ```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+# Legacy: bare keys.
+keys = [("test", "demo", f"user_{i}") for i in range(10)]
+results = await client.batch_remove(keys)
+
+# CAS delete: only delete user_1 if generation is still 3.
+_, meta, _ = await client.get(("test", "demo", "user_1"))
+results = await client.batch_remove([
+    (("test", "demo", "user_1"), {"gen": meta.gen}),
+    ("test", "demo", "user_2"),  # bare key, no CAS
+])
+```
+
+  </TabItem>
+</Tabs>
 
 ## Query & Scan
 

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -246,7 +246,7 @@ Used by: `Query.results()`, `Query.foreach()`
 | `max_records` | `int` | `0` | Max records (0 = all) |
 | `records_per_second` | `int` | `0` | Rate limit per node (0 = unlimited). |
 | `max_concurrent_nodes` | `int` | `0` | Limit parallel node queries (0 = unlimited). |
-| `record_queue_size` | `int` | `5000` | Buffer capacity for record results. |
+| `record_queue_size` | `int` | `1024` | Buffer capacity for record results. |
 | `filter_expression` | `Any` | | Expression filter. |
 | `replica` | `int` | `POLICY_REPLICA_SEQUENCE` | Replica selection. |
 | `read_mode_ap` | `int` | `POLICY_READ_MODE_AP_ONE` | AP read consistency. |


### PR DESCRIPTION
## Summary

Follow-up to #321 addressing two issues found in code review (https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/321#issuecomment-4350374090). #321 was merged before fixes could be applied.

- `docs/docs/api/types.md`: `QueryPolicy.record_queue_size` default corrected `5000` → `1024`. Upstream `aerospike-core` 2.0.0 `QueryPolicy::default()` sets `record_queue_size: 1024`, and the aerospike-py Rust binding (`rust/src/policy/query_policy.rs`) does not override the upstream default — it only forwards user-supplied values.
- `docs/docs/api/client.md`: Restored `<Tabs>` / `<TabItem>` sync+async layout for the `batch_remove` example. Every other batch method on the page (`batch_write`, `batch_operate`, `batch_read`) uses this layout, and `AsyncClient.batch_remove` exists in `__init__.pyi`. The new bare-key / `(key, meta)` CAS demonstration introduced in #321 is preserved in both tabs.

## Test plan

- [ ] `make docs-build` renders without Docusaurus tab errors
- [ ] Visual diff of QueryPolicy default column in rendered docs