### PR TITLE
feat(admin): accept string privilege names (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 [Unreleased]: https://github.com/KimSoungRyoul/aerospike-py/compare/v0.0.1.beta2...HEAD
 
+### Changed
+- `Privilege.code` (used by `admin_create_role` / `admin_grant_privileges` / `admin_revoke_privileges`) now accepts the canonical asadm-style string name in addition to the int constant. Both `{"code": aerospike_py.PRIV_READ}` and `{"code": "read"}` are valid; recognised names are `read`, `read-write`, `read-write-udf`, `write`, `truncate`, `user-admin`, `sys-admin`, `data-admin`, `udf-admin`, `sindex-admin`. Names are case-insensitive and `_` is treated as a synonym for `-`. Removes the need for downstream consumers receiving privilege codes from a wire format (HTTP forms, JSON) to maintain a name → int translation table. Closes #326.
+
 ### Fixed
 - Reading a record with a language-specific blob particle type (PYTHON_BLOB=8, JAVA_BLOB=5, CSHARP_BLOB=7, RUBY_BLOB=9, PHP_BLOB=10, ERLANG_BLOB=11, LUA_BLOB=22) no longer aborts the Python process. The native panic from `aerospike-core` is now caught at every read/write entry point and surfaced to Python as `aerospike_py.RustPanicError` (subclass of `ClientError`), so callers can `try/except` around individual operations or per-record in scans/batch reads. The bin data itself is not recovered — the operation reports the failure and aborts; only the Python process survives. Closes #280.
 

--- a/docs/docs/api/constants.md
+++ b/docs/docs/api/constants.md
@@ -240,18 +240,21 @@ Used with `operate()` and `batch_operate()`.
 
 ## Privilege Codes
 
-| Constant | Description |
-|----------|-------------|
-| `PRIV_READ` | Read |
-| `PRIV_WRITE` | Write |
-| `PRIV_READ_WRITE` | Read-write |
-| `PRIV_READ_WRITE_UDF` | Read-write-UDF |
-| `PRIV_SYS_ADMIN` | System admin |
-| `PRIV_USER_ADMIN` | User admin |
-| `PRIV_DATA_ADMIN` | Data admin |
-| `PRIV_UDF_ADMIN` | UDF admin |
-| `PRIV_SINDEX_ADMIN` | Secondary index admin |
-| `PRIV_TRUNCATE` | Truncate |
+`Privilege.code` accepts either the int constant or the canonical string name
+(case-insensitive; `_` is a synonym for `-`).
+
+| Constant | Name | Description |
+|----------|------|-------------|
+| `PRIV_READ` | `"read"` | Read |
+| `PRIV_WRITE` | `"write"` | Write |
+| `PRIV_READ_WRITE` | `"read-write"` | Read-write |
+| `PRIV_READ_WRITE_UDF` | `"read-write-udf"` | Read-write-UDF |
+| `PRIV_SYS_ADMIN` | `"sys-admin"` | System admin |
+| `PRIV_USER_ADMIN` | `"user-admin"` | User admin |
+| `PRIV_DATA_ADMIN` | `"data-admin"` | Data admin |
+| `PRIV_UDF_ADMIN` | `"udf-admin"` | UDF admin |
+| `PRIV_SINDEX_ADMIN` | `"sindex-admin"` | Secondary index admin |
+| `PRIV_TRUNCATE` | `"truncate"` | Truncate |
 
 ## Status Codes
 

--- a/docs/docs/guides/admin/admin.md
+++ b/docs/docs/guides/admin/admin.md
@@ -65,18 +65,22 @@ client.admin_drop_role("data_reader")
 
 ## Privilege Codes
 
-| Constant | Description |
-|----------|-------------|
-| `PRIV_READ` | Read records |
-| `PRIV_WRITE` | Write records |
-| `PRIV_READ_WRITE` | Read and write |
-| `PRIV_READ_WRITE_UDF` | Read, write, and UDF |
-| `PRIV_SYS_ADMIN` | System admin |
-| `PRIV_USER_ADMIN` | User management |
-| `PRIV_DATA_ADMIN` | Data management (truncate, index) |
-| `PRIV_UDF_ADMIN` | UDF management |
-| `PRIV_SINDEX_ADMIN` | Secondary index management |
-| `PRIV_TRUNCATE` | Truncate operations |
+`code` accepts either the int constant or the canonical string name (asadm-style).
+Names are matched case-insensitively, and `_` is a synonym for `-`
+(`"sys_admin"` == `"sys-admin"`).
+
+| Constant | Name | Description |
+|----------|------|-------------|
+| `PRIV_READ` | `"read"` | Read records |
+| `PRIV_WRITE` | `"write"` | Write records |
+| `PRIV_READ_WRITE` | `"read-write"` | Read and write |
+| `PRIV_READ_WRITE_UDF` | `"read-write-udf"` | Read, write, and UDF |
+| `PRIV_SYS_ADMIN` | `"sys-admin"` | System admin |
+| `PRIV_USER_ADMIN` | `"user-admin"` | User management |
+| `PRIV_DATA_ADMIN` | `"data-admin"` | Data management (truncate, index) |
+| `PRIV_UDF_ADMIN` | `"udf-admin"` | UDF management |
+| `PRIV_SINDEX_ADMIN` | `"sindex-admin"` | Secondary index management |
+| `PRIV_TRUNCATE` | `"truncate"` | Truncate operations |
 
 ## Privilege Scope
 
@@ -84,4 +88,8 @@ client.admin_drop_role("data_reader")
 {"code": aerospike.PRIV_READ}                              # Global
 {"code": aerospike.PRIV_READ, "ns": "test"}                # Namespace
 {"code": aerospike.PRIV_READ, "ns": "test", "set": "demo"} # Namespace + set
+
+# Equivalent string form — useful when codes arrive from a wire format
+# (HTTP form, JSON) so callers don't need a name → int translation table.
+{"code": "read", "ns": "test", "set": "demo"}
 ```

--- a/rust/src/policy/admin_policy.rs
+++ b/rust/src/policy/admin_policy.rs
@@ -41,6 +41,33 @@ fn code_to_privilege_code(code: u8) -> PyResult<PrivilegeCode> {
     }
 }
 
+/// Convert a canonical privilege name (asadm-style) to a Rust PrivilegeCode.
+///
+/// Accepts the same names the server / asadm emits, e.g. `"read"`,
+/// `"read-write"`, `"sys-admin"`. Also accepts the `_` variant
+/// (`"read_write"`, `"sys_admin"`) for ergonomics with Python code that
+/// avoids hyphens.
+fn name_to_privilege_code(name: &str) -> PyResult<PrivilegeCode> {
+    match name.to_ascii_lowercase().replace('_', "-").as_str() {
+        "user-admin" => Ok(PrivilegeCode::UserAdmin),
+        "sys-admin" => Ok(PrivilegeCode::SysAdmin),
+        "data-admin" => Ok(PrivilegeCode::DataAdmin),
+        "udf-admin" => Ok(PrivilegeCode::UDFAdmin),
+        "sindex-admin" => Ok(PrivilegeCode::SIndexAdmin),
+        "read" => Ok(PrivilegeCode::Read),
+        "read-write" => Ok(PrivilegeCode::ReadWrite),
+        "read-write-udf" => Ok(PrivilegeCode::ReadWriteUDF),
+        "write" => Ok(PrivilegeCode::Write),
+        "truncate" => Ok(PrivilegeCode::Truncate),
+        _ => Err(crate::errors::InvalidArgError::new_err(format!(
+            "Unknown privilege name: {:?}. Expected one of: read, read-write, \
+             read-write-udf, write, truncate, user-admin, sys-admin, data-admin, \
+             udf-admin, sindex-admin",
+            name
+        ))),
+    }
+}
+
 /// Convert a Rust PrivilegeCode to a Python integer.
 fn privilege_code_to_int(code: &PrivilegeCode) -> u8 {
     match code {
@@ -59,20 +86,36 @@ fn privilege_code_to_int(code: &PrivilegeCode) -> u8 {
 }
 
 /// Convert a Python list of privilege dicts to Vec<Privilege>.
-/// Each dict: {"code": int, "ns": str (optional), "set": str (optional)}
+///
+/// Each dict: `{"code": int | str, "ns": str (optional), "set": str (optional)}`.
+/// `code` accepts either the int constant (`aerospike_py.PRIV_READ = 10`) or
+/// the canonical string name (`"read"`, `"read-write"`, `"sys-admin"`, …) so
+/// callers receiving privilege names from a wire format (HTTP form, JSON, asadm
+/// output) don't need a translation table.
 pub fn parse_privileges(privileges: &Bound<'_, PyList>) -> PyResult<Vec<Privilege>> {
     let mut result = Vec::new();
     for item in privileges.iter() {
         let dict = item.cast::<PyDict>()?;
-        let code: u8 = dict
-            .get_item("code")?
-            .ok_or_else(|| {
-                crate::errors::InvalidArgError::new_err("Privilege dict must have 'code' key")
-            })?
-            .extract()?;
+        let code_obj = dict.get_item("code")?.ok_or_else(|| {
+            crate::errors::InvalidArgError::new_err("Privilege dict must have 'code' key")
+        })?;
+        let priv_code = if let Ok(code_int) = code_obj.extract::<u8>() {
+            code_to_privilege_code(code_int)?
+        } else if let Ok(code_str) = code_obj.extract::<String>() {
+            name_to_privilege_code(&code_str)?
+        } else {
+            let type_name = code_obj
+                .get_type()
+                .name()
+                .map(|n| n.to_string())
+                .unwrap_or_else(|_| "unknown".to_string());
+            return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                "privilege 'code' must be int or str, got {type_name}"
+            )));
+        };
         let ns = extract_optional_string(dict, "ns")?;
         let set_name = extract_optional_string(dict, "set")?;
-        result.push(Privilege::new(code_to_privilege_code(code)?, ns, set_name));
+        result.push(Privilege::new(priv_code, ns, set_name));
     }
     Ok(result)
 }
@@ -209,6 +252,92 @@ mod tests {
             privileges.append(dict).unwrap();
 
             let err = parse_privileges(&privileges).expect_err("non-string set must be rejected");
+            assert!(err.is_instance_of::<PyTypeError>(py));
+        });
+    }
+
+    #[test]
+    fn parse_privileges_accepts_string_code() {
+        Python::initialize();
+        Python::attach(|py| {
+            let privileges = PyList::empty(py);
+            for name in [
+                "read",
+                "read-write",
+                "read-write-udf",
+                "write",
+                "truncate",
+                "user-admin",
+                "sys-admin",
+                "data-admin",
+                "udf-admin",
+                "sindex-admin",
+            ] {
+                let dict = PyDict::new(py);
+                dict.set_item("code", name).unwrap();
+                privileges.append(dict).unwrap();
+            }
+
+            let parsed = parse_privileges(&privileges).expect("string codes should parse");
+            assert_eq!(parsed.len(), 10);
+            assert!(matches!(parsed[0].code, PrivilegeCode::Read));
+            assert!(matches!(parsed[1].code, PrivilegeCode::ReadWrite));
+            assert!(matches!(parsed[2].code, PrivilegeCode::ReadWriteUDF));
+            assert!(matches!(parsed[3].code, PrivilegeCode::Write));
+            assert!(matches!(parsed[4].code, PrivilegeCode::Truncate));
+            assert!(matches!(parsed[5].code, PrivilegeCode::UserAdmin));
+            assert!(matches!(parsed[6].code, PrivilegeCode::SysAdmin));
+            assert!(matches!(parsed[7].code, PrivilegeCode::DataAdmin));
+            assert!(matches!(parsed[8].code, PrivilegeCode::UDFAdmin));
+            assert!(matches!(parsed[9].code, PrivilegeCode::SIndexAdmin));
+        });
+    }
+
+    #[test]
+    fn parse_privileges_string_code_is_case_and_separator_insensitive() {
+        Python::initialize();
+        Python::attach(|py| {
+            let privileges = PyList::empty(py);
+            for name in ["READ", "Read-Write", "sys_admin", "READ_WRITE_UDF"] {
+                let dict = PyDict::new(py);
+                dict.set_item("code", name).unwrap();
+                privileges.append(dict).unwrap();
+            }
+
+            let parsed = parse_privileges(&privileges).expect("normalized names should parse");
+            assert_eq!(parsed.len(), 4);
+            assert!(matches!(parsed[0].code, PrivilegeCode::Read));
+            assert!(matches!(parsed[1].code, PrivilegeCode::ReadWrite));
+            assert!(matches!(parsed[2].code, PrivilegeCode::SysAdmin));
+            assert!(matches!(parsed[3].code, PrivilegeCode::ReadWriteUDF));
+        });
+    }
+
+    #[test]
+    fn parse_privileges_rejects_unknown_string_code() {
+        Python::initialize();
+        Python::attach(|py| {
+            let privileges = PyList::empty(py);
+            let dict = PyDict::new(py);
+            dict.set_item("code", "super-admin").unwrap();
+            privileges.append(dict).unwrap();
+
+            let err = parse_privileges(&privileges).expect_err("unknown name must be rejected");
+            assert!(err.to_string().contains("Unknown privilege name"));
+        });
+    }
+
+    #[test]
+    fn parse_privileges_rejects_non_int_non_str_code() {
+        Python::initialize();
+        Python::attach(|py| {
+            let privileges = PyList::empty(py);
+            let dict = PyDict::new(py);
+            dict.set_item("code", 1.5_f64).unwrap();
+            privileges.append(dict).unwrap();
+
+            let err = parse_privileges(&privileges)
+                .expect_err("float code must be rejected as TypeError");
             assert!(err.is_instance_of::<PyTypeError>(py));
         });
     }

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -2809,7 +2809,25 @@ PRIV_SINDEX_ADMIN: Literal[4]
 PRIV_TRUNCATE: Literal[14]
 
 PrivilegeCode = Literal[0, 1, 2, 3, 4, 10, 11, 12, 13, 14]
-"""Valid privilege codes for admin role/grant operations."""
+"""Valid privilege codes (int) for admin role/grant operations."""
+
+PrivilegeName = Literal[
+    "read",
+    "read-write",
+    "read-write-udf",
+    "write",
+    "truncate",
+    "user-admin",
+    "sys-admin",
+    "data-admin",
+    "udf-admin",
+    "sindex-admin",
+]
+"""Canonical privilege names accepted in place of ``PrivilegeCode``.
+
+Names are matched case-insensitively and ``_`` is treated as a synonym for
+``-`` (e.g. ``"sys_admin"`` == ``"sys-admin"``).
+"""
 
 # Status Codes
 AEROSPIKE_OK: Literal[0]

--- a/src/aerospike_py/types.py
+++ b/src/aerospike_py/types.py
@@ -235,7 +235,7 @@ class ClientConfig(TypedDict, total=False):
 
 
 class Privilege(TypedDict, total=False):
-    code: int
+    code: int | str
     ns: str
     set: str
 

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -103,3 +103,47 @@ class TestAdminRole:
         assert isinstance(roles, list)
         # Built-in roles should exist
         assert len(roles) >= 1
+
+    @skip_if_no_security
+    def test_create_role_accepts_string_privilege_code(self, client):
+        """Privilege ``code`` accepts canonical string names (issue #326)."""
+        client.admin_create_role(
+            "test_role_str_code",
+            [{"code": "read", "ns": "test", "set": "demo"}],
+        )
+
+        try:
+            role_info = client.admin_query_role("test_role_str_code")
+            assert role_info["name"] == "test_role_str_code"
+            assert len(role_info["privileges"]) == 1
+            # Server normalises back to int code on read.
+            assert role_info["privileges"][0]["code"] == aerospike_py.PRIV_READ
+        finally:
+            client.admin_drop_role("test_role_str_code")
+
+    @skip_if_no_security
+    def test_grant_revoke_privileges_accept_string_codes(self, client):
+        """grant/revoke accept string privilege names too (issue #326)."""
+        client.admin_create_role(
+            "test_role_str_grant",
+            [{"code": "read"}],
+        )
+
+        try:
+            client.admin_grant_privileges(
+                "test_role_str_grant",
+                [{"code": "write"}],
+            )
+            role_info = client.admin_query_role("test_role_str_grant")
+            codes = [p["code"] for p in role_info["privileges"]]
+            assert aerospike_py.PRIV_WRITE in codes
+
+            client.admin_revoke_privileges(
+                "test_role_str_grant",
+                [{"code": "read"}],
+            )
+            role_info = client.admin_query_role("test_role_str_grant")
+            codes = [p["code"] for p in role_info["privileges"]]
+            assert aerospike_py.PRIV_READ not in codes
+        finally:
+            client.admin_drop_role("test_role_str_grant")


### PR DESCRIPTION
## Summary
- `Privilege.code` (used by `admin_create_role` / `admin_grant_privileges` / `admin_revoke_privileges`) now accepts the canonical asadm-style string name in addition to the int constant. Both `{"code": aerospike_py.PRIV_READ}` and `{"code": "read"}` are valid.
- Recognised names: `read`, `read-write`, `read-write-udf`, `write`, `truncate`, `user-admin`, `sys-admin`, `data-admin`, `udf-admin`, `sindex-admin`. Names are case-insensitive and `_` is treated as a synonym for `-` (so `"sys_admin"` works too).
- Removes the need for downstream consumers receiving privilege codes from a wire format (HTTP forms, JSON, asadm output) to maintain a name → int translation table — see aerospike-cluster-manager#254 for the workaround this issue was filed against.

## Implementation notes
- The translation lives in the Rust binding (`rust/src/policy/admin_policy.rs::parse_privileges`) so both sync (`Client`) and async (`AsyncClient`) paths get the new behaviour without per-method shims.
- `parse_privileges` first tries `extract::<u8>()` (preserves the fast path for int callers), then falls back to `extract::<String>()` and normalises before mapping to `PrivilegeCode`. Unknown ints continue to raise `InvalidArgError`; unknown names raise `InvalidArgError` with the list of accepted names; non-int/non-str values raise `TypeError` (instead of the previous opaque `'str' object cannot be interpreted as an integer`).
- `Privilege.code` type is widened to `int | str`. New `PrivilegeName = Literal[...]` alias added in the stub for callers that want to type-narrow.

## Test plan
- [x] `cargo test --manifest-path rust/Cargo.toml --lib admin_policy` — 8 tests passing, including 4 new ones covering string codes, case/separator normalisation, unknown names, and non-int/non-str rejection.
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` clean on the touched files.
- [x] `uv run pytest tests/unit/` — 868 passed.
- [ ] `tests/integration/test_admin.py::TestAdminRole::test_create_role_accepts_string_privilege_code` and `::test_grant_revoke_privileges_accept_string_codes` — added; will run on a server with security enabled in CI (`make test-integration`).
- [x] Manual smoke: `aerospike_py.Privilege` accepts both `{"code": PRIV_READ}` and `{"code": "read"}` at construction time.

Closes #326.