### PR TITLE
docs: replace stale KimSoungRyoul/aerospike-py URLs with canonical org

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -8,7 +8,7 @@ description: Development setup, build, test, and code style guidelines.
 ## Setup
 
 ```bash
-git clone https://github.com/KimSoungRyoul/aerospike-py.git
+git clone https://github.com/aerospike-ce-ecosystem/aerospike-py.git
 cd aerospike-py
 make install          # uv sync --all-groups
 make build            # uv run maturin develop --release

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -133,7 +133,7 @@ aerospike-py is tested against **Aerospike Server 6.x and 7.x** (Community and E
 
 Open an issue on the GitHub repository:
 
-- **Bug reports:** [github.com/KimSoungRyoul/aerospike-py/issues/new](https://github.com/KimSoungRyoul/aerospike-py/issues/new)
+- **Bug reports:** [github.com/aerospike-ce-ecosystem/aerospike-py/issues/new](https://github.com/aerospike-ce-ecosystem/aerospike-py/issues/new)
 - **Feature requests:** Same link -- use the "Feature Request" template if available.
 
 Please include your Python version, OS, aerospike-py version (`aerospike_py.__version__`), and a minimal reproduction when reporting bugs.

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -353,13 +353,13 @@ aerospike-py supports Python 3.14t (free-threaded / no-GIL builds). However, kee
 If you encounter issues specific to free-threaded Python, try:
 
 1. Falling back to a standard CPython build to isolate the issue.
-2. Checking the [GitHub issues](https://github.com/KimSoungRyoul/aerospike-py/issues) for known free-threaded compatibility problems.
+2. Checking the [GitHub issues](https://github.com/aerospike-ce-ecosystem/aerospike-py/issues) for known free-threaded compatibility problems.
 
 ## Getting Help
 
 If your issue is not covered here:
 
-1. Check the [GitHub Issues](https://github.com/KimSoungRyoul/aerospike-py/issues) for existing reports.
+1. Check the [GitHub Issues](https://github.com/aerospike-ce-ecosystem/aerospike-py/issues) for existing reports.
 2. Open a new issue with:
    - Python version (`python --version`)
    - aerospike-py version (`python -c "import aerospike_py; print(aerospike_py.__version__)"`)

--- a/docs/docs/integrations/fastapi.md
+++ b/docs/docs/integrations/fastapi.md
@@ -128,7 +128,7 @@ async def delete_user(user_id: str, request: Request):
 
 ## Full Example
 
-The [`examples/sample-fastapi/`](https://github.com/KimSoungRyoul/aerospike-py/tree/main/examples/sample-fastapi) directory contains a complete application with 11 routers, Pydantic models, Docker Compose setup, and tests.
+The [`examples/sample-fastapi/`](https://github.com/aerospike-ce-ecosystem/aerospike-py/tree/main/examples/sample-fastapi) directory contains a complete application with 11 routers, Pydantic models, Docker Compose setup, and tests.
 
 ```bash
 cd examples/sample-fastapi


### PR DESCRIPTION
## Summary
The repo moved from `KimSoungRyoul/aerospike-py` (personal fork) to `aerospike-ce-ecosystem/aerospike-py` (org), but five doc pages were still pointing at the old fork — so bug reporters and new contributors clicking those links land on a stale tracker / non-canonical clone target.

## Changes
| File | Was | Now |
|---|---|---|
| `docs/docs/contributing.md` (L11) | clone from `KimSoungRyoul/aerospike-py` | clone from `aerospike-ce-ecosystem/aerospike-py` |
| `docs/docs/faq.md` (L136) | bug-report link to fork | link to org |
| `docs/docs/integrations/fastapi.md` (L131) | sample-fastapi tree link to fork | link to org |
| `docs/docs/guides/troubleshooting.md` (L356, 362) | ×2 issues links to fork | ×2 to org |

5 lines total (4 files).

## Test plan
- [x] `grep -rln "KimSoungRyoul/aerospike-py" docs/docs/` → no matches
- [x] `make docs-build` passes for both `en` and `ko` locales (Docusaurus treats broken internal links as build failures, so a clean build is the link check)
- [x] Edits are URL-only — no copy or structural change