### PR TITLE
perf(metrics): add `production` Cargo feature to compile out stage_timer

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,3 +38,12 @@ otel = [
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
 ]
+# `production` strips the `db_client_internal_stage_seconds` stage-profiling
+# instrumentation at compile time. The default build keeps the runtime
+# `AEROSPIKE_PY_INTERNAL_METRICS` toggle (atomic load + branch on every hot
+# path), so most users should stick with default. Build with
+# `--features production` only when you've finished diagnosing perf issues
+# and want to reclaim the per-stage overhead (≈11 atomic loads per
+# batch_read call when profiling is OFF, plus an Instant::now() roundtrip
+# per stage when ON).
+production = []

--- a/rust/src/metrics.rs
+++ b/rust/src/metrics.rs
@@ -49,6 +49,18 @@ pub fn set_internal_stage_enabled(enabled: bool) {
 }
 
 /// Check if internal stage profiling is currently enabled. Hot path.
+///
+/// Compile-time short-circuited to `false` when the `production` Cargo
+/// feature is on, allowing LLVM to dead-code-eliminate the entire stage
+/// timer branch from hot paths.
+#[cfg(feature = "production")]
+#[inline(always)]
+pub fn is_internal_stage_enabled() -> bool {
+    false
+}
+
+/// Check if internal stage profiling is currently enabled. Hot path.
+#[cfg(not(feature = "production"))]
 #[inline]
 pub fn is_internal_stage_enabled() -> bool {
     INTERNAL_STAGE_ENABLED.load(Ordering::Relaxed)
@@ -243,6 +255,18 @@ pub fn record_internal_stage_unchecked(stage: &'static str, op_name: &str, durat
 /// the start of a cross-boundary timing window (one that can't be wrapped in
 /// a single `stage_timer!` block, e.g. timestamps that travel through `async`
 /// boundaries or struct fields).
+///
+/// Compile-time short-circuited to `None` when the `production` Cargo feature
+/// is on — call sites that do `if let Some(t) = maybe_now() { ... }` are
+/// then dead-code-eliminated entirely.
+#[cfg(feature = "production")]
+#[inline(always)]
+pub fn maybe_now() -> Option<Instant> {
+    None
+}
+
+/// Capture `Instant::now()` only when internal stage profiling is enabled.
+#[cfg(not(feature = "production"))]
 #[inline]
 pub fn maybe_now() -> Option<Instant> {
     if is_internal_stage_enabled() {
@@ -283,11 +307,25 @@ pub fn get_text() -> String {
 /// Works with both sync and `async` expressions — use inside an `async` block
 /// as `stage_timer!("io", "batch_read", { foo.await? })`.
 ///
+/// Compile-time strip: build with `--features production` and the macro
+/// expands to `$body` directly — no atomic load, no `Instant::now()`, no
+/// histogram observation. Pair with `cargo expand` if you want to verify
+/// the elimination.
+///
 /// ```ignore
 /// stage_timer!("key_parse", "batch_read", {
 ///     parse_keys(py, keys)?
 /// })
 /// ```
+#[cfg(feature = "production")]
+#[macro_export]
+macro_rules! stage_timer {
+    ($stage:expr, $op:expr, $body:expr) => {{
+        $body
+    }};
+}
+
+#[cfg(not(feature = "production"))]
 #[macro_export]
 macro_rules! stage_timer {
     ($stage:expr, $op:expr, $body:expr) => {{


### PR DESCRIPTION
## Summary

Addresses **E. Production tracing dead-code-elimination** from issue #347's analysis.

The internal stage profiling pipeline (`stage_timer!`, `maybe_now()`, `is_internal_stage_enabled()`) currently runs an atomic load on every invocation. Across one `batch_read` call that fires ~11 times (one per `db_client_internal_stage_seconds` stage). When profiling is ON each fire additionally pays an `Instant::now()` roundtrip and a Prometheus histogram observation.

This PR adds a `production` Cargo feature that compile-strips the instrumentation entirely, leaving the macro as a direct passthrough of `$body`.

## Changes

- `rust/Cargo.toml`: declare new `production` feature (opt-in, off by default)
- `rust/src/metrics.rs`:
  - `is_internal_stage_enabled()` — returns `false` always under `production`, allowing LLVM to dead-code-eliminate every stage_timer branch
  - `maybe_now()` — returns `None` always under `production`; call sites pattern-matching `Option<Instant>` are then DCE'd
  - `stage_timer!` macro — split into two `#[cfg]`-gated definitions; production version expands to `$body` directly

## Default behavior unchanged

PyPI wheels keep the runtime `AEROSPIKE_PY_INTERNAL_METRICS` toggle — single atomic load per stage when profiling is OFF. The `production` feature is intended for users who build from source and have finished diagnosing perf issues.

## Test plan

- [x] `cargo check` — clean, both with and without `--features production`
- [x] `cargo test --lib` — 159 tests pass, both feature configs
- [x] `make test-unit` — 894 pass, 8 skipped (server-dependent)
- [x] `make build` (default) — clean
- [x] `maturin develop --release --features production` — clean wheel
- [x] `make test-integration -k batch` — 46/46 pass under production build
- [ ] CI: full test matrix

🤖 Authored with [Claude Code](https://claude.com/claude-code)