### PR TITLE
feat(batch): add batch_read_many for single-roundtrip multi-group reads

### DIFF
--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -33,7 +33,7 @@ enum CloseOutcome {
     },
 }
 
-use crate::batch_types::{PendingBatchRead, PendingBatchRecords};
+use crate::batch_types::{PendingBatchRead, PendingBatchReadMany, PendingBatchRecords};
 use crate::errors::as_to_pyerr;
 use crate::panic_safety::future_into_py_panic_safe;
 use crate::policy::admin_policy::{parse_privileges, role_to_py, user_to_py};
@@ -778,6 +778,67 @@ impl PyAsyncClient {
                         io_complete_at,
                     })
                 }
+            })
+        })
+    }
+
+    /// Read multiple groups of records in a single merged batch call (async).
+    ///
+    /// Compared to `asyncio.gather(*[client.batch_read(...) for _ in groups])`,
+    /// this issues exactly one Tokio task, one limiter acquisition, one
+    /// `client.batch()` network round-trip (Aerospike's native batch protocol
+    /// supports mixed-set keys), and one GIL hand-off — regardless of how
+    /// many groups are passed.
+    ///
+    /// Returns a `list[BatchReadHandle]` of the same length as `groups`,
+    /// preserving input order. Each handle behaves identically to the one
+    /// returned by `batch_read` (same `as_dict()` / `batch_records` API).
+    #[pyo3(signature = (groups, bins=None, policy=None))]
+    fn batch_read_many<'py>(
+        &self,
+        py: Python<'py>,
+        groups: &Bound<'_, PyList>,
+        bins: Option<Vec<String>>,
+        policy: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        debug!("async batch_read_many: groups_count={}", groups.len());
+
+        let client = self.get_client()?;
+        let limiter = self.limiter.clone();
+        let args = crate::stage_timer!("key_parse", "batch_read_many", {
+            client_common::prepare_batch_read_many_args(
+                py,
+                groups,
+                &bins,
+                policy,
+                &self.connection_info,
+            )?
+        });
+
+        let spawned_at = crate::metrics::maybe_now();
+        crate::stage_timer!("future_into_py_setup", "batch_read_many", {
+            future_into_py_panic_safe(py, "AsyncClient.batch_read_many", async move {
+                if let Some(t) = spawned_at {
+                    crate::metrics::record_internal_stage_unchecked(
+                        "tokio_schedule_delay",
+                        "batch_read_many",
+                        t.elapsed().as_secs_f64(),
+                    );
+                }
+
+                let _permit = crate::stage_timer!("limiter_wait", "batch_read_many", {
+                    limiter.acquire_named("batch_read_many").await?
+                });
+
+                let groups = crate::stage_timer!("io", "batch_read_many", {
+                    client_ops::do_batch_read_many(&client, &args).await?
+                });
+
+                let io_complete_at = crate::metrics::maybe_now();
+                Ok(PendingBatchReadMany {
+                    groups,
+                    io_complete_at,
+                })
             })
         })
     }

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -184,6 +184,50 @@ impl<'py> IntoPyObject<'py> for PendingBatchRead {
     }
 }
 
+/// Future result of `AsyncClient.batch_read_many`. Carries one
+/// `Vec<BatchRecord>` per input group; gets wrapped into a Python `list` of
+/// `BatchReadHandle` on `into_pyobject`. Single GIL hand-off serves N groups.
+pub struct PendingBatchReadMany {
+    pub groups: Vec<Vec<BatchRecord>>,
+    /// Timestamp when Rust async I/O completed — populated only when
+    /// internal stage profiling is enabled.
+    pub io_complete_at: Option<std::time::Instant>,
+}
+
+impl<'py> IntoPyObject<'py> for PendingBatchReadMany {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        if let Some(t) = self.io_complete_at {
+            crate::metrics::record_internal_stage_unchecked(
+                "spawn_blocking_delay",
+                "batch_read_many",
+                t.elapsed().as_secs_f64(),
+            );
+        }
+        let into_pyobject_at = crate::metrics::maybe_now();
+        crate::stage_timer!("into_pyobject", "batch_read_many", {
+            let handles: Vec<Py<PyBatchReadHandle>> = self
+                .groups
+                .into_iter()
+                .map(|results| {
+                    Py::new(
+                        py,
+                        PyBatchReadHandle {
+                            inner: Arc::new(results),
+                            into_pyobject_at,
+                        },
+                    )
+                })
+                .collect::<PyResult<Vec<_>>>()?;
+            let list = pyo3::types::PyList::new(py, handles)?;
+            Ok(list.into_any())
+        })
+    }
+}
+
 // ── PyBatchReadHandle ────────────────────────────────────────────
 //
 // Zero-conversion handle returned by async `batch_read`. Wraps raw Rust

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1167,6 +1167,46 @@ impl PyClient {
         }
     }
 
+    /// Read multiple groups of records in a single merged batch call.
+    ///
+    /// Sync counterpart of `AsyncClient.batch_read_many`. Returns
+    /// `list[BatchRecords]` (one dict per input group, preserving order).
+    #[pyo3(signature = (groups, bins=None, policy=None))]
+    fn batch_read_many(
+        &self,
+        py: Python<'_>,
+        groups: &Bound<'_, PyList>,
+        bins: Option<Vec<String>>,
+        policy: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyAny>> {
+        debug!("batch_read_many: groups_count={}", groups.len());
+        let client = self.get_client()?.clone();
+        let args = client_common::prepare_batch_read_many_args(
+            py,
+            groups,
+            &bins,
+            policy,
+            &self.connection_info,
+        )?;
+        let limiter = self.limiter.clone();
+        let split: Vec<Vec<aerospike_core::BatchRecord>> =
+            catch_panic_sync("Client.batch_read_many", || {
+                py.detach(|| {
+                    RUNTIME.block_on(async {
+                        let _permit = limiter.acquire_named("batch_read_many").await?;
+                        client_ops::do_batch_read_many(&client, &args).await
+                    })
+                })
+            })?;
+
+        let result_list = pyo3::types::PyList::empty(py);
+        for group in split {
+            let dict = batch_to_dict_py(py, &group)?;
+            result_list.append(dict)?;
+        }
+        Ok(result_list.unbind().into_any())
+    }
+
     /// Perform operations on multiple records. Returns list of (key, meta, bins) tuples.
     #[pyo3(signature = (keys, ops, policy=None))]
     fn batch_operate(

--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -480,6 +480,99 @@ impl BatchReadArgs {
     }
 }
 
+// ── batch_read_many ──────────────────────────────────────────────────────────
+
+/// Pre-parsed args for `batch_read_many`. Groups multiple key lists that share
+/// a single `(BatchPolicy, BatchReadPolicy, Bins)`, so the underlying
+/// `client.batch()` call can serve them as one merged request (single network
+/// round-trip via Aerospike's native batch protocol) and we split the
+/// per-group results back out on the way home.
+pub struct BatchReadManyArgs {
+    pub groups: Vec<BatchReadGroup>,
+    pub batch_policy: aerospike_core::BatchPolicy,
+    pub read_policy: aerospike_core::BatchReadPolicy,
+    pub bins_selector: Bins,
+    /// Namespace/set of the first key across all groups (for tracing labels).
+    pub batch_ns: String,
+    pub batch_set: String,
+    pub otel: OtelContext,
+}
+
+pub struct BatchReadGroup {
+    pub rust_keys: Vec<Key>,
+}
+
+pub fn prepare_batch_read_many_args(
+    py: Python<'_>,
+    groups: &Bound<'_, PyList>,
+    bins: &Option<Vec<String>>,
+    policy: Option<&Bound<'_, PyDict>>,
+    conn_info: &Arc<ConnectionInfo>,
+) -> PyResult<BatchReadManyArgs> {
+    let batch_policy = parse_batch_policy(policy)?;
+    let read_policy = parse_batch_read_policy(policy)?;
+    let bins_selector = match bins {
+        None => Bins::All,
+        Some(b) if b.is_empty() => Bins::None,
+        Some(b) => {
+            let refs: Vec<&str> = b.iter().map(|s| s.as_str()).collect();
+            Bins::from(refs.as_slice())
+        }
+    };
+
+    let mut parsed_groups: Vec<BatchReadGroup> = Vec::with_capacity(groups.len());
+    let mut first_ns_set: Option<(String, String)> = None;
+    for item in groups.iter() {
+        let keys_list = item.cast::<PyList>().map_err(|_| {
+            pyo3::exceptions::PyValueError::new_err(
+                "batch_read_many: each request must be a list of key tuples",
+            )
+        })?;
+        let rust_keys = crate::types::key::py_to_keys(&keys_list)?;
+        if first_ns_set.is_none() {
+            if let Some(k) = rust_keys.first() {
+                first_ns_set = Some((k.namespace.clone(), k.set_name.clone()));
+            }
+        }
+        parsed_groups.push(BatchReadGroup { rust_keys });
+    }
+
+    let (batch_ns, batch_set) = first_ns_set.unwrap_or_default();
+
+    Ok(BatchReadManyArgs {
+        groups: parsed_groups,
+        batch_policy,
+        read_policy,
+        bins_selector,
+        batch_ns,
+        batch_set,
+        otel: OtelContext::new(py, conn_info),
+    })
+}
+
+impl BatchReadManyArgs {
+    /// Flatten all groups into a single ``Vec<BatchOperation>`` for one
+    /// `client.batch()` call, plus the per-group boundary offsets used to
+    /// split the result back out.
+    pub fn to_combined_ops(&self) -> (Vec<BatchOperation>, Vec<usize>) {
+        let total: usize = self.groups.iter().map(|g| g.rust_keys.len()).sum();
+        let mut ops = Vec::with_capacity(total);
+        let mut boundaries = Vec::with_capacity(self.groups.len() + 1);
+        boundaries.push(0);
+        for g in &self.groups {
+            for k in &g.rust_keys {
+                ops.push(BatchOperation::read(
+                    &self.read_policy,
+                    k.clone(),
+                    self.bins_selector.clone(),
+                ));
+            }
+            boundaries.push(ops.len());
+        }
+        (ops, boundaries)
+    }
+}
+
 // ── batch_operate ────────────────────────────────────────────────────────────
 
 pub struct BatchOperateArgs {

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -231,6 +231,48 @@ pub async fn do_batch_read(client: &AsClient, args: &BatchReadArgs) -> PyResult<
     )
 }
 
+/// Read multiple groups of records in a single merged batch call.
+///
+/// Issues one network round-trip via Aerospike's native multi-key batch
+/// protocol and splits the result back into per-group `Vec<BatchRecord>`
+/// using the boundaries computed during prep. Records inside each group
+/// preserve the order of their input keys.
+pub async fn do_batch_read_many(
+    client: &AsClient,
+    args: &crate::client_common::BatchReadManyArgs,
+) -> PyResult<Vec<Vec<BatchRecord>>> {
+    let (ops, boundaries) = args.to_combined_ops();
+    let combined: Vec<BatchRecord> = traced_op!(
+        "batch_read_many",
+        &args.batch_ns,
+        &args.batch_set,
+        args.otel.parent_ctx,
+        args.otel.conn_info,
+        client.batch(&args.batch_policy, &ops).await
+    )?;
+
+    if combined.len() != *boundaries.last().unwrap_or(&0) {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "batch_read_many: aerospike-core returned {} records for {} ops \
+             (expected equal counts) — refusing to split",
+            combined.len(),
+            boundaries.last().copied().unwrap_or(0),
+        )));
+    }
+
+    let mut split: Vec<Vec<BatchRecord>> = Vec::with_capacity(args.groups.len());
+    let mut iter = combined.into_iter();
+    for w in boundaries.windows(2) {
+        let group_size = w[1] - w[0];
+        let mut group = Vec::with_capacity(group_size);
+        for _ in 0..group_size {
+            group.push(iter.next().expect("boundary mismatch — should be unreachable"));
+        }
+        split.push(group);
+    }
+    Ok(split)
+}
+
 /// Perform operations on multiple records in a batch.
 pub async fn do_batch_operate(
     client: &AsClient,

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -759,6 +759,33 @@ class Client:
         """
         ...
 
+    def batch_read_many(
+        self,
+        groups: list[list[Key]],
+        bins: Optional[list[str]] = None,
+        policy: Optional[dict[str, Any]] = None,
+    ) -> list[BatchRecords]:
+        """Read multiple groups of records in a single merged batch call.
+
+        Sync counterpart of :meth:`AsyncClient.batch_read_many`. Issues
+        one network round-trip via Aerospike's native multi-key batch
+        protocol regardless of how many groups are passed, and splits
+        the per-group results back out preserving input order.
+
+        Args:
+            groups: List of key-tuple lists. Each inner list maps to its
+                own ``dict`` in the result, preserving input order.
+            bins: Optional list of bin names; ``None`` reads all bins; an
+                empty list performs an existence check. Shared across all groups.
+            policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict,
+                shared across all groups.
+
+        Returns:
+            ``list[BatchRecords]`` of the same length as ``groups``, in
+            the same order. Each element is a ``dict[Key, AerospikeRecord]``.
+        """
+        ...
+
     def batch_operate(
         self,
         keys: list[Key],
@@ -1823,6 +1850,45 @@ class AsyncClient:
                 (("test", "demo", "user2"), {"name": "Bob"}, {"ttl": 86400}),
             ]
             results = await client.batch_write(records_with_meta)
+            ```
+        """
+        ...
+
+    async def batch_read_many(
+        self,
+        groups: list[list[Key]],
+        bins: Optional[list[str]] = None,
+        policy: Optional[dict[str, Any]] = None,
+    ) -> list[BatchRecords]:
+        """Read multiple groups of records in a single merged batch call.
+
+        For N input groups, issues one Tokio task, one limiter acquisition,
+        one network round-trip, and one GIL hand-off — regardless of N.
+        Aerospike's native batch protocol carries mixed-set keys in one
+        request, so the merge is free at the wire.
+
+        Args:
+            groups: List of key-tuple lists. Each inner list maps to its
+                own ``dict`` in the result, preserving input order.
+            bins: Optional list of bin names; ``None`` reads all bins; an
+                empty list performs an existence check. Shared across
+                all groups.
+            policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict,
+                shared across all groups.
+
+        Returns:
+            ``list[BatchRecords]`` of the same length as ``groups``, in
+            the same order. Each element is a ``dict[Key, AerospikeRecord]``.
+
+        Example:
+            ```python
+            feature_keys = [
+                [("test", f"fv_{fv}", f"u{i}") for i in range(80)]
+                for fv in range(9)
+            ]
+            results = await client.batch_read_many(feature_keys)
+            for fv_idx, records in enumerate(results):
+                ...  # records[user_key] -> bins dict
             ```
         """
         ...

--- a/src/aerospike_py/_async_client.py
+++ b/src/aerospike_py/_async_client.py
@@ -190,6 +190,47 @@ class AsyncClient:
             return raw  # NumpyBatchRecords path unchanged
         return raw.as_dict()
 
+    @catch_unexpected("AsyncClient.batch_read_many")
+    async def batch_read_many(
+        self,
+        groups: list[list[tuple[str, str, Any]]],
+        bins: list[str] | None = None,
+        policy: dict[str, Any] | None = None,
+    ) -> list[dict]:
+        """Read multiple groups of records in a single merged batch call.
+
+        For N input groups, issues exactly one Tokio task + one limiter
+        acquisition + one network round-trip + one GIL hand-off — vs the
+        N of each you'd pay calling :meth:`batch_read` N times in a
+        :func:`asyncio.gather`. Aerospike's native batch protocol carries
+        mixed-set keys in one request so the merge is free at the wire.
+
+        Args:
+            groups: List of key-tuple lists. Each inner list maps to its own
+                ``dict`` in the result, preserving input order.
+            bins: Optional list of bin names; ``None`` reads all bins; an
+                empty list performs an existence check. Shared across all
+                groups (per-group overrides intentionally not exposed in
+                this minimal API).
+            policy: Optional batch policy dict, shared across all groups.
+
+        Returns:
+            ``list[dict[Key, AerospikeRecord]]`` of the same length as
+            ``groups``, in the same order.
+
+        Example:
+            ```python
+            feature_keys = [
+                [("test", f"fv_{fv}", f"u{i}") for i in range(80)]
+                for fv in range(9)
+            ]
+            results = await client.batch_read_many(feature_keys)
+            # results[fv][user_key] -> bins dict
+            ```
+        """
+        handles = await self._inner.batch_read_many(groups, bins, policy)
+        return [h.as_dict() for h in handles]
+
     @catch_unexpected("AsyncClient.batch_write_numpy")
     async def batch_write_numpy(
         self, data, namespace: str, set_name: str, _dtype, key_field: str = "_key", policy=None, retry: int = 0

--- a/tests/integration/test_batch_read_many.py
+++ b/tests/integration/test_batch_read_many.py
@@ -1,0 +1,128 @@
+"""Integration tests for batch_read_many on both Client and AsyncClient.
+
+Verifies that grouping N batch_reads into a single merged call produces
+the same per-group dicts as N separate calls (correctness), and that the
+input order is preserved on the way back out.
+"""
+
+import asyncio
+
+import pytest
+
+NS = "test"
+
+
+class TestBatchReadManySync:
+    def test_returns_list_of_dicts_in_order(self, client, cleanup):
+        groups: list[list[tuple[str, str, str]]] = []
+        for fv in range(3):
+            group = [(NS, f"brm_sync_fv_{fv}", f"u{i}") for i in range(4)]
+            for i, k in enumerate(group):
+                cleanup.append(k)
+                client.put(k, {"fv": fv, "user_idx": i})
+            groups.append(group)
+
+        results = client.batch_read_many(groups)
+        assert isinstance(results, list)
+        assert len(results) == 3
+        for fv, group_result in enumerate(results):
+            assert isinstance(group_result, dict)
+            assert len(group_result) == 4
+            for user_idx in range(4):
+                rec = group_result[f"u{user_idx}"]
+                assert rec["fv"] == fv
+
+    def test_equivalent_to_loop_of_batch_read(self, client, cleanup):
+        groups: list[list[tuple[str, str, str]]] = []
+        for fv in range(2):
+            group = [(NS, f"brm_sync_eq_{fv}", f"u{i}") for i in range(3)]
+            for i, k in enumerate(group):
+                cleanup.append(k)
+                client.put(k, {"fv": fv})
+            groups.append(group)
+
+        many = client.batch_read_many(groups)
+        loop = [client.batch_read(g) for g in groups]
+        assert many == loop
+
+
+@pytest.fixture(autouse=True)
+async def _seed_groups(async_client, async_cleanup):
+    """Seed 3 sets × 4 records each. Each set models a feature view."""
+    seeds: list[list[tuple[str, str, str]]] = []
+    for fv in range(3):
+        group = [(NS, f"brm_fv_{fv}", f"u{i}") for i in range(4)]
+        for i, k in enumerate(group):
+            async_cleanup.append(k)
+            await async_client.put(k, {"fv": fv, "user_idx": i})
+        seeds.append(group)
+    yield seeds
+
+
+class TestBatchReadMany:
+    async def test_returns_list_of_dicts_in_order(self, async_client, _seed_groups):
+        groups = _seed_groups
+        results = await async_client.batch_read_many(groups)
+
+        assert isinstance(results, list)
+        assert len(results) == len(groups)
+        for fv, group_result in enumerate(results):
+            assert isinstance(group_result, dict)
+            assert len(group_result) == 4
+            for user_idx in range(4):
+                rec = group_result[f"u{user_idx}"]
+                assert rec["fv"] == fv
+                assert rec["user_idx"] == user_idx
+
+    async def test_empty_group_returns_empty_dict(self, async_client, _seed_groups):
+        """An empty key list inside the multi-batch must still produce a
+        slot (an empty dict) in the output — preserves positional alignment."""
+        groups = [
+            _seed_groups[0],
+            [],
+            _seed_groups[2],
+        ]
+        results = await async_client.batch_read_many(groups)
+        assert len(results) == 3
+        assert len(results[0]) == 4
+        assert results[1] == {}
+        assert len(results[2]) == 4
+
+    async def test_bins_filter_applies_to_all_groups(self, async_client, _seed_groups):
+        groups = _seed_groups
+        results = await async_client.batch_read_many(groups, bins=["fv"])
+        for group_result in results:
+            for rec in group_result.values():
+                assert "fv" in rec
+                assert "user_idx" not in rec
+
+    async def test_equivalent_to_gather_of_batch_read(
+        self, async_client, _seed_groups
+    ):
+        """The fundamental contract: batch_read_many is observationally
+        identical to gather(batch_read for each group). Anything else means
+        the merge/split logic introduced a bug."""
+        groups = _seed_groups
+
+        many_result = await async_client.batch_read_many(groups)
+        gather_result = await asyncio.gather(
+            *[async_client.batch_read(g) for g in groups]
+        )
+
+        assert len(many_result) == len(gather_result)
+        for many_dict, gather_dict in zip(many_result, gather_result):
+            assert many_dict == gather_dict
+
+    async def test_missing_keys_excluded_from_each_group(
+        self, async_client, _seed_groups
+    ):
+        """Missing keys in a group produce no entry in that group's dict —
+        same semantic as batch_read."""
+        groups = [
+            _seed_groups[0] + [(NS, "brm_fv_0", "no_such_user")],
+            _seed_groups[1],
+        ]
+        results = await async_client.batch_read_many(groups)
+        assert len(results[0]) == 4  # missing key omitted
+        assert "no_such_user" not in results[0]
+        assert len(results[1]) == 4


### PR DESCRIPTION
## Summary

Addresses **A. \`batch_read_many\` — merge multiple batches into a single tokio task** from issue #347. This is the highest-ROI item the issue identified (⭐⭐⭐).

For workloads that fan out into N feature-view batches — e.g. \`asyncio.gather(*[client.batch_read(...) for _ in range(9)])\` from the ssa-pctcvr endpoint in #347 — the new API pays the per-call PyO3 + tokio + GIL overhead **exactly once** instead of N times. Aerospike's native batch protocol carries mixed-set keys in one wire request, so the merge is also free at the network layer.

## API

\`\`\`python
async def batch_read_many(
    groups: list[list[tuple[ns, set, user_key]]],
    bins: list[str] | None = None,
    policy: dict | None = None,
) -> list[dict[UserKey, AerospikeRecord]]
\`\`\`

- One \`dict\` per input group, preserving input order
- \`bins\` / \`policy\` are shared across all groups (per-group overrides intentionally not in this minimal API — can be added later if needed)
- Sync variant on \`Client\` mirrors the same signature

### Example

\`\`\`python
feature_keys = [
    [("test", f"fv_{fv}", f"u{i}") for i in range(80)]
    for fv in range(9)
]
# Before — 9 tokio tasks, 9 limiter acquires, 9 GIL hand-offs
results = await asyncio.gather(*[client.batch_read(g) for g in feature_keys])
# After  — 1 of each, 1 network round-trip
results = await client.batch_read_many(feature_keys)
\`\`\`

## Implementation

| File | Change |
|---|---|
| \`rust/src/client_common.rs\` | New \`BatchReadManyArgs\` + \`prepare_batch_read_many_args\`; \`to_combined_ops()\` flattens groups into one \`Vec<BatchOperation>\` plus boundaries |
| \`rust/src/client_ops.rs\` | New \`do_batch_read_many\` — single \`client.batch()\` call, splits by boundaries |
| \`rust/src/batch_types.rs\` | New \`PendingBatchReadMany\` — single GIL hand-off, returns \`list[BatchReadHandle]\` |
| \`rust/src/async_client.rs\` | New \`batch_read_many\` method on \`PyAsyncClient\` with stage-timer instrumentation on \`key_parse\`, \`future_into_py_setup\`, \`tokio_schedule_delay\`, \`limiter_wait\`, \`io\`, \`spawn_blocking_delay\`, \`into_pyobject\` |
| \`rust/src/client.rs\` | Sync counterpart via \`RUNTIME.block_on\` |
| \`src/aerospike_py/_async_client.py\` | Wrapper that calls handle \`.as_dict()\` on each entry |
| \`src/aerospike_py/__init__.pyi\` | Type stubs on both \`Client\` and \`AsyncClient\` |
| \`tests/integration/test_batch_read_many.py\` | 7 new tests (sync × 2, async × 5) |

## Test plan

- [x] \`cargo check\` — clean
- [x] \`make test-unit\` — 894 pass + 1 sync/async method parity test now requires symmetry on both sides (added)
- [x] \`test_batch_read_many.py\` — 7/7 pass against local Aerospike CE 8.1
  - Order preserved (sync + async)
  - Equivalence to \`asyncio.gather(*[batch_read(g) for g in groups])\` (async)
  - Equivalence to loop of \`client.batch_read\` (sync)
  - Empty group slot retention
  - Shared \`bins\` filter applies per group
  - Missing keys omitted per group (matches \`batch_read\` semantic)
- [x] Existing \`test_batch.py\` + \`test_batch_handle.py\` — 54/54 pass (no regression)
- [ ] CI: full test matrix

## Observability

All stages labeled \`batch_read_many\` for separate observability via \`AEROSPIKE_PY_INTERNAL_METRICS=1\`. Stages mirror \`batch_read\`: \`key_parse\`, \`future_into_py_setup\`, \`tokio_schedule_delay\`, \`limiter_wait\`, \`io\`, \`spawn_blocking_delay\`, \`into_pyobject\`.

## Out of scope

- **Per-group policy / bins overrides.** The minimal \`list[list[Key]]\` API matches the most common use case (9 FVs reading the same shape). Tuple-based per-group config can be layered on later.
- **NumPy fast path.** \`_dtype\` is not exposed yet — single-batch \`batch_read\` still owns the NumPy structured-array path; multi-batch numpy would be additive.

🤖 Authored with [Claude Code](https://claude.com/claude-code)