### PR TITLE
feat(runtime): add AEROSPIKE_RUNTIME_MODE env to opt into current_thread

### DIFF
--- a/rust/src/runtime.rs
+++ b/rust/src/runtime.rs
@@ -47,6 +47,56 @@ fn configured_workers() -> usize {
     }
 }
 
+/// Tokio runtime flavor selectable via `AEROSPIKE_RUNTIME_MODE`.
+#[derive(Clone, Copy)]
+enum RuntimeMode {
+    /// Default — `tokio::runtime::Builder::new_multi_thread()` with
+    /// `AEROSPIKE_RUNTIME_WORKERS` worker threads. Backward-compatible
+    /// behavior; work-stealing pool suited to single-process deployments.
+    MultiThread,
+    /// `tokio::runtime::Builder::new_current_thread()` — single-threaded,
+    /// no work-stealing. Suitable for multi-process servers (uvicorn,
+    /// gunicorn) where each Python worker process runs its own Tokio
+    /// runtime and the parallelism comes from process count, not threads.
+    /// Eliminates work-stealing/sync overhead at the cost of removing
+    /// background thread-level concurrency inside the runtime.
+    CurrentThread,
+}
+
+/// Read the runtime mode from `AEROSPIKE_RUNTIME_MODE` env var.
+/// Accepts `multi_thread` (default) or `current_thread` (case-insensitive,
+/// underscores or dashes accepted).
+fn configured_mode() -> RuntimeMode {
+    match std::env::var("AEROSPIKE_RUNTIME_MODE")
+        .ok()
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase().replace('-', "_"))
+        .as_deref()
+    {
+        Some("current_thread") => RuntimeMode::CurrentThread,
+        Some("multi_thread") | None => RuntimeMode::MultiThread,
+        Some(other) => {
+            warn!(
+                "AEROSPIKE_RUNTIME_MODE={other:?} not recognized; falling back to multi_thread \
+                 (valid: multi_thread, current_thread)"
+            );
+            RuntimeMode::MultiThread
+        }
+    }
+}
+
+/// Build a Tokio runtime builder honoring the configured mode + worker count.
+fn make_builder(mode: RuntimeMode, workers: usize) -> tokio::runtime::Builder {
+    match mode {
+        RuntimeMode::MultiThread => {
+            let mut b = tokio::runtime::Builder::new_multi_thread();
+            b.worker_threads(workers);
+            b
+        }
+        RuntimeMode::CurrentThread => tokio::runtime::Builder::new_current_thread(),
+    }
+}
+
 /// Global multi-threaded Tokio runtime shared across all sync client operations.
 ///
 /// Defaults to 2 worker threads (configurable via `AEROSPIKE_RUNTIME_WORKERS` env var).
@@ -58,11 +108,16 @@ fn configured_workers() -> usize {
 /// Uses `enable_io()` + `enable_time()` instead of `enable_all()` to avoid the
 /// signal driver, which can conflict with Python's own signal handling.
 pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    let mode = configured_mode();
     let workers = configured_workers();
 
-    info!("Initializing sync Tokio runtime with {} workers", workers);
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(workers)
+    let mode_name = match mode {
+        RuntimeMode::MultiThread => "multi_thread",
+        RuntimeMode::CurrentThread => "current_thread",
+    };
+    info!("Initializing sync Tokio runtime ({mode_name}, workers={workers})");
+
+    make_builder(mode, workers)
         .enable_io()
         .enable_time()
         .build()
@@ -74,13 +129,15 @@ pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
             panic!(
                 "aerospike-py: failed to create Tokio runtime: {e}\n\
                  \n\
+                 Mode              : {mode_name}\n\
                  Requested workers : {workers}\n\
-                 Env var           : AEROSPIKE_RUNTIME_WORKERS\n\
+                 Env vars          : AEROSPIKE_RUNTIME_MODE, AEROSPIKE_RUNTIME_WORKERS\n\
                  \n\
                  Troubleshooting:\n\
                  1. Reduce workers — export AEROSPIKE_RUNTIME_WORKERS=1\n\
-                 2. Check thread limits — ulimit -u  (nproc)\n\
-                 3. On Linux containers, verify /proc/sys/kernel/threads-max\n\
+                 2. Try single-thread mode — export AEROSPIKE_RUNTIME_MODE=current_thread\n\
+                 3. Check thread limits — ulimit -u  (nproc)\n\
+                 4. On Linux containers, verify /proc/sys/kernel/threads-max\n\
                  \n\
                  This panic is intentional: LazyLock<Runtime> cannot propagate \
                  errors, and a missing Tokio runtime is unrecoverable."
@@ -98,12 +155,16 @@ pub static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
 /// call `Python::attach()` after I/O completion.  Limiting workers to 2 (or
 /// the value of `AEROSPIKE_RUNTIME_WORKERS`) dramatically reduces contention.
 pub fn init_async_runtime() {
+    let mode = configured_mode();
     let workers = configured_workers();
+    let mode_name = match mode {
+        RuntimeMode::MultiThread => "multi_thread",
+        RuntimeMode::CurrentThread => "current_thread",
+    };
     info!(
-        "Configuring async (pyo3-async-runtimes) Tokio runtime with {} workers",
-        workers
+        "Configuring async (pyo3-async-runtimes) Tokio runtime ({mode_name}, workers={workers})"
     );
-    let mut builder = tokio::runtime::Builder::new_multi_thread();
-    builder.worker_threads(workers).enable_all();
+    let mut builder = make_builder(mode, workers);
+    builder.enable_all();
     pyo3_async_runtimes::tokio::init(builder);
 }


### PR DESCRIPTION
## Summary

Addresses **G. `current_thread` Tokio runtime** from issue #347's analysis.

For deployment shapes where the host process already supplies parallelism — uvicorn / gunicorn / Bento workers, one Tokio runtime per Python process — the multi-thread runtime's work-stealing scheduler is pure overhead. Each process has just a couple of worker threads contending for the same GIL anyway, and work-stealing adds atomic/sync cost on every task pickup.

Add `AEROSPIKE_RUNTIME_MODE` env var that switches both the sync `RUNTIME` static and the async `pyo3-async-runtimes::tokio::init()` between `Builder::new_multi_thread()` (default, unchanged) and `Builder::new_current_thread()` (single-threaded, no work-stealing/sync).

## Changes

`rust/src/runtime.rs`:
- `RuntimeMode` enum + `configured_mode()` reads `AEROSPIKE_RUNTIME_MODE` (accepts `multi_thread` / `current_thread`, case-insensitive, `-` or `_` separators)
- `make_builder(mode, workers)` returns a configured `tokio::runtime::Builder`
- `RUNTIME` and `init_async_runtime()` both go through `make_builder`
- Worker count `AEROSPIKE_RUNTIME_WORKERS` is ignored when mode=current_thread (the flavor has no worker pool)
- Unknown env values fall back to `multi_thread` with a warn-level log

## Verified upstream

`pyo3_async_runtimes::tokio::init(builder: Builder)` accepts the bare `tokio::runtime::Builder`, so `Builder::new_current_thread()` is supported without any patches. Tokio Cargo feature `rt-multi-thread` (already declared) is a superset of `rt`, so current_thread compiles cleanly.

## Test plan

- [x] `cargo check` — clean
- [x] `make test-unit` — 894 pass, 8 skipped (server-dependent)
- [x] `make test-integration -k batch` under **default** (multi_thread) — 46/46 pass
- [x] `make test-integration -k batch` under **`AEROSPIKE_RUNTIME_MODE=current_thread`** — 46/46 pass
- [ ] CI: full test matrix

## When to use which

| Deployment shape | Recommended |
|---|---|
| Single Python process (script, notebook) | `multi_thread` (default) |
| Multi-process server (uvicorn `--workers N`, gunicorn) | `current_thread` |
| Mixed async/sync inside one process | `multi_thread` |

🤖 Authored with [Claude Code](https://claude.com/claude-code)