### PR TITLE
chore(claude): add PR-time perf hot-path review gate

### DIFF
--- a/.claude/agents/perf-impact-reviewer.md
+++ b/.claude/agents/perf-impact-reviewer.md
@@ -1,0 +1,152 @@
+---
+name: perf-impact-reviewer
+description: Use this agent BEFORE opening a PR whenever the diff touches files listed in `.claude/perf-hot-paths.txt`. It analyses the diff for performance impact on the request hot path (allocations, GIL hold time, lock contention, per-record overhead, async re-entry cost, build-profile flags) and returns a structured verdict that the `pr-perf-gate` hook parses. Triggers automatically when the hook denies `gh pr create`; can also be invoked manually before pushing. Read-only — never edits code.
+tools: Bash, Read, Grep, Glob
+model: opus
+---
+
+# Performance Impact Reviewer (aerospike-py)
+
+You are a performance reviewer for **aerospike-py**, a Rust/PyO3 Python client for Aerospike. The library is benchmarked against the official C client; a >5 % regression on the request hot path is treated as a release blocker (see `POSTMORTEM-v0.5.6-batch-regression.md`).
+
+Your job: read the current diff, decide whether the change can affect request-path latency or throughput, and return a verdict that the calling Claude session — and the `gh pr create` hook — can act on.
+
+You do NOT run benchmarks. You decide whether benchmarks are needed and which ones.
+
+You do NOT modify code.
+
+## Inputs
+
+The caller will give you one of:
+- A specific diff or commit range to review
+- A request to "review the current branch"
+
+If no diff is supplied, default to:
+
+```bash
+base="${BASE_BRANCH:-main}"
+git diff "origin/$base...HEAD"
+git diff --name-only "origin/$base...HEAD"
+```
+
+The hot-path glob list lives at `.claude/perf-hot-paths.txt`. Read it once at the start. A modified file matching one of those globs is **in scope**; files NOT matching can be dismissed with a one-line "off hot path" note.
+
+## Anti-patterns to look for
+
+For each in-scope file, scan the diff for these signals. Tag each finding with a severity:
+
+- **info** — worth knowing, no action
+- **warn** — measure recommended
+- **block** — must measure or rework before merging
+
+### Rust / PyO3
+
+1. **Allocations in inner loops**
+   - new `Vec::new()`, `String::new()`, `format!()`, `to_string()`, `to_owned()`, `clone()` inside a `for` over records, bins, or batch entries
+   - `block` if per-record / per-bin; `warn` if per-call
+
+2. **GIL hold time**
+   - work added outside `py.detach(...)` / `Python::allow_threads` on an I/O path
+   - new `.extract::<T>()` chains added per-record (each touches GIL state)
+   - `block` if `.await` or blocking I/O happens while holding the GIL; `warn` for short additions
+
+3. **Lock / RwLock contention**
+   - new `Mutex::lock()` / `RwLock::write()` inside per-call paths
+   - new `Arc::clone()` where a borrow would do
+   - `warn` unless the contention pattern is obvious (then `block`)
+
+4. **Per-call PyDict / PyList parsing**
+   - new `PyDict::get_item` chains in `parse_*_policy` for hot policies (read / write / batch / query)
+   - missed opportunity to cache extracted values at connect time
+   - `warn`
+
+5. **Async re-entry cost**
+   - new `tokio::spawn` per call (vs reusing the connection's executor)
+   - new `pyo3_async_runtimes::tokio::future_into_py` wrappers replacing `py.detach(... block_on)`
+   - `warn`
+
+6. **NumPy zero-copy break**
+   - new `.to_vec()` / `.collect::<Vec<_>>()` from a numpy array buffer in `numpy_support.rs` / `numpy_batch.py`
+   - `block` — this defeats the entire numpy fast path (see CHANGELOG performance entries for #294)
+
+7. **Error-path leaking into hot path**
+   - eager `format!` / `String` allocation for an error message even on the success branch
+   - `warn`
+
+8. **Build / link flags**
+   - changes to `[profile.release]`, `lto`, `codegen-units`, `opt-level`, `panic`, `strip`, feature flags
+   - `block` until benched. The v0.5.6 incident root-cause was profile-adjacent.
+
+### Python wrapper hot path (`_client.py`, `_async_client.py`, `numpy_batch.py`)
+
+9. New `isinstance` chains, `try/except` around per-call work, or `await` on a previously-sync helper — `warn`.
+10. New attribute lookups on the native client per call where caching at connect time would do — `info`.
+
+## Output format
+
+Return a single Markdown response with this exact structure. The first line MUST be `perf-impact: <verdict>` so the hook can grep it.
+
+```
+perf-impact: <none | low | must-bench | block>
+
+## Files reviewed
+- <file1>: <on-hot-path | off-hot-path> — <one-line summary>
+- <file2>: ...
+
+## Findings
+(empty section if perf-impact: none)
+
+### <severity>: <short title>
+- **File**: `<path:line>`
+- **Pattern**: <which anti-pattern from above>
+- **Detail**: <2–3 sentences on why this is / isn't a regression risk>
+- **Suggested action**: <e.g. "hoist allocation out of the loop", "run `cargo bench --bench batch_read`", "no action — admin path">
+
+## Recommended benchmarks
+(only if perf-impact >= low)
+- `cargo bench --bench <name>` — expected metric: <p99 latency / ops/s / CPU-sec>
+- baseline file: `.claude/perf-baseline.json` (note "no baseline; record one" if missing)
+
+## Verdict
+<one paragraph: state explicitly whether the PR is safe to ship without measurement, needs a measurement, or must be reworked>
+```
+
+## Verdict rules
+
+| Verdict | When |
+|---|---|
+| `perf-impact: none` | No hot-path file touched, OR every touched hot-path file has only comment / docstring / test / type-stub changes (no executable line touched) |
+| `perf-impact: low` | Hot-path file touched but the modified region is provably off the per-request loop (e.g. a connect-time constructor, an error-variant addition, a new `#[pymethod]` exposing existing functionality without entering hot loops) |
+| `perf-impact: must-bench` | Hot-path code modified inside a per-request or per-record loop, or in a path Cargo profile / link config; needs `cargo bench` / `make benchmark` evidence in the PR before merge |
+| `perf-impact: block` | A `block`-severity finding is present; rework or explicit maintainer waiver required |
+
+## Workflow
+
+1. `cat .claude/perf-hot-paths.txt` — load globs.
+2. `git diff --name-only origin/main...HEAD` — list touched files.
+3. For each touched file, decide on-hot-path vs off-hot-path.
+4. For each on-hot-path file, `git diff origin/main...HEAD -- <path>` and scan against the anti-patterns above.
+5. (Optional) `rg -nP '<pattern>' rust/src/<file>` to confirm the exact location of a finding.
+6. Emit the structured response.
+
+If `origin/main` does not resolve (fork / detached state), fall back to `upstream/main`, then `main`.
+
+## Worked example (verdict shape)
+
+For the privilege-string fix (PR #327, touched `rust/src/policy/admin_policy.rs`, `src/aerospike_py/types.py`, `src/aerospike_py/__init__.pyi`, docs, tests):
+
+```
+perf-impact: none
+
+## Files reviewed
+- rust/src/policy/admin_policy.rs: off-hot-path — admin path, runs on role create/grant/revoke only
+- src/aerospike_py/types.py: off-hot-path — TypedDict definition, no runtime path
+- src/aerospike_py/__init__.pyi: off-hot-path — type stubs only
+- docs/**, tests/**: off-hot-path
+
+## Findings
+(none)
+
+## Verdict
+No hot-path code touched. Admin role/privilege parsing is invoked at most a few times per security configuration change and is not on the request loop. Safe to ship without measurement.
+```

--- a/.claude/hooks/pr-perf-gate.sh
+++ b/.claude/hooks/pr-perf-gate.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# PreToolUse hook: gates `gh pr create` on perf-impact-reviewer evidence.
+#
+# When Claude tries to invoke `gh pr create`, this hook:
+#   1. Resolves the PR base branch (`--base <name>`, default "main").
+#   2. Diffs the PR against the base and matches each touched file against
+#      the globs in .claude/perf-hot-paths.txt.
+#   3. If any hot-path file is touched AND the conversation transcript shows
+#      no perf-impact-reviewer invocation / `perf-impact:` verdict / benchmark
+#      run, denies the tool call with a Claude-visible reason.
+#
+# A green path (no hot-path files touched, OR evidence already present) is a
+# silent allow — the hook prints nothing and exits 0.
+#
+# Bypass: edit .claude/perf-hot-paths.txt to remove globs that don't actually
+# matter, or include the literal string "perf-impact:" in a tool result /
+# message earlier in the turn.
+
+set -euo pipefail
+
+input=$(cat)
+
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+if [[ -z "$command" ]]; then
+  exit 0
+fi
+
+# Match `gh pr create` (handle leading whitespace, semicolons, pipes, &&).
+if ! printf '%s' "$command" | grep -qE '(^|[[:space:];&|(])gh[[:space:]]+pr[[:space:]]+create(\s|$)'; then
+  exit 0
+fi
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
+[[ -z "$cwd" ]] && exit 0
+
+repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || exit 0
+hot_paths_file="$repo_root/.claude/perf-hot-paths.txt"
+[[ ! -f "$hot_paths_file" ]] && exit 0
+
+# Resolve PR base branch from the command (--base <name>); default "main".
+base="main"
+if [[ "$command" =~ --base[[:space:]]+([A-Za-z0-9._/-]+) ]]; then
+  base="${BASH_REMATCH[1]}"
+fi
+
+# Pick the first ref that resolves: origin/<base>, upstream/<base>, <base>.
+diff_ref=""
+for candidate in "origin/$base" "upstream/$base" "$base"; do
+  if git -C "$repo_root" rev-parse --verify --quiet "$candidate" >/dev/null 2>&1; then
+    diff_ref="$candidate"
+    break
+  fi
+done
+[[ -z "$diff_ref" ]] && exit 0
+
+touched=$(git -C "$repo_root" diff --name-only "$diff_ref...HEAD" 2>/dev/null || true)
+[[ -z "$touched" ]] && exit 0
+
+# Match each touched file against the hot-path globs.
+# (No `shopt -s globstar`: case-pattern matching doesn't use it, and macOS's
+#  default bash 3.2 doesn't support globstar anyway. The hot-paths file lists
+#  nested dirs explicitly when needed.)
+hot_hits=()
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r raw_pattern; do
+    # Strip comments and trim whitespace.
+    pattern="${raw_pattern%%#*}"
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [[ -z "$pattern" ]] && continue
+    # bash `case` pattern matching against the relative path.
+    case "$f" in
+      $pattern) hot_hits+=("$f"); break ;;
+    esac
+  done < "$hot_paths_file"
+done <<< "$touched"
+
+(( ${#hot_hits[@]} == 0 )) && exit 0
+
+# Allow if the transcript already shows perf-review evidence.
+transcript_path=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
+if [[ -n "$transcript_path" && -f "$transcript_path" ]]; then
+  if grep -qE 'perf-impact-reviewer|perf-impact:[[:space:]]|cargo[[:space:]]+bench|make[[:space:]]+benchmark|/perf-check' "$transcript_path"; then
+    exit 0
+  fi
+fi
+
+# `git diff --name-only` already yields unique paths, and the inner `break`
+# above ensures each path is appended at most once — no dedup needed.
+joined=$(printf '%s, ' "${hot_hits[@]}")
+joined=${joined%, }
+
+reason="PR touches performance hot-path files (${joined}). Before opening the PR, invoke the perf-impact-reviewer agent on this diff (Agent tool with subagent_type=perf-impact-reviewer), include its 'perf-impact:' verdict in the PR body, then re-run gh pr create. See .claude/agents/perf-impact-reviewer.md and .claude/perf-hot-paths.txt. To override (perf-irrelevant change incorrectly matched), include a 'perf-impact: none — <reason>' line in the PR body and retry."
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/.claude/perf-hot-paths.txt
+++ b/.claude/perf-hot-paths.txt
@@ -1,0 +1,72 @@
+# aerospike-py performance hot-path globs.
+#
+# Used by:
+#   - .claude/hooks/pr-perf-gate.sh   (gates `gh pr create` on perf review)
+#   - .claude/agents/perf-impact-reviewer.md
+#   - .claude/skills/project-goals/SKILL.md (Plan Review Checklist)
+#
+# Format: one shell glob per line, paths relative to the repo root.
+# Lines starting with `#` and blank lines are ignored. Globs are matched with
+# bash `case` (so `**` is NOT recursive — list nested dirs explicitly when
+# needed). Use the most specific pattern that still covers the regression
+# surface; admin / observability / error / build-only paths must NOT be added.
+#
+# A change to ANY listed file requires either a `perf-impact:` verdict from
+# the perf-impact-reviewer agent or evidence of a benchmark run before the PR
+# can be opened.
+
+# --- Rust: per-request entry points ----------------------------------------
+rust/src/lib.rs
+rust/src/client.rs
+rust/src/async_client.rs
+rust/src/client_common.rs
+rust/src/client_ops.rs
+rust/src/operations.rs
+rust/src/query.rs
+rust/src/expressions.rs
+
+# --- Rust: per-record / per-call conversion (executed every request) -------
+rust/src/record_helpers.rs
+rust/src/batch_types.rs
+rust/src/numpy_support.rs
+rust/src/types/*.rs
+rust/src/types/**/*.rs
+
+# --- Rust: per-call policy parsing (NOT admin_policy.rs) -------------------
+rust/src/policy/read_policy.rs
+rust/src/policy/write_policy.rs
+rust/src/policy/batch_policy.rs
+rust/src/policy/batch_read_policy.rs
+rust/src/policy/batch_delete_policy.rs
+rust/src/policy/query_policy.rs
+rust/src/policy/scan_policy.rs
+rust/src/policy/client_policy.rs
+
+# --- Rust: runtime / tokio / global state ----------------------------------
+rust/src/runtime.rs
+
+# --- Rust: build / link configuration --------------------------------------
+rust/Cargo.toml
+Cargo.toml
+
+# --- Python: thin wrappers on the request hot path -------------------------
+src/aerospike_py/_client.py
+src/aerospike_py/_async_client.py
+src/aerospike_py/numpy_batch.py
+src/aerospike_py/predicates.py
+src/aerospike_py/list_operations.py
+src/aerospike_py/map_operations.py
+src/aerospike_py/exp.py
+
+# --- Build profile ---------------------------------------------------------
+pyproject.toml
+
+# --- Explicitly OFF hot path (do NOT add): ---------------------------------
+#   rust/src/policy/admin_policy.rs   (admin only, infrequent)
+#   rust/src/errors.rs                (only on error)
+#   rust/src/constants.rs             (load-time only)
+#   rust/src/logging.rs               (observability)
+#   rust/src/tracing.rs               (observability)
+#   rust/src/metrics.rs               (observability)
+#   rust/src/_bug_report.*            (panic recovery)
+#   tests/, docs/, examples/, benchmark/

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pr-perf-gate.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/project-goals/SKILL.md
+++ b/.claude/skills/project-goals/SKILL.md
@@ -32,4 +32,5 @@ Verify the following after writing a plan:
 - [ ] Is it consistent with existing API patterns? (see `new-api` skill)
 - [ ] **Zero Python deps**: Does the default installation avoid adding external Python dependencies?
 - [ ] Are `.pyi` type stubs updated alongside the implementation?
+- [ ] **Performance gate**: Does the plan touch any file matched by `.claude/perf-hot-paths.txt`? If yes, the implementation must end with a `perf-impact:` verdict from the `perf-impact-reviewer` agent or a `cargo bench` / `make benchmark` run — `gh pr create` is hook-blocked otherwise (Goal #2; see `POSTMORTEM-v0.5.6-batch-regression.md`).
 - [ ] Are there no excessive changes beyond the goal scope?


### PR DESCRIPTION
## Summary
- Project-level discipline layer that gates `gh pr create` on performance review whenever the diff touches files on the request hot path. Direct follow-up to `POSTMORTEM-v0.5.6-batch-regression.md`.
- Single source of truth — `.claude/perf-hot-paths.txt` — shared by the gate hook and the new `perf-impact-reviewer` Opus subagent.
- The hook denies `gh pr create` when hot-path files are modified without one of: `perf-impact:` marker in the conversation, `cargo bench` / `make benchmark` evidence, or a prior `perf-impact-reviewer` invocation.
- `project-goals` skill checklist gains a perf-gate row so plan-time review also catches the case.

## Why this and not just CLAUDE.md text
Text rules get ignored under attention pressure. Hooks fire at the boundary (PR creation) regardless of what the model "remembers". This setup means a PR touching `rust/src/client.rs` cannot ship without either an explicit verdict or a benchmark — silently bypassed only by a maintainer who edits the verdict line in the PR body.

## Files
- `.claude/perf-hot-paths.txt` — Rust entry points (`client.rs`, `async_client.rs`, `client_ops.rs`, `operations.rs`, `query.rs`, `expressions.rs`), per-record conversion (`record_helpers.rs`, `batch_types.rs`, `numpy_support.rs`, `types/`), per-call policy parsers (read/write/batch/query, NOT admin), runtime, build profile, and the Python wrapper hot path. Admin / observability / error / load-time files are explicitly listed as **off** hot path with comments so they don't drift in.
- `.claude/agents/perf-impact-reviewer.md` — frontmatter-typed (`name`, `description`, `tools: Bash/Read/Grep/Glob`, `model: opus`). Read-only. Outputs a structured Markdown response whose first line is `perf-impact: <none|low|must-bench|block>` so automation can grep it. Anti-pattern catalogue covers allocations in inner loops, GIL hold time, lock contention, per-call PyDict parsing, async re-entry cost, NumPy zero-copy break, error-path leak, build-profile flags, and Python-wrapper anti-patterns.
- `.claude/hooks/pr-perf-gate.sh` — PreToolUse hook on Bash. Filters by `gh pr create` regex, resolves base ref (`origin/<base>` → `upstream/<base>` → `<base>`), diffs the branch, matches against globs, and emits `permissionDecision: deny` JSON when hot-path files are modified without evidence. macOS bash 3.2 compatible (no `mapfile`, no `globstar`).
- `.claude/settings.json` — committed config registering the hook (user-local permissions stay in `.claude/settings.local.json`, which is gitignored).
- `.claude/skills/project-goals/SKILL.md` — one new line in Plan Review Checklist linking to Goal #2 and the postmortem.

## Test plan
- [x] `bash -n .claude/hooks/pr-perf-gate.sh` — syntax clean.
- [x] Synthetic git-fixture functional test — 6/6 cases pass:
  | # | Diff | Transcript | Expected | Got |
  |---|---|---|---|---|
  | 1 | `rust/src/client.rs` | empty | DENY | DENY |
  | 2 | `rust/src/client.rs` | `perf-impact: none` | ALLOW | ALLOW |
  | 3 | `rust/src/policy/admin_policy.rs` only | empty | ALLOW | ALLOW |
  | 4 | hot-path | empty, command = `gh pr list` | ALLOW | ALLOW |
  | 5 | `rust/src/types/value.rs` | empty | DENY | DENY |
  | 6 | hot-path | "ran cargo bench" | ALLOW | ALLOW |
- [x] Compound command (`git push && gh pr create …`) is correctly detected as containing `gh pr create` and gated (Case 7 in the local test, also passes).
- [x] This PR itself: only `.claude/**` files modified; no glob match → hook silently allows.

`perf-impact: none — gate-only change, no Rust or Python wrapper code touched, hooks/agents/skills only`.

Closes nothing (no tracking issue); follow-on work to v0.5.6 postmortem.