### PR TITLE
chore(ci): add ACE plugins PR-time follow-up issue workflow

### DIFF
--- a/.github/workflows/ace-plugins-pr-notify.yml
+++ b/.github/workflows/ace-plugins-pr-notify.yml
@@ -1,0 +1,224 @@
+name: ACE Plugins PR Notify
+# Creates / updates a follow-up issue on aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins
+# whenever a PR touching skill- or docs-relevant files is opened against main.
+# Complements `skill-impact-notify.yml` (which fires on push to main → project-hub).
+run-name: "ACE Plugins PR Notify: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}"
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    branches: [main]
+    paths:
+      # Python public surface
+      - 'src/aerospike_py/__init__.py'
+      - 'src/aerospike_py/__init__.pyi'
+      - 'src/aerospike_py/types.py'
+      - 'src/aerospike_py/exception.py'
+      - 'src/aerospike_py/exception.pyi'
+      - 'src/aerospike_py/list_operations.py'
+      - 'src/aerospike_py/map_operations.py'
+      - 'src/aerospike_py/exp.py'
+      - 'src/aerospike_py/predicates.py'
+      # Rust surface
+      - 'rust/src/lib.rs'
+      - 'rust/src/errors.rs'
+      - 'rust/src/constants.rs'
+      - 'rust/src/policy/**'
+      - 'rust/src/client.rs'
+      - 'rust/src/async_client.rs'
+      - 'rust/src/client_common.rs'
+      - 'rust/src/client_ops.rs'
+      # Docs
+      - 'docs/docs/api/**'
+      - 'docs/i18n/ko/**'
+
+jobs:
+  ace-plugins-pr-notify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+      PLUGINS_REPO: aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins
+      SOURCE_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_STATE: ${{ github.event.pull_request.state }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+    steps:
+      - name: Detect skill-affecting files and upsert ACE plugins follow-up issue
+        run: |
+          set -euo pipefail
+
+          echo "=== Step 1: Get changed files for PR #${PR_NUMBER} ==="
+          # Use GH CLI on the source repo to get the PR file list as plain paths
+          CHANGED_FILES=$(gh pr view "${PR_NUMBER}" \
+            --repo "${SOURCE_REPO}" \
+            --json files \
+            --jq '[.files[].path] | join("\n")')
+          echo "Changed files:"
+          echo "${CHANGED_FILES}"
+
+          echo "=== Step 2: Map files to affected skills ==="
+          AFFECTED_SKILLS=""
+          AFFECTED_FILES=""
+
+          while IFS= read -r file; do
+            [ -z "${file}" ] && continue
+            case "${file}" in
+              src/aerospike_py/__init__.py|src/aerospike_py/__init__.pyi)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (API signatures, return types, constants)\n"
+                ;;
+              src/aerospike_py/exception.py|src/aerospike_py/exception.pyi)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\naerospike-py-fastapi\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api**, **aerospike-py-fastapi** (exception types)\n"
+                ;;
+              src/aerospike_py/types.py)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\naerospike-py-fastapi\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api**, **aerospike-py-fastapi** (return types)\n"
+                ;;
+              src/aerospike_py/list_operations.py)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (List CDT operations)\n"
+                ;;
+              src/aerospike_py/map_operations.py)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (Map CDT operations)\n"
+                ;;
+              src/aerospike_py/exp.py)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (Expression filters)\n"
+                ;;
+              src/aerospike_py/predicates.py)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (Query predicates)\n"
+                ;;
+              rust/src/lib.rs)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (module exports)\n"
+                ;;
+              rust/src/errors.rs)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\naerospike-py-fastapi\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api**, **aerospike-py-fastapi** (exception hierarchy, HTTP mapping)\n"
+                ;;
+              rust/src/constants.rs)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (constants)\n"
+                ;;
+              rust/src/policy/*)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (policy parsing)\n"
+                ;;
+              rust/src/client.rs|rust/src/async_client.rs|rust/src/client_common.rs|rust/src/client_ops.rs)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (client methods)\n"
+                ;;
+              docs/docs/api/*)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (API reference docs)\n"
+                ;;
+              docs/i18n/ko/*)
+                AFFECTED_SKILLS="${AFFECTED_SKILLS}aerospike-py-api\n"
+                AFFECTED_FILES="${AFFECTED_FILES}- \`${file}\` -> **aerospike-py-api** (Korean i18n mirror)\n"
+                ;;
+            esac
+          done <<< "${CHANGED_FILES}"
+
+          UNIQUE_SKILLS=$(echo -e "${AFFECTED_SKILLS}" | sort -u | grep -v '^$' | paste -sd ',' -)
+
+          if [ -z "${UNIQUE_SKILLS}" ]; then
+            echo "No skill-impacting files in this PR. Skipping."
+            exit 0
+          fi
+          echo "Affected skills: ${UNIQUE_SKILLS}"
+
+          # Per-skill yes/no flags
+          API_HIT="no"; FASTAPI_HIT="no"
+          case ",${UNIQUE_SKILLS}," in *,aerospike-py-api,*) API_HIT="yes" ;; esac
+          case ",${UNIQUE_SKILLS}," in *,aerospike-py-fastapi,*) FASTAPI_HIT="yes" ;; esac
+
+          echo "=== Step 3: Build issue title/body ==="
+          ISSUE_TITLE="[skill-followup] aerospike-py PR #${PR_NUMBER}: ${PR_TITLE}"
+
+          # Truncate PR description to first 1000 chars
+          BODY_TRUNCATED=$(printf "%s" "${PR_BODY:-_(no description)_}" | head -c 1000)
+
+          ISSUE_BODY=$(cat <<ISSUEEOF
+          ## Source PR
+          - **PR**: aerospike-py [#${PR_NUMBER}](${PR_URL})
+          - **Title**: ${PR_TITLE}
+          - **Author**: @${PR_AUTHOR}
+          - **State**: ${PR_STATE}
+
+          ## Affected skills (auto-detected)
+          - aerospike-py-api: ${API_HIT}
+          - aerospike-py-fastapi: ${FASTAPI_HIT}
+
+          ## Changed files relevant to skills/docs
+          $(echo -e "${AFFECTED_FILES}")
+
+          ## Recommended follow-up
+          - [ ] aerospike-py-api skill: SKILL.md trigger keywords / reference docs update
+          - [ ] aerospike-py-fastapi skill: reflect changed signatures / exception mapping
+          - [ ] aerospike-py docs (\`docs/docs/api/*.md\`) update
+          - [ ] Korean i18n mirror (\`docs/i18n/ko/...\`) update
+
+          ## PR description (truncated)
+          ${BODY_TRUNCATED}
+
+          ---
+          Auto-generated by aerospike-py \`.github/workflows/ace-plugins-pr-notify.yml\`
+          ISSUEEOF
+          )
+          # Strip the YAML-block leading indent (10 spaces) so markdown renders correctly
+          ISSUE_BODY=$(echo "${ISSUE_BODY}" | sed 's/^          //')
+
+          echo "=== Step 4: Idempotent upsert (search by PR marker in title) ==="
+          # Search for an existing open issue for this PR. The title-prefix marker
+          # `[skill-followup] aerospike-py PR #<num>:` is the stable idempotency key.
+          MARKER="aerospike-py PR #${PR_NUMBER}:"
+          EXISTING=$(gh search issues "in:title \"${MARKER}\"" \
+            --repo "${PLUGINS_REPO}" \
+            --state open \
+            --json number,title \
+            --limit 10 || echo "[]")
+          EXISTING_NUM=$(echo "${EXISTING}" | jq -r --arg m "${MARKER}" \
+            '.[] | select(.title | contains($m)) | .number' | head -1 || true)
+
+          if [ -n "${EXISTING_NUM}" ]; then
+            echo "Existing issue #${EXISTING_NUM} found on ${PLUGINS_REPO}. Adding update comment."
+            COMMENT_BODY=$(cat <<COMMENTEOF
+          ### Update for aerospike-py PR #${PR_NUMBER}
+
+          Triggered by event \`${{ github.event.action }}\` on ${{ github.event.pull_request.updated_at }}.
+
+          - **State**: ${PR_STATE}
+          - **Affected skills**: ${UNIQUE_SKILLS}
+
+          #### Changed files relevant to skills/docs
+          $(echo -e "${AFFECTED_FILES}")
+
+          ---
+          Auto-generated by aerospike-py \`.github/workflows/ace-plugins-pr-notify.yml\`
+          COMMENTEOF
+          )
+            COMMENT_BODY=$(echo "${COMMENT_BODY}" | sed 's/^          //')
+            gh issue comment "${EXISTING_NUM}" \
+              --repo "${PLUGINS_REPO}" \
+              --body "${COMMENT_BODY}"
+          else
+            echo "No existing issue. Creating new follow-up issue on ${PLUGINS_REPO}."
+            gh issue create \
+              --repo "${PLUGINS_REPO}" \
+              --title "${ISSUE_TITLE}" \
+              --body "${ISSUE_BODY}" \
+              --label "skill-followup" \
+              --label "aerospike-py" \
+              --label "cross-repo"
+          fi
+
+          echo "=== Done ==="


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ace-plugins-pr-notify.yml` that fires on `pull_request` events (`opened`, `reopened`, `ready_for_review`, `synchronize`) against `main`, restricted to a curated list of skill- / docs-relevant paths.
- On a hit, the workflow creates a follow-up tracking issue on `aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins`, or comments on the existing one if a previous run for the same PR already opened it (idempotent via the `aerospike-py PR #<num>:` title marker).
- Complements the existing `skill-impact-notify.yml` (push-to-main → project-hub) — the new one runs **earlier** in the PR lifecycle and targets the **plugins repo directly**.

## Why
- New aerospike-py PRs that change the public API surface (Python `__init__.pyi`, exception types, CDT/expression helpers, predicates) or the Rust client/policy layer often need parallel updates to `aerospike-py-api` / `aerospike-py-fastapi` skills and to `docs/docs/api/**` (+ Korean i18n mirror).
- Recent batch of PRs (#331, #333, #334) showed that some skill-side updates were left uncommitted; this workflow makes the follow-up explicit and tracked at the moment the PR is opened, instead of after merge.

## Trigger conditions
- Event: `pull_request` with `types: [opened, reopened, ready_for_review, synchronize]`, `branches: [main]`.
- Path filters (workflow won't fire otherwise):
  - Python: `src/aerospike_py/__init__.py(.pyi)`, `types.py`, `exception.py(.pyi)`, `list_operations.py`, `map_operations.py`, `exp.py`, `predicates.py`
  - Rust: `rust/src/lib.rs`, `errors.rs`, `constants.rs`, `policy/**`, `client.rs`, `async_client.rs`, `client_common.rs`, `client_ops.rs`
  - Docs: `docs/docs/api/**`, `docs/i18n/ko/**`

## Permissions & secrets
- Job declares `permissions: { contents: read, pull-requests: read }`.
- Cross-repo writes use the **existing** `secrets.GH_AW_GITHUB_TOKEN` PAT (already used by `skill-impact-notify.yml`). No new secret introduced.

## Issue body format example
```
## Source PR
- **PR**: aerospike-py [#331](<url>)
- **Title**: feat(scan): add ScanPolicy TypedDict
- **Author**: @KimSoungRyoul
- **State**: open

## Affected skills (auto-detected)
- aerospike-py-api: yes
- aerospike-py-fastapi: no

## Changed files relevant to skills/docs
- `src/aerospike_py/__init__.pyi` -> **aerospike-py-api** (API signatures, return types, constants)
- `rust/src/policy/scan.rs` -> **aerospike-py-api** (policy parsing)
- `docs/docs/api/scan.md` -> **aerospike-py-api** (API reference docs)

## Recommended follow-up
- [ ] aerospike-py-api skill: SKILL.md trigger keywords / reference docs update
- [ ] aerospike-py-fastapi skill: reflect changed signatures / exception mapping
- [ ] aerospike-py docs (`docs/docs/api/*.md`) update
- [ ] Korean i18n mirror (`docs/i18n/ko/...`) update
```
Title: `[skill-followup] aerospike-py PR #<num>: <title>`. Labels: `skill-followup`, `aerospike-py`, `cross-repo`.

## Idempotency
- Searches the plugins repo for an open issue whose title contains `aerospike-py PR #<num>:`.
- If found, posts a "Triggered by event …" comment instead of opening a duplicate.
- If not found, opens a new issue.

## Test plan
- [ ] Merge this PR.
- [ ] Open a follow-up PR that touches one of the listed paths (e.g., a no-op edit to `src/aerospike_py/__init__.pyi`).
- [ ] Confirm an issue lands on `aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins` with the expected title/labels/body.
- [ ] Push another commit to the same PR; confirm the workflow comments on the existing issue rather than creating a new one.
- [ ] Open a PR that touches *only* unrelated files (e.g., `tests/unit/...`); confirm the workflow is not triggered (no run appears).

## Notes / future work
- Existing `skill-impact-notify.yml` is **untouched** — kept as the merge-time signal to project-hub.
- Watch the `GH_AW_GITHUB_TOKEN` PAT expiry; rotation would block both workflows.