### PR TITLE
perf(batch): cache repeated namespace/set extractions in py_to_keys

### DIFF
--- a/rust/src/types/key.rs
+++ b/rust/src/types/key.rs
@@ -36,58 +36,7 @@ pub fn py_to_key(key_tuple: &Bound<'_, PyAny>) -> PyResult<Key> {
     let set_name: String = tuple.get_item(1)?.cast::<PyString>()?.to_str()?.to_owned();
     let key_item = tuple.get_item(2)?;
 
-    // For bytes keys, compute digest with STRING particle type (3) to match
-    // the official Python C client behavior for cross-client compatibility.
-    // Check this before py_to_value() to avoid a redundant Vec<u8> allocation.
-    if let Ok(b) = key_item.cast::<PyBytes>() {
-        let bytes_data = b.as_bytes();
-
-        // Handle 4-element tuple with explicit digest
-        if tuple.len() == 4 && !tuple.get_item(3)?.is_none() {
-            let digest_bytes: Vec<u8> = tuple.get_item(3)?.extract()?;
-            if digest_bytes.len() == 20 {
-                let mut digest = [0u8; 20];
-                digest.copy_from_slice(&digest_bytes);
-                return Ok(Key {
-                    namespace,
-                    set_name,
-                    user_key: Some(Value::Blob(bytes_data.to_vec())),
-                    digest,
-                });
-            }
-        }
-
-        let digest = compute_bytes_key_digest(&set_name, bytes_data);
-        return Ok(Key {
-            namespace,
-            set_name,
-            user_key: Some(Value::Blob(bytes_data.to_vec())),
-            digest,
-        });
-    }
-
-    let user_key = py_to_value(&key_item)?;
-
-    // Handle 4-element tuple with explicit digest
-    if tuple.len() == 4 && !tuple.get_item(3)?.is_none() {
-        let digest_bytes: Vec<u8> = tuple.get_item(3)?.extract()?;
-        if digest_bytes.len() == 20 {
-            let mut digest = [0u8; 20];
-            digest.copy_from_slice(&digest_bytes);
-            return Ok(Key {
-                namespace,
-                set_name,
-                user_key: match &user_key {
-                    Value::Nil => None,
-                    _ => Some(user_key),
-                },
-                digest,
-            });
-        }
-    }
-
-    Key::new(namespace, set_name, user_key)
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid key: {e}")))
+    build_key(namespace, set_name, &key_item, &tuple)
 }
 
 /// Convert Rust Key to Python tuple (namespace, set, key, digest)
@@ -113,8 +62,125 @@ pub fn key_to_py(py: Python<'_>, key: &Key) -> PyResult<Py<PyAny>> {
 }
 
 /// Convert a Python list of key tuples to a `Vec<Key>`.
+///
+/// Fast path for batches whose keys share `(namespace, set)`: caches the
+/// most recently seen Python string objects by pointer identity. When the
+/// next key's namespace or set is the same Python object as the previous
+/// one (the typical case — callers usually pass interned set names), the
+/// `PyString` cast and UTF-8 validation runs once and subsequent keys
+/// reuse the cached `String` via `clone()` instead.
+///
+/// `aerospike_core::Key` requires owned `String` fields so we still pay
+/// one allocation per key, but skip the PyString round-trip.
 pub fn py_to_keys(keys: &Bound<'_, PyList>) -> PyResult<Vec<Key>> {
-    keys.iter().map(|k| py_to_key(&k)).collect()
+    let mut last_ns: Option<(*const pyo3::ffi::PyObject, String)> = None;
+    let mut last_set: Option<(*const pyo3::ffi::PyObject, String)> = None;
+    keys.iter()
+        .map(|k| py_to_key_with_cache(&k, &mut last_ns, &mut last_set))
+        .collect()
+}
+
+/// Single-key conversion with caller-provided `(ns, set)` caches.
+///
+/// Each cache slot tracks the Python pointer of the most recently extracted
+/// `PyString` plus its owned `String`. A cache hit (pointer match) clones
+/// the cached `String`; a miss falls back to a full PyString extraction
+/// and overwrites the slot.
+fn py_to_key_with_cache(
+    key_tuple: &Bound<'_, PyAny>,
+    last_ns: &mut Option<(*const pyo3::ffi::PyObject, String)>,
+    last_set: &mut Option<(*const pyo3::ffi::PyObject, String)>,
+) -> PyResult<Key> {
+    let tuple = key_tuple.cast::<PyTuple>()?;
+    if tuple.len() < 3 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Key tuple must have at least 3 elements: (namespace, set, key)",
+        ));
+    }
+
+    let ns_item = tuple.get_item(0)?;
+    let namespace = extract_cached_str(&ns_item, last_ns)?;
+    let set_item = tuple.get_item(1)?;
+    let set_name = extract_cached_str(&set_item, last_set)?;
+    let key_item = tuple.get_item(2)?;
+
+    build_key(namespace, set_name, &key_item, &tuple)
+}
+
+/// Resolve a `PyString` to an owned `String`, reusing the cached value
+/// when the input is the same Python object as the previous extraction.
+fn extract_cached_str(
+    item: &Bound<'_, PyAny>,
+    last: &mut Option<(*const pyo3::ffi::PyObject, String)>,
+) -> PyResult<String> {
+    let ptr = item.as_ptr() as *const _;
+    if let Some((cached_ptr, cached_str)) = last.as_ref() {
+        if *cached_ptr == ptr {
+            return Ok(cached_str.clone());
+        }
+    }
+    let owned = item.cast::<PyString>()?.to_str()?.to_owned();
+    *last = Some((ptr, owned.clone()));
+    Ok(owned)
+}
+
+/// Common key construction shared between `py_to_key` and the cached path.
+/// Handles bytes keys (digest computed with STRING particle type for C
+/// client compatibility), explicit 4-element digest tuples, and the
+/// fallback `Key::new` path for typed user keys.
+fn build_key(
+    namespace: String,
+    set_name: String,
+    key_item: &Bound<'_, PyAny>,
+    tuple: &Bound<'_, PyTuple>,
+) -> PyResult<Key> {
+    if let Ok(b) = key_item.cast::<PyBytes>() {
+        let bytes_data = b.as_bytes();
+
+        if tuple.len() == 4 && !tuple.get_item(3)?.is_none() {
+            let digest_bytes: Vec<u8> = tuple.get_item(3)?.extract()?;
+            if digest_bytes.len() == 20 {
+                let mut digest = [0u8; 20];
+                digest.copy_from_slice(&digest_bytes);
+                return Ok(Key {
+                    namespace,
+                    set_name,
+                    user_key: Some(Value::Blob(bytes_data.to_vec())),
+                    digest,
+                });
+            }
+        }
+
+        let digest = compute_bytes_key_digest(&set_name, bytes_data);
+        return Ok(Key {
+            namespace,
+            set_name,
+            user_key: Some(Value::Blob(bytes_data.to_vec())),
+            digest,
+        });
+    }
+
+    let user_key = py_to_value(key_item)?;
+
+    if tuple.len() == 4 && !tuple.get_item(3)?.is_none() {
+        let digest_bytes: Vec<u8> = tuple.get_item(3)?.extract()?;
+        if digest_bytes.len() == 20 {
+            let mut digest = [0u8; 20];
+            digest.copy_from_slice(&digest_bytes);
+            return Ok(Key {
+                namespace,
+                set_name,
+                user_key: match &user_key {
+                    Value::Nil => None,
+                    _ => Some(user_key),
+                },
+                digest,
+            });
+        }
+    }
+
+    Key::new(namespace, set_name, user_key)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid key: {e}")))
 }
 
 #[cfg(test)]
@@ -149,6 +215,87 @@ mod tests {
                 0xcc, 0x6a, 0xfd, 0xba, 0xef, 0x4d,
             ]
         );
+    }
+
+    /// `py_to_keys` caches `(ns, set)` Python strings by pointer identity
+    /// — verify that passing the same Python `str` for `ns` across many
+    /// tuples produces correctly-extracted `Key`s without divergence.
+    #[test]
+    fn test_py_to_keys_caches_repeated_ns_set() {
+        Python::initialize();
+        Python::attach(|py| {
+            // Use a single interned Python string for `ns` shared across all
+            // tuples — exercises the pointer-identity cache hit path.
+            let ns = pyo3::types::PyString::new(py, "test");
+            let set_a = pyo3::types::PyString::new(py, "set_a");
+            let keys: Vec<Bound<'_, pyo3::types::PyAny>> = (0..5)
+                .map(|i| {
+                    PyTuple::new(
+                        py,
+                        [
+                            ns.as_any().clone(),
+                            set_a.as_any().clone(),
+                            pyo3::types::PyString::new(py, &format!("k{i}"))
+                                .as_any()
+                                .clone(),
+                        ],
+                    )
+                    .unwrap()
+                    .into_any()
+                })
+                .collect();
+            let list = PyList::new(py, &keys).unwrap();
+
+            let result = py_to_keys(&list).unwrap();
+            assert_eq!(result.len(), 5);
+            for (i, k) in result.iter().enumerate() {
+                assert_eq!(k.namespace, "test");
+                assert_eq!(k.set_name, "set_a");
+                let expected_key = format!("k{i}");
+                match &k.user_key {
+                    Some(Value::String(s)) => assert_eq!(s, &expected_key),
+                    other => panic!("unexpected user_key: {other:?}"),
+                }
+            }
+        });
+    }
+
+    /// Cache must invalidate when the `ns` Python object changes between
+    /// keys — verify that mixing two namespaces in one batch produces
+    /// the correct `Key.namespace` for each entry.
+    #[test]
+    fn test_py_to_keys_cache_invalidates_on_change() {
+        Python::initialize();
+        Python::attach(|py| {
+            let ns_a = pyo3::types::PyString::new(py, "ns_a");
+            let ns_b = pyo3::types::PyString::new(py, "ns_b");
+            let set = pyo3::types::PyString::new(py, "set");
+            let keys: Vec<Bound<'_, pyo3::types::PyAny>> = (0..4)
+                .map(|i| {
+                    let ns = if i % 2 == 0 { &ns_a } else { &ns_b };
+                    PyTuple::new(
+                        py,
+                        [
+                            ns.as_any().clone(),
+                            set.as_any().clone(),
+                            pyo3::types::PyString::new(py, &format!("k{i}"))
+                                .as_any()
+                                .clone(),
+                        ],
+                    )
+                    .unwrap()
+                    .into_any()
+                })
+                .collect();
+            let list = PyList::new(py, &keys).unwrap();
+
+            let result = py_to_keys(&list).unwrap();
+            assert_eq!(result.len(), 4);
+            assert_eq!(result[0].namespace, "ns_a");
+            assert_eq!(result[1].namespace, "ns_b");
+            assert_eq!(result[2].namespace, "ns_a");
+            assert_eq!(result[3].namespace, "ns_b");
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Addresses **D. PyO3 args extraction — String interning for ns/set** from issue #347's analysis of `prepare_batch_read_args` hot-path overhead.

For batches whose keys share the same `(namespace, set)` (the typical case — e.g. 9 FV × 80 keys → 6,480 PyString extractions per request), `py_to_keys` previously re-extracted the namespace and set from Python on every iteration even though every result was identical.

This PR adds a tiny pointer-identity cache: `py_to_keys` tracks the most recently seen Python string objects for `ns` and `set` and reuses the previously-extracted `String` via `clone()` when the next key tuple references the same Python object.

## Changes

- `rust/src/types/key.rs`
  - New `py_to_keys` body with inline `(*PyObject, String)` cache for `ns`/`set`
  - New `extract_cached_str` helper applying the cache; `py_to_key_with_cache` orchestrates per-key work
  - Refactor: extract post-(ns, set) construction into `build_key` shared by single-key (`py_to_key`) and cached paths — removes duplication

## Constraints respected

- `aerospike_core::Key` still requires owned `String`, so we keep one allocation per key. The optimization avoids the PyString round-trip (cast + UTF-8 validation + `to_owned`), not the final clone into the `Key` struct.
- `py_to_key` (single-key call sites) signature unchanged; this affects only batch ops via `py_to_keys` (called from `prepare_batch_read_args` and `prepare_batch_operate_args`).

## Test plan

- [x] `cargo test --lib types::key::` — 5 tests pass (3 existing + 2 new)
  - `test_py_to_keys_caches_repeated_ns_set` — verifies cache hit produces correct extraction when same `PyString` reused across keys
  - `test_py_to_keys_cache_invalidates_on_change` — verifies cache miss path handles mixed namespaces in one batch
- [x] `make test-unit` — 886 pass, 8 skipped (Aerospike server-dependent, expected)
- [x] `make test-integration -k batch_read` — 18 passed against local Aerospike CE 8.1
- [x] `make build` (release) — clean
- [ ] CI: full test matrix

## Out of scope

Issue #347 also suggests option D.1 — a `batch_read_with_ns(ns, set, user_keys)` API variant that skips per-key tuple unpacking entirely. That would be additive (a new public API) and is left for a separate PR.

🤖 Authored with [Claude Code](https://claude.com/claude-code)