### PR TITLE
feat(exp): expose REGEX_* flag constants and document PK regex scan

### DIFF
--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -269,6 +269,14 @@ pub fn register_constants(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("HLL_WRITE_NO_FAIL", 4)?;
     m.add("HLL_WRITE_ALLOW_FOLD", 8)?;
 
+    // --- Regex Flags (for exp.regex_compare) ---
+    // Mirrors aerospike_core::expressions::regex_flag::RegexFlag (POSIX regex.h values).
+    m.add("REGEX_NONE", 0)?;
+    m.add("REGEX_EXTENDED", 1)?;
+    m.add("REGEX_ICASE", 2)?;
+    m.add("REGEX_NOSUB", 4)?;
+    m.add("REGEX_NEWLINE", 8)?;
+
     // --- Privilege codes ---
     m.add("PRIV_READ", 10)?;
     m.add("PRIV_WRITE", 13)?;

--- a/src/aerospike_py/__init__.py
+++ b/src/aerospike_py/__init__.py
@@ -170,6 +170,12 @@ from aerospike_py._aerospike import (  # noqa: F401
     HLL_WRITE_UPDATE_ONLY,
     HLL_WRITE_NO_FAIL,
     HLL_WRITE_ALLOW_FOLD,
+    # Regex Flags
+    REGEX_NONE,
+    REGEX_EXTENDED,
+    REGEX_ICASE,
+    REGEX_NOSUB,
+    REGEX_NEWLINE,
     # Privilege codes
     PRIV_READ,
     PRIV_WRITE,
@@ -550,6 +556,12 @@ __all__ = [
     "HLL_WRITE_UPDATE_ONLY",
     "HLL_WRITE_NO_FAIL",
     "HLL_WRITE_ALLOW_FOLD",
+    # Regex Flags
+    "REGEX_NONE",
+    "REGEX_EXTENDED",
+    "REGEX_ICASE",
+    "REGEX_NOSUB",
+    "REGEX_NEWLINE",
     # Privilege codes
     "PRIV_READ",
     "PRIV_WRITE",

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -2629,6 +2629,13 @@ HLL_WRITE_UPDATE_ONLY: int
 HLL_WRITE_NO_FAIL: int
 HLL_WRITE_ALLOW_FOLD: int
 
+# Regex Flags (for exp.regex_compare)
+REGEX_NONE: int
+REGEX_EXTENDED: int
+REGEX_ICASE: int
+REGEX_NOSUB: int
+REGEX_NEWLINE: int
+
 # Privilege Codes
 PRIV_READ: int
 PRIV_WRITE: int

--- a/src/aerospike_py/exp.py
+++ b/src/aerospike_py/exp.py
@@ -16,6 +16,25 @@ Usage example::
     # Pass to policy
     policy = {"filter_expression": expr}
     client.get(key, policy=policy)
+
+PK regex filter scan (server-side filtering on the user key)::
+
+    from aerospike_py import exp, REGEX_NONE, POLICY_KEY_SEND
+
+    # Write with sendKey=true so the user key is stored on the record.
+    client.put(("test", "users", "aaa001"), {"v": 1},
+               policy={"key": POLICY_KEY_SEND})
+
+    # Match all records whose PK starts with "aaa".
+    expr = exp.regex_compare("^aaa.*", REGEX_NONE,
+                             exp.key(exp.EXP_TYPE_STRING))
+    records = client.query("test", "users").results(
+        policy={"filter_expression": expr})
+
+This is a full set scan with server-side filtering — it does not use a primary
+index (Aerospike's primary index keys on the digest, not the user key string).
+Records written without ``POLICY_KEY_SEND`` will not match. Avoid on hot paths;
+prefer a separate prefix bin with a secondary index for production lookups.
 """
 
 from typing import Any
@@ -517,7 +536,12 @@ def int_rscan(value: Expr, search: Expr) -> Expr:
 
 
 def regex_compare(regex: str, flags: int, bin_expr: Expr) -> Expr:
-    """Create regex string comparison expression."""
+    """Create regex string comparison expression.
+
+    ``flags`` is a bitwise OR of ``REGEX_*`` constants exposed at the package
+    level: ``REGEX_NONE``, ``REGEX_EXTENDED``, ``REGEX_ICASE``, ``REGEX_NOSUB``,
+    ``REGEX_NEWLINE``. The values mirror POSIX ``regex.h`` flags.
+    """
     return _cmd("regex_compare", regex=regex, flags=flags, bin=bin_expr)
 
 

--- a/tests/integration/test_expressions.py
+++ b/tests/integration/test_expressions.py
@@ -244,3 +244,63 @@ class TestExpressionMetadata:
         )
         _, _, bins = client.get(key, policy={"filter_expression": expr})
         assert bins["age"] == 25
+
+
+class TestPkRegexFilterScan:
+    """PK regex filter scan via exp.regex_compare(..., exp.key(EXP_TYPE_STRING)).
+
+    Equivalent to Java client's
+    ``Exp.regexCompare(pattern, RegexFlag.NONE, Exp.key(Exp.Type.STRING))``.
+    Performs a full set scan with server-side filtering on the user key — does
+    not use a primary index. Records must be written with POLICY_KEY_SEND.
+    """
+
+    SET = "expr_pk_regex"
+
+    def _seed(self, client, cleanup, user_keys, *, send_key):
+        policy = {"key": aerospike_py.POLICY_KEY_SEND} if send_key else None
+        for uk in user_keys:
+            key = ("test", self.SET, uk)
+            cleanup.append(key)
+            client.put(key, {"v": uk}, policy=policy)
+
+    def test_pk_regex_filter_scan(self, client, cleanup):
+        """^aaa.* matches only records whose user key starts with 'aaa'."""
+        self._seed(client, cleanup, ["aaa001", "aaa002", "bbb001"], send_key=True)
+
+        expr = exp.regex_compare(
+            "^aaa.*",
+            aerospike_py.REGEX_NONE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        results = client.query("test", self.SET).results(policy={"filter_expression": expr})
+
+        matched = sorted(r.key.user_key for r in results if r.key is not None)
+        assert matched == ["aaa001", "aaa002"]
+
+    def test_pk_regex_filter_scan_no_send_key(self, client, cleanup):
+        """Records without POLICY_KEY_SEND have no stored user key — no match."""
+        self._seed(client, cleanup, ["aaa001", "aaa002"], send_key=False)
+
+        expr = exp.regex_compare(
+            "^aaa.*",
+            aerospike_py.REGEX_NONE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        results = client.query("test", self.SET).results(policy={"filter_expression": expr})
+
+        assert results == []
+
+    def test_pk_regex_filter_scan_icase(self, client, cleanup):
+        """REGEX_ICASE matches user keys regardless of case."""
+        self._seed(client, cleanup, ["AAA001", "aaa002", "bbb001"], send_key=True)
+
+        expr = exp.regex_compare(
+            "^aaa.*",
+            aerospike_py.REGEX_ICASE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        results = client.query("test", self.SET).results(policy={"filter_expression": expr})
+
+        matched = sorted(r.key.user_key for r in results if r.key is not None)
+        assert matched == ["AAA001", "aaa002"]

--- a/tests/integration/test_expressions.py
+++ b/tests/integration/test_expressions.py
@@ -1,5 +1,7 @@
 """Integration tests for expression filters (requires Aerospike server)."""
 
+import uuid
+
 import pytest
 
 import aerospike_py
@@ -255,12 +257,16 @@ class TestPkRegexFilterScan:
     not use a primary index. Records must be written with POLICY_KEY_SEND.
     """
 
-    SET = "expr_pk_regex"
+    @pytest.fixture(autouse=True)
+    def _isolated_set(self):
+        # Unique set per test invocation so stragglers from a previously
+        # interrupted run cannot contaminate empty-result assertions.
+        self.set_name = f"expr_pk_regex_{uuid.uuid4().hex[:12]}"
 
     def _seed(self, client, cleanup, user_keys, *, send_key):
         policy = {"key": aerospike_py.POLICY_KEY_SEND} if send_key else None
         for uk in user_keys:
-            key = ("test", self.SET, uk)
+            key = ("test", self.set_name, uk)
             cleanup.append(key)
             client.put(key, {"v": uk}, policy=policy)
 
@@ -273,13 +279,19 @@ class TestPkRegexFilterScan:
             aerospike_py.REGEX_NONE,
             exp.key(exp.EXP_TYPE_STRING),
         )
-        results = client.query("test", self.SET).results(policy={"filter_expression": expr})
+        results = client.query("test", self.set_name).results(policy={"filter_expression": expr})
 
         matched = sorted(r.key.user_key for r in results if r.key is not None)
         assert matched == ["aaa001", "aaa002"]
 
     def test_pk_regex_filter_scan_no_send_key(self, client, cleanup):
-        """Records without POLICY_KEY_SEND have no stored user key — no match."""
+        """Records without POLICY_KEY_SEND have no stored user key — no match.
+
+        The empty result confirms that records in the set were *evaluated* by
+        the filter and rejected (because they lack a stored user key), not
+        that the scan failed. Compare with test_pk_regex_filter_scan_no_match,
+        where records are stored with sendKey but the pattern excludes them.
+        """
         self._seed(client, cleanup, ["aaa001", "aaa002"], send_key=False)
 
         expr = exp.regex_compare(
@@ -287,7 +299,20 @@ class TestPkRegexFilterScan:
             aerospike_py.REGEX_NONE,
             exp.key(exp.EXP_TYPE_STRING),
         )
-        results = client.query("test", self.SET).results(policy={"filter_expression": expr})
+        results = client.query("test", self.set_name).results(policy={"filter_expression": expr})
+
+        assert results == []
+
+    def test_pk_regex_filter_scan_no_match(self, client, cleanup):
+        """Pattern that matches nothing returns an empty list (filter ran)."""
+        self._seed(client, cleanup, ["aaa001", "bbb001"], send_key=True)
+
+        expr = exp.regex_compare(
+            "^zzz.*",
+            aerospike_py.REGEX_NONE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        results = client.query("test", self.set_name).results(policy={"filter_expression": expr})
 
         assert results == []
 
@@ -300,7 +325,7 @@ class TestPkRegexFilterScan:
             aerospike_py.REGEX_ICASE,
             exp.key(exp.EXP_TYPE_STRING),
         )
-        results = client.query("test", self.SET).results(policy={"filter_expression": expr})
+        results = client.query("test", self.set_name).results(policy={"filter_expression": expr})
 
         matched = sorted(r.key.user_key for r in results if r.key is not None)
         assert matched == ["AAA001", "aaa002"]


### PR DESCRIPTION
## Summary

- Expose `REGEX_NONE/EXTENDED/ICASE/NOSUB/NEWLINE` as named constants on the package, mirroring `aerospike_core::expressions::regex_flag::RegexFlag` (POSIX regex.h values). Eliminates magic integers like `0` / `2` at `exp.regex_compare` call sites and brings parity with the Java client's `RegexFlag.*` API.
- Document the **PK regex filter scan** pattern in `exp.py` — `exp.regex_compare(pattern, REGEX_*, exp.key(EXP_TYPE_STRING))` with `POLICY_KEY_SEND` on writes — and the operational caveat that this is a full set scan + server-side filter, not a primary-index lookup (Aerospike's primary index keys on the digest, not the user key string).
- Add integration tests covering prefix match, missing-sendKey (no match), no-match pattern, and ICASE.

No new builder API or Query method is introduced — the feature is already supported end-to-end by `exp.regex_compare` + `exp.key()` + `QueryPolicy.filter_expression`. This PR is **discoverability + named constants + tests + docs**.

## Changes

| File | Change |
|---|---|
| `rust/src/constants.rs` | Register `REGEX_NONE/EXTENDED/ICASE/NOSUB/NEWLINE` (values 0/1/2/4/8) |
| `src/aerospike_py/__init__.py` | Import + `__all__` |
| `src/aerospike_py/__init__.pyi` | Stubs |
| `src/aerospike_py/exp.py` | Module docstring example + `regex_compare` docstring referencing the new constants |
| `tests/integration/test_expressions.py` | New `TestPkRegexFilterScan` class (4 cases, uuid-isolated set names) |

## Equivalent to Java client

```java
QueryPolicy policy = new QueryPolicy();
policy.filterExp = Exp.build(
    Exp.regexCompare("^aaa.*", RegexFlag.NONE, Exp.key(Exp.Type.STRING))
);
client.query(policy, stmt);
```

```python
from aerospike_py import exp, REGEX_NONE, POLICY_KEY_SEND

client.put(("test", "users", "aaa001"), {"v": 1},
           policy={"key": POLICY_KEY_SEND})

expr = exp.regex_compare("^aaa.*", REGEX_NONE, exp.key(exp.EXP_TYPE_STRING))
records = client.query("test", "users").results(
    policy={"filter_expression": expr})
```

## Test plan

- [x] `make build` — Rust compiles cleanly with new constants
- [x] `make validate` — fmt + lint + typecheck + 863 unit tests pass
- [x] Manual smoke: `aerospike_py.REGEX_NONE..NEWLINE` resolve to `0/1/2/4/8`; `exp.regex_compare(..., exp.key(EXP_TYPE_STRING))` produces the expected expression dict
- [ ] `make test-integration` against local Aerospike CE — runs `TestPkRegexFilterScan` (prefix / no-sendKey / no-match / icase). Verified against the same fixture pattern as existing `TestExpressionMetadata::test_key_exists_filter`; needs reviewer verification with a server attached.

## Operational caveats (also documented in `exp.py`)

- **Not a PK index scan**: full set scan + server-side filter. Aerospike's primary index is on the digest, not the user key string. Avoid for hot-path prefix lookups; prefer a separate prefix bin + secondary index, or a lookup-set model.
- **`POLICY_KEY_SEND` required at write time**: records written without it have no stored user key and never match a `key()` expression.

## Cross-repo

- A companion issue tracking the Cluster Manager UI exposure is open at aerospike-ce-ecosystem/aerospike-cluster-manager#287.
- The `aerospike-py-api` skill in `aerospike-ce-ecosystem-plugins` will be updated in a separate PR.
