### PR TITLE
fix(ci): release only when release-worthy paths change

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -24,13 +24,16 @@ jobs:
         id: changes
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          # Exclude auto docs-freeze commits (pushed by docs-version.yaml after each
-          # release) so they don't self-trigger an empty release the next day.
+          # Only commits that touch user-facing library code or package metadata count
+          # toward a release. CI workflows, docs, tests, examples, build configs, etc.
+          # don't change what gets shipped to PyPI and so don't warrant a new release —
+          # this also implicitly excludes the auto `docs: freeze version` commits.
+          RELEASE_PATHS=(rust/ src/ pyproject.toml Cargo.toml Cargo.lock uv.lock)
           if [ -z "$LATEST_TAG" ]; then
             echo "No previous release found. Checking all commits."
-            COMMIT_COUNT=$(git log HEAD --pretty=tformat:"%s" | grep -vcE '^docs: freeze version ' || true)
+            COMMIT_COUNT=$(git log HEAD --pretty=tformat:"%H" -- "${RELEASE_PATHS[@]}" | wc -l | tr -d ' ')
           else
-            COMMIT_COUNT=$(git log "${LATEST_TAG}..HEAD" --pretty=tformat:"%s" | grep -vcE '^docs: freeze version ' || true)
+            COMMIT_COUNT=$(git log "${LATEST_TAG}..HEAD" --pretty=tformat:"%H" -- "${RELEASE_PATHS[@]}" | wc -l | tr -d ' ')
           fi
           echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
           echo "commit_count=${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
@@ -59,8 +62,10 @@ jobs:
           # daily-release auto-bumps minor (feat) or patch only.
           # Major bump is manual: a maintainer tags the new major version themselves.
           # `feat!:` / `BREAKING CHANGE` markers surface in release notes, not in version.
-          COMMITS=$(git log "${LATEST_TAG}..HEAD" --pretty=format:"%s")
-          HAS_FEAT=$(echo "$COMMITS" | grep -cE '^feat(\(.+\))?!?:' || true)
+          # Only feat commits that touch release-worthy paths trigger a minor bump —
+          # `feat(ci):` or `feat(docs):` shouldn't bump the public version.
+          RELEASE_PATHS=(rust/ src/ pyproject.toml Cargo.toml Cargo.lock uv.lock)
+          HAS_FEAT=$(git log "${LATEST_TAG}..HEAD" --pretty=tformat:"%s" -- "${RELEASE_PATHS[@]}" | grep -cE '^feat(\(.+\))?!?:' || true)
 
           if [ "$HAS_FEAT" -gt 0 ]; then
             MINOR=$((MINOR + 1))


### PR DESCRIPTION
## 배경

PR #343는 `docs: freeze version` 자기참조 루프만 막았습니다. 그러나 daily-release는 여전히 main에 어떤 종류의 커밋이든 1개라도 있으면 release를 만듭니다. 즉:

- CI 워크플로우만 변경 (`.github/workflows/...`)
- README/POSTMORTEM 같은 문서 수정 (`*.md`)
- 테스트 추가 (`tests/...`)
- Makefile, pre-commit config 등 빌드 설정

이런 변경은 **PyPI에 실제 ship되지 않는** 것들인데도 patch release가 생성되어 사용자의 `pip install --upgrade` 시점에 새 버전이 잡힙니다. 사용자가 보기엔 의미 없는 release.

## 해결

commit message가 아니라 **변경된 파일 path 기반**으로 release-worthy 여부를 판단합니다. PyPI에 실제로 ship되는 path만 allowlist에 넣습니다.

```bash
RELEASE_PATHS=(rust/ src/ pyproject.toml Cargo.toml Cargo.lock uv.lock)
```

| Path | 이유 |
|------|------|
| `rust/` | Rust core (PyO3 native module) |
| `src/` | Python wrapper, type stubs, public API |
| `pyproject.toml` | package metadata, build config |
| `Cargo.toml` | Rust deps |
| `Cargo.lock`, `uv.lock` | dep lock 변경 (deps update PR도 release 가치 있음) |

allowlist에 없는 path 변경(`.github/`, `docs/`, `tests/`, `examples/`, `benchmark/`, `scripts/`, `Makefile`, `*.md`, 각종 dotfile)은 release를 트리거하지 않습니다.

`Determine next version` 단계의 `feat` 카운트도 같은 allowlist를 적용합니다. `feat(ci):` 또는 `feat(docs):` 같은 커밋만 있을 때 잘못된 minor bump가 되는 걸 방지합니다.

`docs: freeze version` 패턴 매칭은 제거했습니다. 그 커밋들은 `docs/`만 변경하므로 path allowlist에 의해 자동 제외됩니다.

## 검증

| 구간 | 결과 | 기대 |
|------|------|------|
| v0.9.2..v0.10.0 | 2 commits, 1 feat → minor bump | 실제 v0.10.0 = minor bump ✓ |
| v0.10.0..v0.10.1 | 0 (skip) | 빈 release 차단 ✓ |
| v0.10.1..v0.10.2 | 0 (skip) | 빈 release 차단 ✓ |
| v0.10.2..v0.10.3 | 0 (skip) | #342는 ci 변경 → release-worthy 아님 ✓ |
| v0.10.3..v0.10.4 | 0 (skip) | 빈 release 차단 ✓ |
| v0.10.4..v0.10.5 | 0 (skip) | 빈 release 차단 ✓ |
| v0.10.5..HEAD | 0 (skip) | 오늘 시점 차단 ✓ |

v0.10.2..v0.10.3 케이스(`refactor(ci): daily-release ...`)는 이전 PR #343에서는 1로 카운트되어 release를 트리거했지만, 이제는 0으로 정정됩니다.

## Allowlist 유지보수

릴리스되는 코드 path가 추가되면 (예: 새 SDK 모듈 디렉토리) `RELEASE_PATHS`에 추가해야 합니다. 단, aerospike-py는 monorepo가 아니라 단일 라이브러리이므로 변동 가능성은 낮습니다.