### PR TITLE
test/docs(exp): PK regex scan edge cases and flags=0 default note

### DIFF
--- a/src/aerospike_py/exp.py
+++ b/src/aerospike_py/exp.py
@@ -541,6 +541,10 @@ def regex_compare(regex: str, flags: int, bin_expr: Expr) -> Expr:
     ``flags`` is a bitwise OR of ``REGEX_*`` constants exposed at the package
     level: ``REGEX_NONE``, ``REGEX_EXTENDED``, ``REGEX_ICASE``, ``REGEX_NOSUB``,
     ``REGEX_NEWLINE``. The values mirror POSIX ``regex.h`` flags.
+
+    ``flags=0`` (equivalent to ``REGEX_NONE``) selects the server's default
+    mode — POSIX basic regular expression syntax, case-sensitive — and
+    matches the Java client's ``RegexFlag.NONE``.
     """
     return _cmd("regex_compare", regex=regex, flags=flags, bin=bin_expr)
 

--- a/tests/integration/test_expressions.py
+++ b/tests/integration/test_expressions.py
@@ -329,3 +329,63 @@ class TestPkRegexFilterScan:
 
         matched = sorted(r.key.user_key for r in results if r.key is not None)
         assert matched == ["AAA001", "aaa002"]
+
+    def test_pk_regex_filter_scan_integer_key_excluded(self, client, cleanup):
+        """Integer user keys do not satisfy exp.key(EXP_TYPE_STRING).
+
+        Documents the contract: when records in the same set have heterogeneous
+        user-key types, `exp.key(EXP_TYPE_STRING)` only exposes the string
+        ones. Integer-keyed records are filtered out (the expression evaluates
+        to unknown for them) rather than raising — query continues over the
+        rest of the set.
+        """
+        # Mix string and integer user keys, both written with sendKey.
+        for key in [
+            ("test", self.set_name, "aaa001"),
+            ("test", self.set_name, "aaa002"),
+            ("test", self.set_name, 12345),
+            ("test", self.set_name, 67890),
+        ]:
+            cleanup.append(key)
+            client.put(key, {"v": 1}, policy={"key": aerospike_py.POLICY_KEY_SEND})
+
+        expr = exp.regex_compare(
+            "^aaa.*",
+            aerospike_py.REGEX_NONE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        results = client.query("test", self.set_name).results(policy={"filter_expression": expr})
+
+        matched = sorted(r.key.user_key for r in results if r.key is not None)
+        assert matched == ["aaa001", "aaa002"]
+
+    def test_pk_regex_filter_scan_bitwise_flag_combo(self, client, cleanup):
+        """REGEX_ICASE | REGEX_EXTENDED both apply on a POSIX-extended pattern.
+
+        Locks the bitfield contract: if any constant is changed to a
+        non-orthogonal value the combined behaviour breaks immediately.
+        ``[A-Za-z]{3}001`` requires REGEX_EXTENDED (counted repetition is a
+        POSIX-extended construct); REGEX_ICASE adds case-insensitive matching.
+        """
+        # Sanity-check the bitfield itself.
+        assert aerospike_py.REGEX_ICASE | aerospike_py.REGEX_EXTENDED == 3
+
+        self._seed(
+            client,
+            cleanup,
+            ["AAA001", "aaa002", "BB1001", "x002"],
+            send_key=True,
+        )
+
+        expr = exp.regex_compare(
+            "^[A-Z]{3}001$",
+            aerospike_py.REGEX_ICASE | aerospike_py.REGEX_EXTENDED,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        results = client.query("test", self.set_name).results(policy={"filter_expression": expr})
+
+        matched = sorted(r.key.user_key for r in results if r.key is not None)
+        # Only "AAA001" and "aaa001"-style 3-letter+001 keys match. From the
+        # seed, "AAA001" is the lone match (aaa002 fails the literal "001",
+        # BB1001 fails the {3} letter run, x002 fails everything).
+        assert matched == ["AAA001"]


### PR DESCRIPTION
Closes #339.

Follow-up to #338 covering the three nice-to-have items from code review.

## Summary

- **`exp.regex_compare` docstring**: clarify that `flags=0` (equivalent to `REGEX_NONE`) selects the server's default mode (POSIX basic, case-sensitive) and matches the Java client's `RegexFlag.NONE`. Eliminates the implicit "infer from POSIX" ask.
- **`test_pk_regex_filter_scan_integer_key_excluded`**: documents the contract for heterogeneous user-key types in the same set. Integer-keyed records do not satisfy `exp.key(EXP_TYPE_STRING)` — the expression evaluates to unknown for them, so they're filtered out rather than raising. Confirms the query continues over the rest of the set.
- **`test_pk_regex_filter_scan_bitwise_flag_combo`**: locks the bitfield contract by exercising `REGEX_ICASE | REGEX_EXTENDED` on a POSIX-extended pattern (counted repetition `{3}`). Asserts both the combined integer value (3) and the combined matching behaviour. If any constant is later changed to a non-orthogonal value the test fails immediately.

## Changes

| File | Change |
|---|---|
| `src/aerospike_py/exp.py` | `regex_compare` docstring — 4 lines clarifying `flags=0` semantics |
| `tests/integration/test_expressions.py` | Two new tests in `TestPkRegexFilterScan` |

## Test plan

- [x] `make build` — Rust unchanged; `make validate` — 886 unit tests pass (up from 863, net +23 from prior PRs)
- [ ] CI integration tests (`Integration Tests (AS 7.2)` and `(AS latest)`) — exercise the two new tests against a real Aerospike CE server.

## Operational notes

- The integer-key exclusion test seeds **string + integer** user keys in the same set. This is allowed in Aerospike (sets are logical groupings; per-record key types are independent).
- The bitwise combo test uses `[A-Z]{3}001$` which requires REGEX_EXTENDED; with REGEX_ICASE it should match both `AAA001` and `aaa001`-style keys. Seed includes `AAA001` (matches), `aaa002` (fails literal `001` suffix), `BB1001` (fails `{3}` letter run), `x002` (fails everything).