### PR TITLE
feat(policy): expose BasePolicy.timeout_delay

### DIFF
--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -27,6 +27,7 @@ pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<B
         "socket_timeout" => policy.base_policy.socket_timeout;
         "total_timeout" => policy.base_policy.total_timeout;
         "max_retries" => policy.base_policy.max_retries;
+        "timeout_delay" => policy.base_policy.timeout_delay;
         "allow_inline" => policy.allow_inline;
         "allow_inline_ssd" => policy.allow_inline_ssd;
         "respond_all_keys" => policy.respond_all_keys
@@ -369,6 +370,18 @@ mod tests {
             });
             let p = parse_batch_policy(Some(&d)).unwrap();
             assert_eq!(p.replica, aerospike_core::policy::Replica::Master);
+        });
+    }
+
+    #[test]
+    fn parse_batch_policy_with_timeout_delay() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("timeout_delay", 500u32).unwrap();
+            });
+            let p = parse_batch_policy(Some(&d)).unwrap();
+            assert_eq!(p.base_policy.timeout_delay, 500);
         });
     }
 

--- a/rust/src/policy/query_policy.rs
+++ b/rust/src/policy/query_policy.rs
@@ -32,6 +32,7 @@ pub fn parse_query_policy(
         "socket_timeout" => policy.base_policy.socket_timeout;
         "total_timeout" => policy.base_policy.total_timeout;
         "max_retries" => policy.base_policy.max_retries;
+        "timeout_delay" => policy.base_policy.timeout_delay;
         "max_records" => policy.max_records;
         "records_per_second" => policy.records_per_second;
         "max_concurrent_nodes" => policy.max_concurrent_nodes;
@@ -92,6 +93,18 @@ mod tests {
             });
             let (p, _) = parse_query_policy(Some(&d)).unwrap();
             assert_eq!(p.replica, Replica::PreferRack);
+        });
+    }
+
+    #[test]
+    fn parse_query_policy_with_timeout_delay() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("timeout_delay", 500u32).unwrap();
+            });
+            let (p, _) = parse_query_policy(Some(&d)).unwrap();
+            assert_eq!(p.base_policy.timeout_delay, 500);
         });
     }
 

--- a/rust/src/policy/read_policy.rs
+++ b/rust/src/policy/read_policy.rs
@@ -29,7 +29,8 @@ pub fn parse_read_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<Re
         "socket_timeout" => policy.base_policy.socket_timeout;
         "total_timeout" => policy.base_policy.total_timeout;
         "max_retries" => policy.base_policy.max_retries;
-        "sleep_between_retries" => policy.base_policy.sleep_between_retries
+        "sleep_between_retries" => policy.base_policy.sleep_between_retries;
+        "timeout_delay" => policy.base_policy.timeout_delay
     });
 
     if let Some(val) = dict.get_item("replica")? {
@@ -113,6 +114,18 @@ mod tests {
             });
             let err = parse_read_policy(Some(&d)).expect_err("must error");
             assert!(err.is_instance_of::<crate::errors::InvalidArgError>(py));
+        });
+    }
+
+    #[test]
+    fn parse_read_policy_with_timeout_delay() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = build_dict(py, |d| {
+                d.set_item("timeout_delay", 500u32).unwrap();
+            });
+            let p = parse_read_policy(Some(&d)).unwrap();
+            assert_eq!(p.base_policy.timeout_delay, 500);
         });
     }
 

--- a/rust/src/policy/write_policy.rs
+++ b/rust/src/policy/write_policy.rs
@@ -62,6 +62,7 @@ pub fn parse_write_policy(
         "socket_timeout" => policy.base_policy.socket_timeout;
         "total_timeout" => policy.base_policy.total_timeout;
         "max_retries" => policy.base_policy.max_retries;
+        "timeout_delay" => policy.base_policy.timeout_delay;
         "durable_delete" => policy.durable_delete
     });
 
@@ -125,6 +126,17 @@ mod tests {
             let err = parse_ttl(ttl).expect_err("ttl above u32::MAX must fail");
             assert!(err.is_instance_of::<crate::errors::InvalidArgError>(py));
             assert!(err.to_string().contains("ttl out of range"));
+        });
+    }
+
+    #[test]
+    fn parse_write_policy_with_timeout_delay() {
+        Python::initialize();
+        Python::attach(|py| {
+            let d = pyo3::types::PyDict::new(py);
+            d.set_item("timeout_delay", 500u32).unwrap();
+            let p = parse_write_policy(Some(&d), None).unwrap();
+            assert_eq!(p.base_policy.timeout_delay, 500);
         });
     }
 

--- a/src/aerospike_py/types.py
+++ b/src/aerospike_py/types.py
@@ -103,6 +103,7 @@ class ReadPolicy(TypedDict, total=False):
     total_timeout: int
     max_retries: int
     sleep_between_retries: int
+    timeout_delay: int
     filter_expression: Any
     replica: int
     read_mode_ap: int
@@ -113,6 +114,7 @@ class WritePolicy(TypedDict, total=False):
     socket_timeout: int
     total_timeout: int
     max_retries: int
+    timeout_delay: int
     durable_delete: bool
     key: int
     exists: int
@@ -128,6 +130,7 @@ class BatchPolicy(TypedDict, total=False):
     socket_timeout: int
     total_timeout: int
     max_retries: int
+    timeout_delay: int
     filter_expression: Any
     allow_inline: bool
     allow_inline_ssd: bool
@@ -194,6 +197,7 @@ class QueryPolicy(TypedDict, total=False):
     socket_timeout: int
     total_timeout: int
     max_retries: int
+    timeout_delay: int
     max_records: int
     records_per_second: int
     filter_expression: Any


### PR DESCRIPTION
## Summary

Exposes the `timeout_delay: u32` (ms) field on `aerospike_core::BasePolicy` across all four request-path policy parsers (`ReadPolicy`, `WritePolicy`, `BatchPolicy`, `QueryPolicy`) and their Python `TypedDict` counterparts, so users can configure the post-deadline socket-drain delay documented in aerospike-core 2.0.

Closes #319.

## Changes

- `rust/src/policy/read_policy.rs` — add `timeout_delay` to `extract_policy_fields!` + unit test
- `rust/src/policy/write_policy.rs` — add `timeout_delay` to `extract_policy_fields!` + unit test
- `rust/src/policy/batch_policy.rs` — add `timeout_delay` to `parse_batch_policy` macro + unit test
- `rust/src/policy/query_policy.rs` — add `timeout_delay` to `parse_query_policy` macro + unit test
- `src/aerospike_py/types.py` — add `timeout_delay: int` to `ReadPolicy`, `WritePolicy`, `BatchPolicy`, `QueryPolicy` TypedDicts (already present on `ScanPolicy`)

## Test plan

- [x] `make build` — release build succeeds
- [x] `make fmt` — ruff + cargo fmt clean
- [x] `make lint` — ruff check + clippy `-D warnings` clean
- [x] `make typecheck` — pyright reports 0 errors
- [x] `make test-unit` — 876 tests pass (4 new `parse_*_policy_with_timeout_delay` cases)
- [x] `cargo test --lib timeout_delay` — all 4 new Rust unit tests pass
- [x] `perf-impact-reviewer` verdict: **`perf-impact: none`** — single new `extract_policy_fields!` line per parser is just one extra `PyDict::get_item` lookup per call (only triggered when caller actually sets `timeout_delay`). No allocation, no GIL change, no profile flag change. Same shape as the existing `socket_timeout`/`max_retries` lookups in the same macro.