### PR TITLE
ci: enforce cargo fmt + clippy via pre-commit and CI (Goal #2)

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+allow-expect-in-tests = true
+allow-unwrap-in-tests = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,18 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --manifest-path rust/Cargo.toml --features otel --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,17 @@ stop-aerospike-ce: ## Stop and remove Aerospike CE container
 # ---------------------------------------------------------------------------
 
 .PHONY: lint
-lint: ## Run all linters (ruff + clippy)
+lint: ## Run all linters (ruff + clippy) — matches pre-commit strictness
 	uv run ruff check src/ tests/
 	uv run ruff format --check src/ tests/
-	cargo clippy --manifest-path rust/Cargo.toml --features otel -- -D warnings
+	cargo fmt --all -- --check
+	cargo clippy --manifest-path rust/Cargo.toml --features otel --all-targets -- -D warnings
 
 .PHONY: fmt
 fmt: ## Auto-format Python (ruff) and Rust (cargo fmt)
 	uv run ruff format src/ tests/
 	uv run ruff check --fix src/ tests/
-	cargo fmt --manifest-path rust/Cargo.toml
+	cargo fmt --all --manifest-path rust/Cargo.toml
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -251,57 +251,6 @@ pub fn prepare_exists_args(
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::extract_cluster_name;
-    use pyo3::exceptions::PyTypeError;
-    use pyo3::prelude::*;
-    use pyo3::types::PyDict;
-
-    #[test]
-    fn extract_cluster_name_returns_empty_for_missing_key() {
-        Python::initialize();
-        Python::attach(|py| {
-            let config = PyDict::new(py);
-            let cluster_name = extract_cluster_name(&config).expect("missing key should parse");
-            assert_eq!(cluster_name, "");
-        });
-    }
-
-    #[test]
-    fn extract_cluster_name_returns_empty_for_none() {
-        Python::initialize();
-        Python::attach(|py| {
-            let config = PyDict::new(py);
-            config.set_item("cluster_name", py.None()).unwrap();
-            let cluster_name = extract_cluster_name(&config).expect("None should parse");
-            assert_eq!(cluster_name, "");
-        });
-    }
-
-    #[test]
-    fn extract_cluster_name_accepts_string() {
-        Python::initialize();
-        Python::attach(|py| {
-            let config = PyDict::new(py);
-            config.set_item("cluster_name", "dev-cluster").unwrap();
-            let cluster_name = extract_cluster_name(&config).expect("string should parse");
-            assert_eq!(cluster_name, "dev-cluster");
-        });
-    }
-
-    #[test]
-    fn extract_cluster_name_rejects_non_string_value() {
-        Python::initialize();
-        Python::attach(|py| {
-            let config = PyDict::new(py);
-            config.set_item("cluster_name", 123).unwrap();
-            let err = extract_cluster_name(&config).expect_err("non-string should fail");
-            assert!(err.is_instance_of::<PyTypeError>(py));
-        });
-    }
-}
-
 // ── remove ───────────────────────────────────────────────────────────────────
 
 pub struct RemoveArgs {
@@ -939,4 +888,55 @@ pub fn prepare_create_role_args(
         read_quota,
         write_quota,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_cluster_name;
+    use pyo3::exceptions::PyTypeError;
+    use pyo3::prelude::*;
+    use pyo3::types::PyDict;
+
+    #[test]
+    fn extract_cluster_name_returns_empty_for_missing_key() {
+        Python::initialize();
+        Python::attach(|py| {
+            let config = PyDict::new(py);
+            let cluster_name = extract_cluster_name(&config).expect("missing key should parse");
+            assert_eq!(cluster_name, "");
+        });
+    }
+
+    #[test]
+    fn extract_cluster_name_returns_empty_for_none() {
+        Python::initialize();
+        Python::attach(|py| {
+            let config = PyDict::new(py);
+            config.set_item("cluster_name", py.None()).unwrap();
+            let cluster_name = extract_cluster_name(&config).expect("None should parse");
+            assert_eq!(cluster_name, "");
+        });
+    }
+
+    #[test]
+    fn extract_cluster_name_accepts_string() {
+        Python::initialize();
+        Python::attach(|py| {
+            let config = PyDict::new(py);
+            config.set_item("cluster_name", "dev-cluster").unwrap();
+            let cluster_name = extract_cluster_name(&config).expect("string should parse");
+            assert_eq!(cluster_name, "dev-cluster");
+        });
+    }
+
+    #[test]
+    fn extract_cluster_name_rejects_non_string_value() {
+        Python::initialize();
+        Python::attach(|py| {
+            let config = PyDict::new(py);
+            config.set_item("cluster_name", 123).unwrap();
+            let err = extract_cluster_name(&config).expect_err("non-string should fail");
+            assert!(err.is_instance_of::<PyTypeError>(py));
+        });
+    }
 }

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -463,9 +463,7 @@ pub async fn do_batch_write(
                 retry_results.len()
             );
         }
-        for (original_idx, retry_record) in
-            retry_indices.iter().copied().zip(retry_results.into_iter())
-        {
+        for (original_idx, retry_record) in retry_indices.iter().copied().zip(retry_results) {
             results[original_idx] = retry_record;
         }
     }

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -299,6 +299,50 @@ pub fn as_to_pyerr(err: AsError) -> PyErr {
     }
 }
 
+/// Register all Aerospike exception types on the native Python module.
+pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let py = m.py();
+    // Base exceptions
+    m.add("AerospikeError", py.get_type::<AerospikeError>())?;
+    m.add("ClientError", py.get_type::<ClientError>())?;
+    m.add("ServerError", py.get_type::<ServerError>())?;
+    m.add("RecordError", py.get_type::<RecordError>())?;
+    m.add("ClusterError", py.get_type::<ClusterError>())?;
+    m.add(
+        "AerospikeTimeoutError",
+        py.get_type::<AerospikeTimeoutError>(),
+    )?;
+    m.add("TimeoutError", py.get_type::<AerospikeTimeoutError>())?; // backward compat
+    m.add("InvalidArgError", py.get_type::<InvalidArgError>())?;
+    m.add("BackpressureError", py.get_type::<BackpressureError>())?;
+    m.add("RustPanicError", py.get_type::<RustPanicError>())?;
+    // Record-level exceptions
+    m.add("RecordNotFound", py.get_type::<RecordNotFound>())?;
+    m.add("RecordExistsError", py.get_type::<RecordExistsError>())?;
+    m.add(
+        "RecordGenerationError",
+        py.get_type::<RecordGenerationError>(),
+    )?;
+    m.add("RecordTooBig", py.get_type::<RecordTooBig>())?;
+    m.add("BinNameError", py.get_type::<BinNameError>())?;
+    m.add("BinExistsError", py.get_type::<BinExistsError>())?;
+    m.add("BinNotFound", py.get_type::<BinNotFound>())?;
+    m.add("BinTypeError", py.get_type::<BinTypeError>())?;
+    m.add("FilteredOut", py.get_type::<FilteredOut>())?;
+    // Index exceptions
+    m.add("AerospikeIndexError", py.get_type::<AerospikeIndexError>())?;
+    m.add("IndexError", py.get_type::<AerospikeIndexError>())?; // backward compat
+    m.add("IndexNotFound", py.get_type::<IndexNotFound>())?;
+    m.add("IndexFoundError", py.get_type::<IndexFoundError>())?;
+    // Query exceptions
+    m.add("QueryError", py.get_type::<QueryError>())?;
+    m.add("QueryAbortedError", py.get_type::<QueryAbortedError>())?;
+    // Admin / UDF exceptions
+    m.add("AdminError", py.get_type::<AdminError>())?;
+    m.add("UDFError", py.get_type::<UDFError>())?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,48 +386,4 @@ mod tests {
     fn test_result_code_to_int_unknown() {
         assert_eq!(result_code_to_int(&ResultCode::Unknown(250)), 250);
     }
-}
-
-/// Register all Aerospike exception types on the native Python module.
-pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    let py = m.py();
-    // Base exceptions
-    m.add("AerospikeError", py.get_type::<AerospikeError>())?;
-    m.add("ClientError", py.get_type::<ClientError>())?;
-    m.add("ServerError", py.get_type::<ServerError>())?;
-    m.add("RecordError", py.get_type::<RecordError>())?;
-    m.add("ClusterError", py.get_type::<ClusterError>())?;
-    m.add(
-        "AerospikeTimeoutError",
-        py.get_type::<AerospikeTimeoutError>(),
-    )?;
-    m.add("TimeoutError", py.get_type::<AerospikeTimeoutError>())?; // backward compat
-    m.add("InvalidArgError", py.get_type::<InvalidArgError>())?;
-    m.add("BackpressureError", py.get_type::<BackpressureError>())?;
-    m.add("RustPanicError", py.get_type::<RustPanicError>())?;
-    // Record-level exceptions
-    m.add("RecordNotFound", py.get_type::<RecordNotFound>())?;
-    m.add("RecordExistsError", py.get_type::<RecordExistsError>())?;
-    m.add(
-        "RecordGenerationError",
-        py.get_type::<RecordGenerationError>(),
-    )?;
-    m.add("RecordTooBig", py.get_type::<RecordTooBig>())?;
-    m.add("BinNameError", py.get_type::<BinNameError>())?;
-    m.add("BinExistsError", py.get_type::<BinExistsError>())?;
-    m.add("BinNotFound", py.get_type::<BinNotFound>())?;
-    m.add("BinTypeError", py.get_type::<BinTypeError>())?;
-    m.add("FilteredOut", py.get_type::<FilteredOut>())?;
-    // Index exceptions
-    m.add("AerospikeIndexError", py.get_type::<AerospikeIndexError>())?;
-    m.add("IndexError", py.get_type::<AerospikeIndexError>())?; // backward compat
-    m.add("IndexNotFound", py.get_type::<IndexNotFound>())?;
-    m.add("IndexFoundError", py.get_type::<IndexFoundError>())?;
-    // Query exceptions
-    m.add("QueryError", py.get_type::<QueryError>())?;
-    m.add("QueryAbortedError", py.get_type::<QueryAbortedError>())?;
-    // Admin / UDF exceptions
-    m.add("AdminError", py.get_type::<AdminError>())?;
-    m.add("UDFError", py.get_type::<UDFError>())?;
-    Ok(())
 }

--- a/rust/src/numpy_support.rs
+++ b/rust/src/numpy_support.rs
@@ -1061,10 +1061,10 @@ def make_reverse_slice():
             kind: DtypeKind::Float,
         };
         unsafe {
-            write_float_to_buffer(buf.as_mut_ptr(), &field, 3.14)
+            write_float_to_buffer(buf.as_mut_ptr(), &field, std::f64::consts::PI)
                 .expect("write f32 to valid buffer should succeed");
             let val = ptr::read_unaligned(buf.as_ptr() as *const f32);
-            assert!((val - 3.14f32).abs() < 1e-5);
+            assert!((val - std::f32::consts::PI).abs() < 1e-5);
         }
     }
 
@@ -1079,10 +1079,10 @@ def make_reverse_slice():
             kind: DtypeKind::Float,
         };
         unsafe {
-            write_float_to_buffer(buf.as_mut_ptr(), &field, 3.141592653589793)
+            write_float_to_buffer(buf.as_mut_ptr(), &field, std::f64::consts::PI)
                 .expect("write f64 to valid buffer should succeed");
             let val = ptr::read_unaligned(buf.as_ptr() as *const f64);
-            assert!((val - 3.141592653589793f64).abs() < 1e-15);
+            assert!((val - std::f64::consts::PI).abs() < 1e-15);
         }
     }
 
@@ -1482,12 +1482,12 @@ def make_reverse_slice():
             kind: DtypeKind::Float,
         };
         unsafe {
-            ptr::write_unaligned(buf.as_mut_ptr() as *mut f64, 3.14);
+            ptr::write_unaligned(buf.as_mut_ptr() as *mut f64, std::f64::consts::PI);
             let val = read_value_from_buffer(buf.as_ptr(), &field)
                 .expect("read f64 from valid buffer should succeed");
             match val {
                 Value::Float(FloatValue::F64(bits)) => {
-                    assert!((f64::from_bits(bits) - 3.14).abs() < 1e-10);
+                    assert!((f64::from_bits(bits) - std::f64::consts::PI).abs() < 1e-10);
                 }
                 _ => panic!("expected Float(F64) variant, got {:?}", val),
             }

--- a/rust/src/panic_safety.rs
+++ b/rust/src/panic_safety.rs
@@ -16,7 +16,7 @@
 
 use std::any::Any;
 use std::future::Future;
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use futures::FutureExt;
 use pyo3::prelude::*;
@@ -140,11 +140,7 @@ mod tests {
                 panic!("{}", detail);
             });
             let err = r.unwrap_err();
-            assert!(
-                err.value(py)
-                    .to_string()
-                    .contains("dynamic detail"),
-            );
+            assert!(err.value(py).to_string().contains("dynamic detail"),);
         });
     }
 }

--- a/rust/src/policy/admin_policy.rs
+++ b/rust/src/policy/admin_policy.rs
@@ -94,6 +94,54 @@ fn extract_optional_string(dict: &Bound<'_, PyDict>, field_name: &str) -> PyResu
     }
 }
 
+/// Convert a slice to a Python list.
+fn slice_to_pylist<'py, T>(py: Python<'py>, items: &[T]) -> PyResult<Bound<'py, PyList>>
+where
+    T: IntoPyObject<'py> + Clone,
+{
+    PyList::new(py, items.iter().cloned())
+}
+
+/// Convert a Rust User to a Python dict.
+pub fn user_to_py(py: Python<'_>, user: &aerospike_core::User) -> PyResult<Py<PyAny>> {
+    let dict = PyDict::new(py);
+    dict.set_item("user", &user.user)?;
+    dict.set_item("roles", slice_to_pylist(py, &user.roles)?)?;
+    dict.set_item("conns_in_use", user.conns_in_use)?;
+    if !user.read_info.is_empty() {
+        dict.set_item("read_info", slice_to_pylist(py, &user.read_info)?)?;
+    }
+    if !user.write_info.is_empty() {
+        dict.set_item("write_info", slice_to_pylist(py, &user.write_info)?)?;
+    }
+    Ok(dict.into_any().unbind())
+}
+
+/// Convert a Rust Role to a Python dict.
+pub fn role_to_py(py: Python<'_>, role: &aerospike_core::Role) -> PyResult<Py<PyAny>> {
+    let dict = PyDict::new(py);
+    dict.set_item("name", &role.name)?;
+
+    let privs = PyList::empty(py);
+    for p in &role.privileges {
+        let pd = PyDict::new(py);
+        pd.set_item("code", privilege_code_to_int(&p.code))?;
+        if let Some(ns) = &p.namespace {
+            pd.set_item("ns", ns)?;
+        }
+        if let Some(set) = &p.set_name {
+            pd.set_item("set", set)?;
+        }
+        privs.append(pd)?;
+    }
+    dict.set_item("privileges", privs)?;
+
+    dict.set_item("allowlist", slice_to_pylist(py, &role.allowlist)?)?;
+    dict.set_item("read_quota", role.read_quota)?;
+    dict.set_item("write_quota", role.write_quota)?;
+    Ok(dict.into_any().unbind())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,52 +212,4 @@ mod tests {
             assert!(err.is_instance_of::<PyTypeError>(py));
         });
     }
-}
-
-/// Convert a slice to a Python list.
-fn slice_to_pylist<'py, T>(py: Python<'py>, items: &[T]) -> PyResult<Bound<'py, PyList>>
-where
-    T: IntoPyObject<'py> + Clone,
-{
-    PyList::new(py, items.iter().cloned())
-}
-
-/// Convert a Rust User to a Python dict.
-pub fn user_to_py(py: Python<'_>, user: &aerospike_core::User) -> PyResult<Py<PyAny>> {
-    let dict = PyDict::new(py);
-    dict.set_item("user", &user.user)?;
-    dict.set_item("roles", slice_to_pylist(py, &user.roles)?)?;
-    dict.set_item("conns_in_use", user.conns_in_use)?;
-    if !user.read_info.is_empty() {
-        dict.set_item("read_info", slice_to_pylist(py, &user.read_info)?)?;
-    }
-    if !user.write_info.is_empty() {
-        dict.set_item("write_info", slice_to_pylist(py, &user.write_info)?)?;
-    }
-    Ok(dict.into_any().unbind())
-}
-
-/// Convert a Rust Role to a Python dict.
-pub fn role_to_py(py: Python<'_>, role: &aerospike_core::Role) -> PyResult<Py<PyAny>> {
-    let dict = PyDict::new(py);
-    dict.set_item("name", &role.name)?;
-
-    let privs = PyList::empty(py);
-    for p in &role.privileges {
-        let pd = PyDict::new(py);
-        pd.set_item("code", privilege_code_to_int(&p.code))?;
-        if let Some(ns) = &p.namespace {
-            pd.set_item("ns", ns)?;
-        }
-        if let Some(set) = &p.set_name {
-            pd.set_item("set", set)?;
-        }
-        privs.append(pd)?;
-    }
-    dict.set_item("privileges", privs)?;
-
-    dict.set_item("allowlist", slice_to_pylist(py, &role.allowlist)?)?;
-    dict.set_item("read_quota", role.read_quota)?;
-    dict.set_item("write_quota", role.write_quota)?;
-    Ok(dict.into_any().unbind())
 }

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -495,8 +495,10 @@ mod tests {
     fn apply_record_meta_for_delete_per_record_wins_over_base() {
         Python::initialize();
         Python::attach(|py| {
-            let mut base = aerospike_core::BatchDeletePolicy::default();
-            base.send_key = false;
+            let base = aerospike_core::BatchDeletePolicy {
+                send_key: false,
+                ..Default::default()
+            };
             let meta = build_dict(py, |d| {
                 d.set_item("key", 1i32).unwrap();
                 d.set_item("durable_delete", true).unwrap();

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -240,9 +240,11 @@ mod tests {
     fn apply_record_meta_preserves_unrelated_fields() {
         Python::initialize();
         Python::attach(|py| {
-            let mut base = BatchWritePolicy::default();
-            base.send_key = true;
-            base.commit_level = CommitLevel::CommitMaster;
+            let base = BatchWritePolicy {
+                send_key: true,
+                commit_level: CommitLevel::CommitMaster,
+                ..BatchWritePolicy::default()
+            };
 
             // Meta only sets ttl — other fields must come from base.
             let meta = build_dict(py, |d| {
@@ -259,8 +261,10 @@ mod tests {
     fn apply_record_meta_per_record_wins_over_base() {
         Python::initialize();
         Python::attach(|py| {
-            let mut base = BatchWritePolicy::default();
-            base.send_key = false; // batch policy = DIGEST
+            let base = BatchWritePolicy {
+                send_key: false, // batch policy = DIGEST
+                ..BatchWritePolicy::default()
+            };
 
             // Per-record meta = SEND must override.
             let meta = build_dict(py, |d| {


### PR DESCRIPTION
## Summary
Two commits:

**1. `chore(rust): fix clippy::approx_constant, items_after_test_module, field_reassign_with_default`**
- Replace `3.14*` / `3.141592*` literals with `std::f64::consts::PI` / `std::f32::consts::PI` in `numpy_support.rs` test blocks.
- Move non-test items above `mod tests` in `client_common.rs`, `errors.rs`, `admin_policy.rs`.
- Convert two builder-style assignments in `batch_policy.rs` to struct-update syntax.
- `cargo fmt` cleanup in `panic_safety.rs`.
- No behavior changes.

**2. `ci: enforce cargo fmt + clippy via pre-commit and CI`**
- Add `.clippy.toml` allowing `expect`/`unwrap` in tests only.
- Add local pre-commit hooks for `cargo fmt --check` and `cargo clippy --features otel --all-targets -- -D warnings`.
- CI lint job already runs pre-commit, so coverage auto-extends.

Aligns with **Goal #2 (Performance / Rust-first quality)**.

## Test plan
- [ ] `cargo fmt --all -- --check` — clean (verified locally).
- [ ] `cargo clippy --manifest-path rust/Cargo.toml --features otel --all-targets -- -D warnings` — clean (verified locally).
- [ ] `cargo test --manifest-path rust/Cargo.toml --features otel` — 110 tests pass (verified locally).
- [ ] `pre-commit run --all-files` — all 9 hooks pass.
- [ ] CI lint job stays green.