### PR TITLE
fix(ci): exclude docs:freeze commits from daily-release change detection

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -24,20 +24,22 @@ jobs:
         id: changes
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # Exclude auto docs-freeze commits (pushed by docs-version.yaml after each
+          # release) so they don't self-trigger an empty release the next day.
           if [ -z "$LATEST_TAG" ]; then
             echo "No previous release found. Checking all commits."
-            COMMIT_COUNT=$(git rev-list --count HEAD)
+            COMMIT_COUNT=$(git log HEAD --pretty=tformat:"%s" | grep -vcE '^docs: freeze version ' || true)
           else
-            COMMIT_COUNT=$(git rev-list --count "${LATEST_TAG}..HEAD")
+            COMMIT_COUNT=$(git log "${LATEST_TAG}..HEAD" --pretty=tformat:"%s" | grep -vcE '^docs: freeze version ' || true)
           fi
           echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
           echo "commit_count=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
           if [ "$COMMIT_COUNT" -eq 0 ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No changes since ${LATEST_TAG}. Skipping release."
+            echo "No release-worthy changes since ${LATEST_TAG}. Skipping release."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "${COMMIT_COUNT} commits since ${LATEST_TAG}."
+            echo "${COMMIT_COUNT} release-worthy commits since ${LATEST_TAG}."
           fi
 
       - name: Determine next version


### PR DESCRIPTION
## 문제

`docs-version.yaml`은 release published 시 `docs: freeze version X.Y.Z` 커밋을 main에 직접 push합니다. 그런데 `daily-release.yml`은 마지막 tag 이후의 commit 수만 검사하므로, 그 freeze 커밋 1개만 있어도 다음 날 새 release를 만듭니다. 새 release가 또 freeze 커밋을 push하고, 그게 또 다음날 release를 트리거하는 자기참조 루프입니다.

실제로 최근 5개 0.10.x release 중 4개가 코드 변경 없이 만들어졌습니다.

| 구간 | 실제 커밋 |
|------|-----------|
| v0.10.0 → v0.10.1 | `docs: freeze version 0.10.0` (1건) |
| v0.10.1 → v0.10.2 | `docs: freeze version 0.10.1` (1건) |
| v0.10.2 → v0.10.3 | `refactor(ci) #342` + `docs: freeze 0.10.2` (2건, 의미 있음) |
| v0.10.3 → v0.10.4 | `docs: freeze version 0.10.3` (1건) |
| v0.10.4 → v0.10.5 | `docs: freeze version 0.10.4` (1건) |

## 해결

`Check for changes since last release` 단계에서 `^docs: freeze version ` 패턴 commit을 카운트에서 제외합니다. release-worthy 한 commit이 0이면 skip합니다.

부수적으로 `--pretty=format:` → `tformat:`로 변경했습니다. `format:`은 마지막 줄에 newline을 붙이지 않아 `grep -c`가 마지막 줄을 누락합니다 (검증 중에 발견).

## 검증

기존 release 구간으로 새 로직을 검증했습니다.

| 구간 | 결과 | 기대 |
|------|------|------|
| v0.10.4..v0.10.5 | 0 (skip) | 빈 release 차단 |
| v0.10.2..v0.10.3 | 1 (release) | #342만 카운트 |
| v0.10.0..v0.10.1 | 0 (skip) | 빈 release 차단 |
| v0.10.5..HEAD | 0 (skip) | 오늘 시점 무한 루프 차단 |
| v0.9.2..v0.10.0 | 5 (release) | 정상 release |

## 대안

- `github-actions[bot]` author 전체 제외 — dependabot 등 정상 bot 트리거까지 차단되어 채택 안 함
- docs freeze를 main에 push하지 않는 구조 변경 — docs publish 파이프라인 재설계 필요, 본 fix 범위 밖