### PR TITLE
feat(policy): expose BatchPolicy.concurrency (Sequential/Parallel)

### DIFF
--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -145,6 +145,10 @@ pub fn register_constants(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("POLICY_READ_MODE_AP_ONE", 0)?;
     m.add("POLICY_READ_MODE_AP_ALL", 1)?;
 
+    // --- Batch Concurrency ---
+    m.add("BATCH_CONCURRENCY_SEQUENTIAL", 0u32)?;
+    m.add("BATCH_CONCURRENCY_PARALLEL", 1u32)?;
+
     // --- Read Touch TTL Percent (server v8+) ---
     m.add("READ_TOUCH_TTL_PERCENT_SERVER_DEFAULT", 0)?;
     m.add("READ_TOUCH_TTL_PERCENT_DONT_RESET", -1)?;

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -1,9 +1,11 @@
 //! Batch policy parsing from Python dicts.
 
 use aerospike_core::{
-    BatchDeletePolicy, BatchPolicy, BatchReadPolicy, BatchWritePolicy, GenerationPolicy,
+    BatchDeletePolicy, BatchPolicy, BatchReadPolicy, BatchWritePolicy, Concurrency,
+    GenerationPolicy,
 };
 use log::trace;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -43,9 +45,29 @@ pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<B
         policy.base_policy.read_touch_ttl = parse_read_touch_ttl(val.extract::<i64>()?)?;
     }
 
+    if let Some(val) = dict.get_item("concurrency")? {
+        policy.concurrency = parse_concurrency(val.extract::<i64>()?)?;
+    }
+
     policy.filter_expression = extract_filter_expression(dict)?;
 
     Ok(policy)
+}
+
+/// Map a Python ``int`` to an [`aerospike_core::Concurrency`] variant.
+///
+/// Mapping: ``0 -> Sequential``, ``1 -> Parallel``. Any other value
+/// (including negatives and ``n >= 2``) is rejected with [`PyValueError`].
+/// Note that aerospike-core 2.0's ``Concurrency`` enum only supports the
+/// two variants — there is no ``MaxThreads(n)`` variant in this version.
+fn parse_concurrency(value: i64) -> PyResult<Concurrency> {
+    match value {
+        0 => Ok(Concurrency::Sequential),
+        1 => Ok(Concurrency::Parallel),
+        _ => Err(PyValueError::new_err(format!(
+            "Invalid concurrency value: {value}. Use BATCH_CONCURRENCY_SEQUENTIAL (0) or BATCH_CONCURRENCY_PARALLEL (1)"
+        ))),
+    }
 }
 
 /// Parse the batch-level policy dict into a [`BatchWritePolicy`].
@@ -382,6 +404,58 @@ mod tests {
             });
             let p = parse_batch_policy(Some(&d)).unwrap();
             assert_eq!(p.base_policy.timeout_delay, 500);
+        });
+    }
+
+    #[test]
+    fn parse_batch_policy_default_concurrency_is_parallel() {
+        let p = parse_batch_policy(None).expect("parse ok");
+        assert!(matches!(p.concurrency, Concurrency::Parallel));
+    }
+
+    #[test]
+    fn parse_batch_policy_concurrency_sequential() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("concurrency", 0i64).unwrap();
+            });
+            let p = parse_batch_policy(Some(&d)).expect("parse ok");
+            assert!(matches!(p.concurrency, Concurrency::Sequential));
+        });
+    }
+
+    #[test]
+    fn parse_batch_policy_concurrency_parallel() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("concurrency", 1i64).unwrap();
+            });
+            let p = parse_batch_policy(Some(&d)).expect("parse ok");
+            assert!(matches!(p.concurrency, Concurrency::Parallel));
+        });
+    }
+
+    #[test]
+    fn parse_batch_policy_concurrency_rejects_negative() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("concurrency", -1i64).unwrap();
+            });
+            assert!(parse_batch_policy(Some(&d)).is_err());
+        });
+    }
+
+    #[test]
+    fn parse_batch_policy_concurrency_rejects_unsupported_max_threads() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("concurrency", 4i64).unwrap();
+            });
+            assert!(parse_batch_policy(Some(&d)).is_err());
         });
     }
 

--- a/src/aerospike_py/__init__.py
+++ b/src/aerospike_py/__init__.py
@@ -74,6 +74,9 @@ from aerospike_py._aerospike import (  # noqa: F401
     # Policy Read Mode AP
     POLICY_READ_MODE_AP_ONE,
     POLICY_READ_MODE_AP_ALL,
+    # Batch Concurrency
+    BATCH_CONCURRENCY_SEQUENTIAL,
+    BATCH_CONCURRENCY_PARALLEL,
     # Read Touch TTL Percent (server v8+)
     READ_TOUCH_TTL_PERCENT_SERVER_DEFAULT,
     READ_TOUCH_TTL_PERCENT_DONT_RESET,
@@ -468,6 +471,9 @@ __all__ = [
     # Policy Read Mode AP
     "POLICY_READ_MODE_AP_ONE",
     "POLICY_READ_MODE_AP_ALL",
+    # Batch Concurrency
+    "BATCH_CONCURRENCY_SEQUENTIAL",
+    "BATCH_CONCURRENCY_PARALLEL",
     # Read Touch TTL Percent (server v8+)
     "READ_TOUCH_TTL_PERCENT_SERVER_DEFAULT",
     "READ_TOUCH_TTL_PERCENT_DONT_RESET",

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -2601,6 +2601,13 @@ POLICY_COMMIT_LEVEL_MASTER: Literal[1]
 POLICY_READ_MODE_AP_ONE: Literal[0]
 POLICY_READ_MODE_AP_ALL: Literal[1]
 
+# Batch Concurrency — values for ``BatchPolicy["concurrency"]``.
+# Maps to aerospike-core's ``Concurrency`` enum: Sequential issues commands
+# one node at a time; Parallel (default) issues commands concurrently across
+# nodes using the client's thread pool.
+BATCH_CONCURRENCY_SEQUENTIAL: Literal[0]
+BATCH_CONCURRENCY_PARALLEL: Literal[1]
+
 # -- Stub-only Policy enum aliases ---------------------------------------
 # These aliases live in the type stub only — they are NOT defined at
 # runtime. They give downstream code a single name for each policy enum:

--- a/src/aerospike_py/types.py
+++ b/src/aerospike_py/types.py
@@ -138,6 +138,10 @@ class BatchPolicy(TypedDict, total=False):
     replica: int
     read_mode_ap: int
     read_touch_ttl_percent: int
+    # Concurrency mode for batch requests. Use the module-level
+    # ``BATCH_CONCURRENCY_SEQUENTIAL`` (0) or ``BATCH_CONCURRENCY_PARALLEL``
+    # (1) constants. Default: parallel.
+    concurrency: int
     # Batch-level write defaults — used by ``batch_write``. Per-record
     # ``WriteMeta`` entries override these fields (matching the existing
     # ``ttl``/``gen`` precedence rule).

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -109,6 +109,52 @@ class TestBatchOperate:
             assert counter1 == 25
 
 
+class TestBatchConcurrency:
+    """Smoke tests for ``BatchPolicy["concurrency"]`` (issue #320)."""
+
+    def test_batch_operate_with_sequential_concurrency(self, client, cleanup):
+        keys = [
+            ("test", "demo", "batch_seq_1"),
+            ("test", "demo", "batch_seq_2"),
+        ]
+        for k in keys:
+            cleanup.append(k)
+
+        client.put(keys[0], {"counter": 1})
+        client.put(keys[1], {"counter": 2})
+
+        ops = [
+            {"op": aerospike_py.OPERATOR_INCR, "bin": "counter", "val": 10},
+            {"op": aerospike_py.OPERATOR_READ, "bin": "counter", "val": None},
+        ]
+        policy = {"concurrency": aerospike_py.BATCH_CONCURRENCY_SEQUENTIAL}
+        results = client.batch_operate(keys, ops, policy=policy)
+        assert len(results.batch_records) == 2
+        for br in results.batch_records:
+            assert br.result == 0
+
+    def test_batch_operate_with_parallel_concurrency(self, client, cleanup):
+        keys = [
+            ("test", "demo", "batch_par_1"),
+            ("test", "demo", "batch_par_2"),
+        ]
+        for k in keys:
+            cleanup.append(k)
+
+        client.put(keys[0], {"counter": 1})
+        client.put(keys[1], {"counter": 2})
+
+        ops = [
+            {"op": aerospike_py.OPERATOR_INCR, "bin": "counter", "val": 7},
+            {"op": aerospike_py.OPERATOR_READ, "bin": "counter", "val": None},
+        ]
+        policy = {"concurrency": aerospike_py.BATCH_CONCURRENCY_PARALLEL}
+        results = client.batch_operate(keys, ops, policy=policy)
+        assert len(results.batch_records) == 2
+        for br in results.batch_records:
+            assert br.result == 0
+
+
 class TestBatchWrite:
     """Test batch_operate used as batch write (OPERATOR_WRITE)."""
 


### PR DESCRIPTION
## Summary
- Expose `aerospike_core::Concurrency` on `BatchPolicy` as a Python `int` field (`concurrency`) in the `BatchPolicy` TypedDict
- Add module-level constants `BATCH_CONCURRENCY_SEQUENTIAL` (0) and `BATCH_CONCURRENCY_PARALLEL` (1)
- Reject any other value (negatives or `n >= 2`) with `ValueError` — aerospike-core 2.0's `Concurrency` enum has only Sequential / Parallel variants (no `MaxThreads(n)` in this version)

Closes #320.

## Changes

### Rust
- `rust/src/policy/batch_policy.rs`:
  - Import `aerospike_core::Concurrency` and `pyo3::exceptions::PyValueError`
  - `parse_batch_policy`: branch on `concurrency` key, mapping `int -> Concurrency` via the new `parse_concurrency` helper
  - `parse_concurrency(value: i64)`: `0 -> Sequential`, `1 -> Parallel`, anything else -> `PyValueError`
  - 5 new cargo tests covering default, Sequential, Parallel, negative-rejection, and `n >= 2`-rejection
- `rust/src/constants.rs`: add `BATCH_CONCURRENCY_SEQUENTIAL = 0` / `BATCH_CONCURRENCY_PARALLEL = 1`

### Python
- `src/aerospike_py/types.py`: add `concurrency: int` to `BatchPolicy` TypedDict with a comment pointing at the constants
- `src/aerospike_py/__init__.py`: import the two constants from the native module and re-export via `__all__`
- `src/aerospike_py/__init__.pyi`: stub the two constants as `Literal[0]` / `Literal[1]`

### Tests
- `tests/integration/test_batch.py`: new `TestBatchConcurrency` class with two smoke tests exercising `batch_operate(..., policy={"concurrency": ...})` for both modes

## Perf gate

`rust/src/policy/batch_policy.rs` is on the request hot path (`.claude/perf-hot-paths.txt`). Self-review per `.claude/agents/perf-impact-reviewer.md`:

```
perf-impact: low
```

The change adds one extra `dict.get_item("concurrency")` lookup per batch call (same shape as the existing `replica` / `read_mode_ap` branches). The success path makes no allocations; the error `format!` is on the rejection arm only. No GIL-held async work, no profile-flag changes, no per-record loops touched. Safe to ship without measurement; classified `low` because we did edit a hot-path file.

## Test plan
- [x] `cargo check --manifest-path rust/Cargo.toml`
- [x] `make build` (maturin develop --release)
- [x] `make fmt` / `make lint`
- [x] `make typecheck` (pyright: 0 errors)
- [x] `make test-unit` (876 passed, 2 warnings)
- [x] `cargo test --manifest-path rust/Cargo.toml --lib batch_policy` (24 tests, 5 new — all pass)
- [x] `make run-aerospike-ce` + `pytest tests/integration/test_batch.py` (46 passed including the 2 new concurrency smoke tests)