### PR TITLE
docs: surface follow-up policy fields and batch_apply (#319, #320, #316, #317)

### DIFF
--- a/docs/docs/api/client.md
+++ b/docs/docs/api/client.md
@@ -1006,6 +1006,70 @@ results = await client.batch_remove([
   </TabItem>
 </Tabs>
 
+### `batch_apply(keys, module, function, args=None, policy=None)`
+
+Execute a registered Lua UDF against many records in a single batch call. Same wire shape as [`apply()`](#applykey-module-function-argsnone-policynone) but amortised across the keys in one round-trip.
+
+| Parameter | Description |
+|-----------|-------------|
+| `keys` | Either a list of bare ``Key`` tuples or a list mixing bare keys and ``(key, meta)`` pairs where ``meta`` is a [`BatchUDFMeta`](types.md#batchudfmeta) flat dict. The meta may override the UDF call shape (``module`` / ``function`` / ``args``) and policy fields (``ttl`` / ``commit_level`` / ``key`` / ``durable_delete``) for a specific record. |
+| `module` | Default UDF module name to invoke when a record has no per-record ``module`` override. |
+| `function` | Default UDF function name. |
+| `args` | Optional default argument list. Per-record ``args`` in ``BatchUDFMeta`` (including ``[]`` for explicit no-args) overrides this default. |
+| `policy` | Optional dict combining a transport-level [`BatchPolicy`](types.md#batchpolicy) with batch-level [`BatchUDFPolicy`](types.md#batchudfpolicy) defaults: ``commit_level``, ``ttl``, ``key`` (send_key), ``durable_delete``, ``filter_expression``. |
+
+**Returns:** A ``BatchWriteResult`` with per-record result codes in
+    ``batch_records: list[BatchRecord]``. UDF return values are stored
+    in the per-record ``Record.bins`` map under the Lua-convention
+    ``"SUCCESS"`` key when the call succeeded.
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+# Apply the same UDF to every key in the batch.
+keys = [("test", "demo", f"u_{i}") for i in range(10)]
+results = client.batch_apply(keys, "my_udf", "increment_counter", [1])
+
+for br in results.batch_records:
+    if br.result == 0 and br.record is not None:
+        # UDF return value lives under the "SUCCESS" bin.
+        print(br.record.bins.get("SUCCESS"))
+
+# Per-record overrides: different args + longer TTL on one record.
+results = client.batch_apply(
+    [
+        ("test", "demo", "u_1"),  # uses default args
+        (("test", "demo", "u_2"), {"args": [5], "ttl": 3600}),
+    ],
+    "my_udf", "increment_counter", args=[1],
+)
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+keys = [("test", "demo", f"u_{i}") for i in range(10)]
+results = await client.batch_apply(keys, "my_udf", "increment_counter", [1])
+
+for br in results.batch_records:
+    if br.result == 0 and br.record is not None:
+        print(br.record.bins.get("SUCCESS"))
+
+# Per-record overrides: different args + longer TTL on one record.
+results = await client.batch_apply(
+    [
+        ("test", "demo", "u_1"),
+        (("test", "demo", "u_2"), {"args": [5], "ttl": 3600}),
+    ],
+    "my_udf", "increment_counter", args=[1],
+)
+```
+
+  </TabItem>
+</Tabs>
+
 ## Query & Scan
 
 ### `query(namespace, set_name)`

--- a/docs/docs/api/constants.md
+++ b/docs/docs/api/constants.md
@@ -59,6 +59,15 @@ import aerospike_py as aerospike
 | `POLICY_READ_MODE_AP_ONE` | 0 | Read from one node |
 | `POLICY_READ_MODE_AP_ALL` | 1 | Read from all nodes |
 
+### Batch Concurrency
+
+Controls how a batch request fans out across cluster nodes. Used as the ``concurrency`` key on [`BatchPolicy`](types.md#batchpolicy). Other integer values raise ``ValueError`` at parse time. (aerospike-core 2.0 has no `MaxThreads(n)` variant.)
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `BATCH_CONCURRENCY_SEQUENTIAL` | 0 | Send the per-node sub-requests one at a time. Lower peak load, higher latency. |
+| `BATCH_CONCURRENCY_PARALLEL` | 1 | Default. Send all per-node sub-requests in parallel. |
+
 ### Read Touch TTL Percent
 
 Special values for the ``read_touch_ttl_percent`` policy key (server v8+). Integers 1–100 are interpreted as a percentage; the constants below are the special-meaning sentinels.

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -178,6 +178,7 @@ Used by: `get()`, `select()`, `exists()`
 | `total_timeout` | `int` | `1000` | Total transaction timeout (ms) |
 | `max_retries` | `int` | `2` | Max retries |
 | `sleep_between_retries` | `int` | `0` | Sleep between retries (ms) |
+| `timeout_delay` | `int` | `0` | Delay (ms) before timing out a request after the deadline. Drains the socket so reused connections do not see stale responses. |
 | `filter_expression` | `Any` | | Expression filter built via `aerospike_py.exp`. |
 | `replica` | `int` | `POLICY_REPLICA_SEQUENCE` | Replica selection algorithm. |
 | `read_mode_ap` | `int` | `POLICY_READ_MODE_AP_ONE` | AP namespace read consistency. Maps to `aerospike-core` `ConsistencyLevel`. |
@@ -192,6 +193,7 @@ Used by: `put()`, `remove()`, `touch()`, `append()`, `prepend()`, `increment()`,
 | `socket_timeout` | `int` | `30000` | Socket timeout (ms) |
 | `total_timeout` | `int` | `1000` | Total transaction timeout (ms) |
 | `max_retries` | `int` | `0` | Max retries |
+| `timeout_delay` | `int` | `0` | Delay (ms) before timing out a request after the deadline. |
 | `durable_delete` | `bool` | `false` | Durable delete (Enterprise) |
 | `key` | `int` | `POLICY_KEY_DIGEST` | Key send policy |
 | `exists` | `int` | `POLICY_EXISTS_IGNORE` | Existence policy |
@@ -213,6 +215,8 @@ Used by: `batch_read()`, `batch_operate()`, `batch_write()`, `batch_remove()`
 | `socket_timeout` | `int` | `30000` | Socket timeout (ms) |
 | `total_timeout` | `int` | `1000` | Total transaction timeout (ms) |
 | `max_retries` | `int` | `2` | Max retries |
+| `timeout_delay` | `int` | `0` | Delay (ms) before timing out a request after the deadline. |
+| `concurrency` | `int` | `BATCH_CONCURRENCY_PARALLEL` | Per-node dispatch mode: `BATCH_CONCURRENCY_SEQUENTIAL` (one node at a time) or `BATCH_CONCURRENCY_PARALLEL` (all nodes in parallel — default). See [Batch Concurrency constants](constants.md#batch-concurrency). Other values raise `ValueError`. |
 | `filter_expression` | `Any` | | Expression filter |
 | `allow_inline` | `bool` | `true` | Allow server inline processing in receiving thread |
 | `allow_inline_ssd` | `bool` | `false` | Allow inline processing for SSD namespaces |
@@ -243,6 +247,7 @@ Used by: `Query.results()`, `Query.foreach()`
 | `socket_timeout` | `int` | `30000` | Socket timeout (ms) |
 | `total_timeout` | `int` | `0` | Total timeout (0 = no limit) |
 | `max_retries` | `int` | `2` | Max retries |
+| `timeout_delay` | `int` | `0` | Delay (ms) before timing out a request after the deadline. |
 | `max_records` | `int` | `0` | Max records (0 = all) |
 | `records_per_second` | `int` | `0` | Rate limit per node (0 = unlimited). |
 | `max_concurrent_nodes` | `int` | `0` | Limit parallel node queries (0 = unlimited). |
@@ -293,6 +298,51 @@ client.batch_remove([
     (("test", "demo", "user_1"), {"gen": 3}),
     ("test", "demo", "user_2"),  # bare key, no CAS
 ])
+```
+
+### `BatchUDFPolicy`
+
+Used by: batch-level UDF policy for [`batch_apply()`](client.md#batch_applykeys-module-function-argsnone-policynone). Per-record overrides go in [`BatchUDFMeta`](#batchudfmeta). Transport-level options (timeouts, retries, `concurrency`, etc.) live on [`BatchPolicy`](#batchpolicy) and are merged into the same policy dict you pass to `batch_apply()`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `commit_level` | `int` | `POLICY_COMMIT_LEVEL_ALL` | Commit level (`POLICY_COMMIT_LEVEL_ALL` / `_MASTER`). |
+| `ttl` | `int` | `0` | Record TTL in seconds (`0` = namespace default, `-1` = never expire, `-2` = don't update). |
+| `key` | `int` | `POLICY_KEY_DIGEST` | Key send policy (`POLICY_KEY_DIGEST` / `POLICY_KEY_SEND`). |
+| `durable_delete` | `bool` | `false` | Durable delete for UDFs that delete records (Enterprise 3.10+). |
+| `filter_expression` | `Any` | | Expression filter applied to each record. Records that fail the filter return `BatchRecord.result == FILTERED_OUT`. |
+
+### `BatchUDFMeta`
+
+Per-record meta for `batch_apply()`. Pass as the second element of a `(key, meta)` tuple in the `keys` argument. Single flat dict (matching [`BatchDeleteMeta`](#batchdeletemeta)) that may both override the UDF call shape and the policy fields for a specific record.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `module` | `str` | Override the UDF module name for this record. Falls back to the `module` argument of `batch_apply()`. |
+| `function` | `str` | Override the UDF function name for this record. |
+| `args` | `list[Any]` | Override the argument list. Passing `[]` explicitly clears the default args. |
+| `ttl` | `int` | Override TTL in seconds for this record (same semantics as `WriteMeta.ttl`). |
+| `commit_level` | `int` | Override commit level. |
+| `key` | `int` | Override key send policy (`POLICY_KEY_DIGEST` / `POLICY_KEY_SEND`). |
+| `durable_delete` | `bool` | Override durable_delete. |
+
+:::note
+`filter_expression` is **not** accepted in `BatchUDFMeta` — set it on the batch-level [`BatchUDFPolicy`](#batchudfpolicy) instead. (Per-record `filter_expression` is unwired in aerospike-core 2.0; matches the [`BatchDeleteMeta`](#batchdeletemeta) shape.)
+:::
+
+```python
+# Apply the same UDF to many keys.
+keys = [("test", "demo", f"u_{i}") for i in range(10)]
+results = client.batch_apply(keys, "my_udf", "increment_counter", [1])
+
+# Per-record overrides: different args / longer TTL on one record.
+results = client.batch_apply(
+    [
+        ("test", "demo", "u_1"),  # uses default args
+        (("test", "demo", "u_2"), {"args": [5], "ttl": 3600}),
+    ],
+    "my_udf", "increment_counter", args=[1],
+)
 ```
 
 ### `PartitionFilter`

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/client.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/client.md
@@ -557,6 +557,67 @@ await client.batch_remove(keys)
   </TabItem>
 </Tabs>
 
+### `batch_apply(keys, module, function, args=None, policy=None)`
+
+등록된 Lua UDF를 여러 레코드에 한 번의 배치 호출로 실행합니다. [`apply()`](#applykey-module-function-argsnone-policynone)와 동일한 와이어 형태이지만, 라운드 트립 한 번으로 키들에 분산 처리합니다.
+
+| 파라미터 | 설명 |
+|-----------|-------------|
+| `keys` | 일반 ``Key`` 튜플 리스트, 또는 일반 키와 ``(key, meta)`` 페어가 섞인 리스트. ``meta``는 [`BatchUDFMeta`](types.md#batchudfmeta) 평면 dict로, 특정 레코드에 대해 UDF 호출 형태(``module``/``function``/``args``)와 정책 필드(``ttl``/``commit_level``/``key``/``durable_delete``)를 오버라이드할 수 있습니다. |
+| `module` | 레코드 단위 ``module`` 오버라이드가 없을 때 사용할 기본 UDF 모듈명. |
+| `function` | 기본 UDF 함수명. |
+| `args` | 선택적 기본 인자 리스트. ``BatchUDFMeta``의 ``args``(빈 리스트 ``[]`` 포함)가 이 기본값을 오버라이드합니다. |
+| `policy` | 선택적 정책 dict. 전송-레벨 [`BatchPolicy`](types.md#batchpolicy)와 배치-레벨 [`BatchUDFPolicy`](types.md#batchudfpolicy) 기본값(``commit_level``, ``ttl``, ``key``, ``durable_delete``, ``filter_expression``)을 합칠 수 있습니다. |
+
+**반환값:** ``BatchWriteResult``. 레코드별 결과 코드는 ``batch_records: list[BatchRecord]``에 담깁니다. UDF 반환값은 호출이 성공한 경우 레코드의 ``Record.bins`` 맵에 Lua 컨벤션인 ``"SUCCESS"`` 키로 저장됩니다.
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+# 모든 키에 동일한 UDF 적용
+keys = [("test", "demo", f"u_{i}") for i in range(10)]
+results = client.batch_apply(keys, "my_udf", "increment_counter", [1])
+
+for br in results.batch_records:
+    if br.result == 0 and br.record is not None:
+        # UDF 반환값은 "SUCCESS" 빈에 저장됨
+        print(br.record.bins.get("SUCCESS"))
+
+# 레코드별 오버라이드: 한 레코드만 다른 args + 긴 TTL
+results = client.batch_apply(
+    [
+        ("test", "demo", "u_1"),  # 기본 args 사용
+        (("test", "demo", "u_2"), {"args": [5], "ttl": 3600}),
+    ],
+    "my_udf", "increment_counter", args=[1],
+)
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+keys = [("test", "demo", f"u_{i}") for i in range(10)]
+results = await client.batch_apply(keys, "my_udf", "increment_counter", [1])
+
+for br in results.batch_records:
+    if br.result == 0 and br.record is not None:
+        print(br.record.bins.get("SUCCESS"))
+
+# 레코드별 오버라이드: 한 레코드만 다른 args + 긴 TTL
+results = await client.batch_apply(
+    [
+        ("test", "demo", "u_1"),
+        (("test", "demo", "u_2"), {"args": [5], "ttl": 3600}),
+    ],
+    "my_udf", "increment_counter", args=[1],
+)
+```
+
+  </TabItem>
+</Tabs>
+
 ## Query
 
 ### `query(namespace, set_name)`

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/constants.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/constants.md
@@ -72,6 +72,15 @@ AP 모드에서 읽기 일관성을 제어합니다.
 | `POLICY_READ_MODE_AP_ONE` | 0 | 하나의 노드에서 읽기 |
 | `POLICY_READ_MODE_AP_ALL` | 1 | 모든 노드에서 읽기 |
 
+## Batch Concurrency
+
+배치 요청을 클러스터 노드에 분산하는 방식을 제어합니다. [`BatchPolicy`](types.md#batchpolicy)의 ``concurrency`` 키로 사용됩니다. 다른 정수값은 파싱 시점에 ``ValueError``를 발생시킵니다 (aerospike-core 2.0에는 `MaxThreads(n)` 변형이 없습니다).
+
+| Constant | Value | 설명 |
+|----------|-------|-------------|
+| `BATCH_CONCURRENCY_SEQUENTIAL` | 0 | 노드별 서브-요청을 순차적으로 전송. 피크 부하는 낮지만 지연시간이 증가. |
+| `BATCH_CONCURRENCY_PARALLEL` | 1 | 기본값. 노드별 서브-요청을 병렬 전송. |
+
 ## TTL Constants
 
 | Constant | Value | 설명 |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/types.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/types.md
@@ -225,8 +225,8 @@ client = aerospike_py.client(config).connect()
 | `total_timeout` | `int` | `1000` | 전체 트랜잭션 타임아웃 (ms) |
 | `max_retries` | `int` | `2` | 최대 재시도 횟수 |
 | `sleep_between_retries` | `int` | `0` | 재시도 간 대기 시간 (ms) |
-| `filter_expression` | `Any` | | Expression 필터 (deprecated, `expressions` 사용 권장) |
-| `expressions` | `Any` | | `aerospike_py.exp`로 빌드한 Expression 필터 |
+| `timeout_delay` | `int` | `0` | 데드라인을 지난 요청을 타임아웃 처리하기 전 대기 시간 (ms). 소켓을 비우고 재사용된 연결에서 오래된 응답을 읽지 않도록 합니다. |
+| `filter_expression` | `Any` | | `aerospike_py.exp`로 빌드한 Expression 필터 |
 | `replica` | `int` | `POLICY_REPLICA_SEQUENCE` | 레플리카 알고리즘 |
 | `read_mode_ap` | `int` | `POLICY_READ_MODE_AP_ONE` | AP 읽기 일관성 수준 |
 
@@ -249,14 +249,14 @@ record = client.get(key, policy=policy)
 | `socket_timeout` | `int` | `30000` | 소켓 유휴 타임아웃 (ms) |
 | `total_timeout` | `int` | `1000` | 전체 트랜잭션 타임아웃 (ms) |
 | `max_retries` | `int` | `0` | 최대 재시도 횟수 |
+| `timeout_delay` | `int` | `0` | 데드라인을 지난 요청을 타임아웃 처리하기 전 대기 시간 (ms). |
 | `durable_delete` | `bool` | `False` | 영구 삭제 사용 (Enterprise 전용) |
 | `key` | `int` | `POLICY_KEY_DIGEST` | 키 전송 정책 (`POLICY_KEY_DIGEST`, `POLICY_KEY_SEND`) |
 | `exists` | `int` | `POLICY_EXISTS_IGNORE` | 존재 정책 (`POLICY_EXISTS_*`) |
 | `gen` | `int` | `POLICY_GEN_IGNORE` | Generation 정책 (`POLICY_GEN_IGNORE`, `POLICY_GEN_EQ`, `POLICY_GEN_GT`) |
 | `commit_level` | `int` | `POLICY_COMMIT_LEVEL_ALL` | 커밋 수준 (`POLICY_COMMIT_LEVEL_ALL`, `POLICY_COMMIT_LEVEL_MASTER`) |
 | `ttl` | `int` | `0` | 레코드 TTL (초) |
-| `filter_expression` | `Any` | | Expression 필터 (deprecated, `expressions` 사용 권장) |
-| `expressions` | `Any` | | `aerospike_py.exp`로 빌드한 Expression 필터 |
+| `filter_expression` | `Any` | | `aerospike_py.exp`로 빌드한 Expression 필터 |
 
 ```python
 policy: WritePolicy = {
@@ -277,6 +277,8 @@ client.put(key, bins, policy=policy)
 | `socket_timeout` | `int` | `30000` | 소켓 유휴 타임아웃 (ms) |
 | `total_timeout` | `int` | `1000` | 전체 트랜잭션 타임아웃 (ms) |
 | `max_retries` | `int` | `2` | 최대 재시도 횟수 |
+| `timeout_delay` | `int` | `0` | 데드라인을 지난 요청을 타임아웃 처리하기 전 대기 시간 (ms). |
+| `concurrency` | `int` | `BATCH_CONCURRENCY_PARALLEL` | 노드별 분산 모드. `BATCH_CONCURRENCY_SEQUENTIAL`(노드 순차) 또는 `BATCH_CONCURRENCY_PARALLEL`(전체 병렬, 기본값). [Batch Concurrency 상수](constants.md#batch-concurrency) 참조. 다른 값은 `ValueError`를 발생시킵니다. |
 | `filter_expression` | `Any` | | Expression 필터 |
 
 ```python
@@ -295,14 +297,84 @@ batch = client.batch_read(keys, policy=policy)
 | `socket_timeout` | `int` | `30000` | 소켓 유휴 타임아웃 (ms) |
 | `total_timeout` | `int` | `0` | 전체 트랜잭션 타임아웃 (0 = 제한 없음) |
 | `max_retries` | `int` | `2` | 최대 재시도 횟수 |
+| `timeout_delay` | `int` | `0` | 데드라인을 지난 요청을 타임아웃 처리하기 전 대기 시간 (ms). |
 | `max_records` | `int` | `0` | 최대 반환 레코드 수 (0 = 전부) |
 | `records_per_second` | `int` | `0` | 속도 제한 (0 = 무제한) |
-| `filter_expression` | `Any` | | Expression 필터 (deprecated, `expressions` 사용 권장) |
-| `expressions` | `Any` | | `aerospike_py.exp`로 빌드한 Expression 필터 |
+| `filter_expression` | `Any` | | `aerospike_py.exp`로 빌드한 Expression 필터 |
 
 ```python
 policy: QueryPolicy = {"max_records": 100}
 records = query.results(policy=policy)
+```
+
+### `ScanPolicy`
+
+스캔 작업을 위한 정책입니다. 공식 Aerospike Python C 클라이언트의 `ScanPolicy`를 미러링합니다.
+
+`aerospike-core` 2.0 크레이트는 아직 별도의 `ScanPolicy` 구조체를 노출하지 않으므로, 현재 스캔 호출은 `QueryPolicy` 파서를 경유합니다. 향후 `aerospike-core`에 전용 `ScanPolicy`가 추가되면 사용자 측 타입 변경 없이 내부에서 새 파서로 전환됩니다. [issue #316](https://github.com/aerospike-ce-ecosystem/aerospike-py/issues/316) 참조.
+
+**사용하는 메서드**: `client.scan()` 및 predicate 없는 `client.query()`
+
+| 필드 | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `socket_timeout` | `int` | `30000` | 소켓 유휴 타임아웃 (ms) |
+| `total_timeout` | `int` | `0` | 전체 트랜잭션 타임아웃 (0 = 제한 없음) |
+| `max_retries` | `int` | `2` | 최대 재시도 횟수 |
+| `timeout_delay` | `int` | `0` | 데드라인을 지난 요청을 타임아웃 처리하기 전 대기 시간 (ms). |
+| `filter_expression` | `Any` | | `aerospike_py.exp`로 빌드한 Expression 필터 |
+| `replica` | `int` | `POLICY_REPLICA_SEQUENCE` | 레플리카 알고리즘 |
+| `read_mode_ap` | `int` | `POLICY_READ_MODE_AP_ONE` | AP 읽기 일관성 수준 |
+| `records_per_second` | `int` | `0` | 노드당 속도 제한 (0 = 무제한; 서버 4.7+) |
+| `max_records` | `int` | `0` | 최대 반환 레코드 수 근사값 (0 = 전부; 서버 6.0+) |
+| `durable_delete` | `bool` | `False` | 백그라운드 스캔-쓰기에서 영구 삭제 사용 (Enterprise 3.10+) |
+| `ttl` | `int` | `0` | 백그라운드 스캔-쓰기의 기본 TTL |
+| `partition_filter` | `PartitionFilter` | (4096개 전부) | 스캔할 파티션 부분집합. `aerospike_py.partition_filter_*()` 헬퍼로 생성. |
+
+### `BatchUDFPolicy`
+
+`batch_apply()`를 위한 배치-레벨 UDF 정책입니다. 레코드 단위 오버라이드는 [`BatchUDFMeta`](#batchudfmeta)에 둡니다. 전송-레벨 옵션(타임아웃, 재시도, `concurrency` 등)은 [`BatchPolicy`](#batchpolicy)에 위치하며, `batch_apply()`에 전달하는 동일한 정책 딕셔너리에 머지됩니다.
+
+**사용하는 메서드**: `batch_apply()`
+
+| 필드 | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `commit_level` | `int` | `POLICY_COMMIT_LEVEL_ALL` | 커밋 수준 (`POLICY_COMMIT_LEVEL_ALL` / `_MASTER`) |
+| `ttl` | `int` | `0` | 레코드 TTL (초). `0` = 네임스페이스 기본, `-1` = 만료 안 함, `-2` = 업데이트 안 함 |
+| `key` | `int` | `POLICY_KEY_DIGEST` | 키 전송 정책 (`POLICY_KEY_DIGEST` / `POLICY_KEY_SEND`) |
+| `durable_delete` | `bool` | `False` | UDF가 레코드를 삭제할 때 영구 삭제 (Enterprise 3.10+) |
+| `filter_expression` | `Any` | | 각 레코드에 적용되는 Expression 필터. 필터에 걸린 레코드는 `BatchRecord.result == FILTERED_OUT`을 반환합니다. |
+
+### `BatchUDFMeta`
+
+`batch_apply()`의 레코드 단위 메타입니다. `keys` 인자에서 `(key, meta)` 튜플의 두 번째 요소로 전달합니다. `BatchDeleteMeta`와 동일한 단일 평면 dict 형태이며, UDF 호출 형태와 정책 필드를 동시에 오버라이드할 수 있습니다.
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `module` | `str` | 이 레코드의 UDF 모듈명 오버라이드. 미지정 시 `batch_apply()`의 `module` 인자 사용. |
+| `function` | `str` | 이 레코드의 UDF 함수명 오버라이드. |
+| `args` | `list[Any]` | 인자 리스트 오버라이드. `[]`을 명시적으로 전달하면 기본 args를 비웁니다. |
+| `ttl` | `int` | 이 레코드의 TTL 오버라이드 (초; `WriteMeta.ttl`과 동일 시맨틱). |
+| `commit_level` | `int` | 커밋 수준 오버라이드. |
+| `key` | `int` | 키 전송 정책 오버라이드 (`POLICY_KEY_DIGEST` / `POLICY_KEY_SEND`). |
+| `durable_delete` | `bool` | 영구 삭제 오버라이드. |
+
+:::note
+`filter_expression`은 `BatchUDFMeta`에서 받지 않습니다 — 배치-레벨 [`BatchUDFPolicy`](#batchudfpolicy)에서 설정하세요. (aerospike-core 2.0에서 레코드 단위 `filter_expression`은 와이어링되지 않으며, `BatchDeleteMeta`와 같은 형태입니다.)
+:::
+
+```python
+# 모든 키에 동일한 UDF 적용
+keys = [("test", "demo", f"u_{i}") for i in range(10)]
+results = client.batch_apply(keys, "my_udf", "increment_counter", [1])
+
+# 레코드별 오버라이드: 한 레코드만 다른 args/긴 TTL
+results = client.batch_apply(
+    [
+        ("test", "demo", "u_1"),  # 기본 args 사용
+        (("test", "demo", "u_2"), {"args": [5], "ttl": 3600}),
+    ],
+    "my_udf", "increment_counter", args=[1],
+)
 ```
 
 ### `AdminPolicy`

--- a/scripts/generate-api-docs.py
+++ b/scripts/generate-api-docs.py
@@ -342,7 +342,10 @@ CLIENT_METHOD_SECTIONS = [
     ("CRUD Operations", ["put", "get", "select", "exists", "remove", "touch"]),
     ("String / Numeric Operations", ["append", "prepend", "increment", "remove_bin"]),
     ("Multi-Operation", ["operate", "operate_ordered"]),
-    ("Batch Operations", ["batch_read", "batch_write", "batch_write_numpy", "batch_operate", "batch_remove"]),
+    (
+        "Batch Operations",
+        ["batch_read", "batch_write", "batch_write_numpy", "batch_operate", "batch_remove", "batch_apply"],
+    ),
     ("Query & Scan", ["query", "scan"]),
     ("Index Management", ["index_integer_create", "index_string_create", "index_geo2dsphere_create", "index_remove"]),
     ("Truncate", ["truncate"]),


### PR DESCRIPTION
## Summary

Closes the docs gap for the four in-flight feature PRs (#332/#331/#333/#334), in the same spirit as #321 covered the previous policy surface batch. **This PR is intended to merge AFTER the four feature PRs** — once those land, the EN auto-generator (driven by \`__init__.pyi\` docstrings) and these manual sections converge.

- \`timeout_delay\` field is now documented on every request-path policy table (Read / Write / Batch / Query — and ScanPolicy already had it from #333).
- \`concurrency\` field is now documented on \`BatchPolicy\`, with the new \`BATCH_CONCURRENCY_SEQUENTIAL\` / \`BATCH_CONCURRENCY_PARALLEL\` constants getting their own \`Constants\` subsection.
- New \`BatchUDFPolicy\` / \`BatchUDFMeta\` types and the \`batch_apply()\` method are surfaced on \`types.md\` and \`client.md\` respectively.
- The Korean i18n mirror — which had drifted significantly from EN — now carries all of the above plus a brand-new \`ScanPolicy\` section that #333 added to EN only.

## Changes

**EN** (\`docs/docs/api/\`):
- \`types.md\`: \`timeout_delay\` rows on ReadPolicy / WritePolicy / BatchPolicy / QueryPolicy. \`concurrency\` row on BatchPolicy. New \`### BatchUDFPolicy\` and \`### BatchUDFMeta\` sections (per-record meta deliberately omits \`filter_expression\` — matches the unwired-field fix in #334).
- \`constants.md\`: new \`### Batch Concurrency\` subsection.
- \`client.md\`: new \`### batch_apply()\` section with sync+async tabs. Also restores the sync/async tabs around \`batch_remove\` that the prebuild regenerator strips when async-side examples are unset (carries forward #322's hand-edit).
- \`scripts/generate-api-docs.py\`: register \`batch_apply\` in \`CLIENT_METHOD_SECTIONS\` so that once #334 lands, prebuild emits the section automatically.

**KO i18n** (\`docs/i18n/ko/docusaurus-plugin-content-docs/current/api/\`):
- \`types.md\`: mirror of EN above + drops the deprecated \`expressions\` alias rows that upstream #311 removed long ago + brand-new \`### ScanPolicy\` section (KO was missing it entirely; #333 added EN only).
- \`constants.md\`: mirror of \`Batch Concurrency\`.
- \`client.md\`: mirror of \`### batch_apply()\` with sync+async tabs.

## Why a follow-up PR

Following the pattern set by #321 (and its post-merge fix-up #322): docs land in a separate, focused PR after the corresponding code PRs merge. This keeps each feature PR small and lets the docs PR cover the full surface in one place — including the i18n mirror that the feature PRs typically don't touch.

## Test plan

- [x] \`make docs-build\` passes locally for both \`en\` and \`ko\` locales (Docusaurus 3.9.2).
- [x] One non-fatal \`[WARNING] broken anchor\` on the EN build: \`types.md → client.md#batch_applykeys-...\`. Root cause: the prebuild step (\`scripts/generate-api-docs.py\`) regenerates \`client.md\` from \`__init__.pyi\`, and main's \`.pyi\` does not yet have \`batch_apply\` — so prebuild strips the manual section during local builds. **This warning auto-resolves once #334 merges** and the \`.pyi\` carries the \`batch_apply\` docstring. Docusaurus is configured \`onBrokenAnchors: 'warn'\` (not \`throw\`), so the build stays green either way.
- [x] KO build is fully clean — no warnings, no broken anchors. (Earlier draft had a broken \`#batchdeletemeta\` link from \`BatchUDFMeta\` because KO's \`types.md\` does not yet have a \`BatchDeleteMeta\` section; rewrote those references as plain text.)

## Depends on

- #331 (\`feat/batch-concurrency\`) — \`BatchPolicy.concurrency\` + \`BATCH_CONCURRENCY_*\` constants
- #332 (\`feat/policy-timeout-delay\`) — \`BasePolicy.timeout_delay\` across read/write/batch/query
- #333 (\`feat/scan-policy-typeddict\`) — \`ScanPolicy\` TypedDict
- #334 (\`feat/batch-apply\`) — \`batch_apply()\` method + \`BatchUDFPolicy\` / \`BatchUDFMeta\`

Merge order: #331/#332/#333/#334 → this PR.