### PR TITLE
ci(workflows): idempotently ensure tracking labels exist before issue create

### DIFF
--- a/.github/workflows/ace-plugins-pr-notify.yml
+++ b/.github/workflows/ace-plugins-pr-notify.yml
@@ -212,6 +212,20 @@ jobs:
               --body "${COMMENT_BODY}"
           else
             echo "No existing issue. Creating new follow-up issue on ${PLUGINS_REPO}."
+            # Idempotently ensure required labels exist on the target repo
+            # before creating the issue. `gh issue create --label X` fails
+            # the whole workflow if a label is missing, so a manual delete
+            # in the target repo would otherwise break this notifier.
+            ensure_label() {
+              gh label create "$1" \
+                --repo "${PLUGINS_REPO}" \
+                --description "$2" \
+                --color "$3" 2>/dev/null || true
+            }
+            ensure_label "skill-followup" "Skill-affecting follow-up tracking from upstream repo PRs" "FBCA04"
+            ensure_label "aerospike-py"   "Originated from aerospike-py repo"                          "2B67C6"
+            ensure_label "cross-repo"     "Tracks impact across multiple repos"                        "5319E7"
+
             gh issue create \
               --repo "${PLUGINS_REPO}" \
               --title "${ISSUE_TITLE}" \

--- a/.github/workflows/skill-impact-notify.yml
+++ b/.github/workflows/skill-impact-notify.yml
@@ -114,6 +114,19 @@ jobs:
           ISSUEEOF
           )
 
+          # Idempotently ensure required labels exist on the target repo
+          # before creating the issue. `gh issue create --label X` fails
+          # the whole workflow if a label is missing, so a manual delete
+          # in the target repo would otherwise break this notifier.
+          ensure_label() {
+            gh label create "$1" \
+              --repo "${HUB_REPO}" \
+              --description "$2" \
+              --color "$3" 2>/dev/null || true
+          }
+          ensure_label "skill-impact-review" "Skill impact review — Hub Planner analyzes upstream diff" "D93F0B"
+          ensure_label "cross-repo"          "Tracks impact across multiple repos"                       "5319E7"
+
           gh issue create \
             --repo "${HUB_REPO}" \
             --title "[Skill Impact] ${SOURCE_REPO}: ${COMMIT_TITLE}" \


### PR DESCRIPTION
## Summary

Both cross-repo tracking workflows fail the whole job when a target-repo label is missing, because `gh issue create --label X` errors out. A manual label delete (or a never-created label in a fresh target repo) silently breaks the notifier — which happened twice today:

- `skill-followup` missing on plugins repo → `ace-plugins-pr-notify` failed on PR #338 (fixed mid-session by hand-creating the labels).
- `skill-impact-review` missing on project-hub → `skill-impact-notify` silently failed on every push to main this session and going back to 2026-05-01.

This PR adds a small `ensure_label` shell helper (`gh label create ... || true`) called for each required label immediately before `gh issue create`. The behaviour is:

| Pre-state | Post-state |
|---|---|
| Label exists | No-op (`gh label create` errors with "already exists", suppressed) |
| Label missing | Created with the documented description + color |
| Label deleted later | Recreated on next workflow run |

No semantic change when labels are present.

## Files

| File | Change |
|---|---|
| `.github/workflows/ace-plugins-pr-notify.yml` | Add `ensure_label` for `skill-followup`, `aerospike-py`, `cross-repo` on plugins repo |
| `.github/workflows/skill-impact-notify.yml` | Add `ensure_label` for `skill-impact-review`, `cross-repo` on project-hub |

## Test plan

- [x] YAML syntax validated locally (`yaml.safe_load`)
- [ ] After merge, push to main triggers `skill-impact-notify` — should succeed even if a label is later deleted from project-hub
- [ ] Future PR touching skill-impacting files triggers `ace-plugins-pr-notify` — should succeed even with missing labels

## Background

The token (`secrets.GH_AW_GITHUB_TOKEN`) already has cross-repo write access (it currently creates issues there), so it can create labels too. No permissions change needed.

## Cross-repo

- Today's failed runs `25311763390` (#338 merge) and `25312264886` (#340 merge) were re-run successfully after manually creating `skill-impact-review` on project-hub. With this PR merged, future runs are self-healing and that manual step won't be needed.
- Three older failed runs (`25206780019`, `25206709764`, `25206699219` — 2026-05-01) are still in the failure history. They were caused by the same missing label and would now pass on rerun. Not addressed here; reviewer can clean up at their discretion.