### PR TITLE
feat(batch): add batch_read_ordered returning list in input key order

### DIFF
--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -33,7 +33,7 @@ enum CloseOutcome {
     },
 }
 
-use crate::batch_types::{PendingBatchRead, PendingBatchRecords};
+use crate::batch_types::{PendingBatchRead, PendingBatchReadOrdered, PendingBatchRecords};
 use crate::errors::as_to_pyerr;
 use crate::panic_safety::future_into_py_panic_safe;
 use crate::policy::admin_policy::{parse_privileges, role_to_py, user_to_py};
@@ -778,6 +778,72 @@ impl PyAsyncClient {
                         io_complete_at,
                     })
                 }
+            })
+        })
+    }
+
+    /// Read multiple records, returning results in caller-supplied key order.
+    ///
+    /// Same single-batch network behavior as `batch_read`, but materializes
+    /// `list[Optional[dict]]` with one entry per input key (preserving order,
+    /// `None` for missing records) instead of the unordered `dict` keyed by
+    /// `user_key`. Saves callers from doing 720-step `.get(user_pk)` lookups
+    /// after every batch read.
+    ///
+    /// Reordering happens in Rust via a 20-byte digest HashMap built from
+    /// the result vector, then a positional walk over the input digests.
+    #[pyo3(signature = (keys, bins=None, policy=None))]
+    fn batch_read_ordered<'py>(
+        &self,
+        py: Python<'py>,
+        keys: &Bound<'_, PyList>,
+        bins: Option<Vec<String>>,
+        policy: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        debug!("async batch_read_ordered: keys_count={}", keys.len());
+
+        let client = self.get_client()?;
+        let limiter = self.limiter.clone();
+        let args = crate::stage_timer!("key_parse", "batch_read_ordered", {
+            client_common::prepare_batch_read_args(
+                py,
+                keys,
+                &bins,
+                policy,
+                &self.connection_info,
+            )?
+        });
+
+        // Capture input digests now (before the args move into the future) so
+        // we can reorder results by position. `Key.digest` is already computed
+        // during `py_to_keys`, so this is a cheap memcpy.
+        let input_digests: Vec<[u8; 20]> = args.rust_keys.iter().map(|k| k.digest).collect();
+
+        let spawned_at = crate::metrics::maybe_now();
+        crate::stage_timer!("future_into_py_setup", "batch_read_ordered", {
+            future_into_py_panic_safe(py, "AsyncClient.batch_read_ordered", async move {
+                if let Some(t) = spawned_at {
+                    crate::metrics::record_internal_stage_unchecked(
+                        "tokio_schedule_delay",
+                        "batch_read_ordered",
+                        t.elapsed().as_secs_f64(),
+                    );
+                }
+
+                let _permit = crate::stage_timer!("limiter_wait", "batch_read_ordered", {
+                    limiter.acquire_named("batch_read_ordered").await?
+                });
+
+                let results = crate::stage_timer!("io", "batch_read_ordered", {
+                    client_ops::do_batch_read(&client, &args).await?
+                });
+
+                let io_complete_at = crate::metrics::maybe_now();
+                Ok(PendingBatchReadOrdered {
+                    input_digests,
+                    results,
+                    io_complete_at,
+                })
             })
         })
     }

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -184,6 +184,65 @@ impl<'py> IntoPyObject<'py> for PendingBatchRead {
     }
 }
 
+/// Future result of `AsyncClient.batch_read_ordered`. Carries the per-key
+/// digests in input order so we can reorder the cluster's `Vec<BatchRecord>`
+/// into a positional `list[Optional[dict]]` inside `into_pyobject`.
+pub struct PendingBatchReadOrdered {
+    /// 20-byte digests of input keys, in caller-supplied order.
+    pub input_digests: Vec<[u8; 20]>,
+    pub results: Vec<BatchRecord>,
+    pub io_complete_at: Option<std::time::Instant>,
+}
+
+impl<'py> IntoPyObject<'py> for PendingBatchReadOrdered {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        use crate::types::value::value_to_py;
+        use std::collections::HashMap;
+
+        if let Some(t) = self.io_complete_at {
+            crate::metrics::record_internal_stage_unchecked(
+                "spawn_blocking_delay",
+                "batch_read_ordered",
+                t.elapsed().as_secs_f64(),
+            );
+        }
+
+        crate::stage_timer!("into_pyobject", "batch_read_ordered", {
+            // Build digest → record index map. We index into `self.results`
+            // (avoiding lifetimes from `self`) so we can materialize
+            // each bins dict inside the loop without borrow gymnastics.
+            let mut idx_by_digest: HashMap<[u8; 20], usize> =
+                HashMap::with_capacity(self.results.len());
+            for (i, br) in self.results.iter().enumerate() {
+                idx_by_digest.insert(br.key.digest, i);
+            }
+
+            let list = PyList::empty(py);
+            for digest in &self.input_digests {
+                let py_value: Py<PyAny> = match idx_by_digest.get(digest) {
+                    Some(&i) => match &self.results[i].record {
+                        Some(record) => {
+                            let bins = PyDict::new(py);
+                            for (name, value) in &record.bins {
+                                bins.set_item(name, value_to_py(py, value)?)?;
+                            }
+                            bins.into_any().unbind()
+                        }
+                        None => py.None(),
+                    },
+                    None => py.None(),
+                };
+                list.append(py_value)?;
+            }
+            Ok(list.into_any())
+        })
+    }
+}
+
 // ── PyBatchReadHandle ────────────────────────────────────────────
 //
 // Zero-conversion handle returned by async `batch_read`. Wraps raw Rust

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1167,6 +1167,63 @@ impl PyClient {
         }
     }
 
+    /// Read multiple records, returning results in caller-supplied key order.
+    ///
+    /// Sync counterpart of `AsyncClient.batch_read_ordered`. Returns
+    /// `list[Optional[dict]]` with one slot per input key (`None` for
+    /// missing records).
+    #[pyo3(signature = (keys, bins=None, policy=None))]
+    fn batch_read_ordered(
+        &self,
+        py: Python<'_>,
+        keys: &Bound<'_, PyList>,
+        bins: Option<Vec<String>>,
+        policy: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyAny>> {
+        use crate::types::value::value_to_py;
+        use std::collections::HashMap;
+
+        debug!("batch_read_ordered: keys_count={}", keys.len());
+        let client = self.get_client()?.clone();
+        let args =
+            client_common::prepare_batch_read_args(py, keys, &bins, policy, &self.connection_info)?;
+        let input_digests: Vec<[u8; 20]> = args.rust_keys.iter().map(|k| k.digest).collect();
+        let limiter = self.limiter.clone();
+        let results = catch_panic_sync("Client.batch_read_ordered", || {
+            py.detach(|| {
+                RUNTIME.block_on(async {
+                    let _permit = limiter.acquire_named("batch_read_ordered").await?;
+                    client_ops::do_batch_read(&client, &args).await
+                })
+            })
+        })?;
+
+        let mut idx_by_digest: HashMap<[u8; 20], usize> =
+            HashMap::with_capacity(results.len());
+        for (i, br) in results.iter().enumerate() {
+            idx_by_digest.insert(br.key.digest, i);
+        }
+
+        let list = pyo3::types::PyList::empty(py);
+        for digest in &input_digests {
+            let py_value: Py<PyAny> = match idx_by_digest.get(digest) {
+                Some(&i) => match &results[i].record {
+                    Some(record) => {
+                        let bins_dict = PyDict::new(py);
+                        for (name, value) in &record.bins {
+                            bins_dict.set_item(name, value_to_py(py, value)?)?;
+                        }
+                        bins_dict.into_any().unbind()
+                    }
+                    None => py.None(),
+                },
+                None => py.None(),
+            };
+            list.append(py_value)?;
+        }
+        Ok(list.unbind().into_any())
+    }
+
     /// Perform operations on multiple records. Returns list of (key, meta, bins) tuples.
     #[pyo3(signature = (keys, ops, policy=None))]
     fn batch_operate(

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -759,6 +759,31 @@ class Client:
         """
         ...
 
+    def batch_read_ordered(
+        self,
+        keys: list[Key],
+        bins: Optional[list[str]] = None,
+        policy: Optional[dict[str, Any]] = None,
+    ) -> list[Optional[dict[str, Any]]]:
+        """Read multiple records, returning results in caller-supplied key order.
+
+        Sync counterpart of :meth:`AsyncClient.batch_read_ordered`. Returns
+        ``list[Optional[dict]]`` — one slot per input key, preserving
+        input order, with ``None`` for missing records — instead of the
+        unordered ``dict`` keyed by ``user_key``.
+
+        Reordering happens in Rust via a 20-byte digest HashMap.
+
+        Args:
+            keys: List of ``(namespace, set, primary_key)`` tuples.
+            bins: Optional list of bin names; ``None`` reads all bins.
+            policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict.
+
+        Returns:
+            ``list[Optional[dict]]`` of the same length as ``keys``.
+        """
+        ...
+
     def batch_operate(
         self,
         keys: list[Key],
@@ -1824,6 +1849,30 @@ class AsyncClient:
             ]
             results = await client.batch_write(records_with_meta)
             ```
+        """
+        ...
+
+    async def batch_read_ordered(
+        self,
+        keys: list[Key],
+        bins: Optional[list[str]] = None,
+        policy: Optional[dict[str, Any]] = None,
+    ) -> list[Optional[dict[str, Any]]]:
+        """Read multiple records, returning results in caller-supplied key order.
+
+        Same network behavior as :meth:`batch_read` but returns
+        ``list[Optional[dict]]`` — one slot per input key, in input
+        order, with ``None`` for missing records — instead of the
+        unordered ``dict`` keyed by ``user_key``.
+
+        Args:
+            keys: List of ``(namespace, set, primary_key)`` tuples.
+            bins: Optional list of bin names; ``None`` reads all bins.
+            policy: Optional [`BatchPolicy`](types.md#batchpolicy) dict.
+
+        Returns:
+            ``list[Optional[dict]]`` of the same length as ``keys``,
+            preserving input order; ``None`` for missing records.
         """
         ...
 

--- a/src/aerospike_py/_async_client.py
+++ b/src/aerospike_py/_async_client.py
@@ -190,6 +190,49 @@ class AsyncClient:
             return raw  # NumpyBatchRecords path unchanged
         return raw.as_dict()
 
+    @catch_unexpected("AsyncClient.batch_read_ordered")
+    async def batch_read_ordered(
+        self,
+        keys: list,
+        bins: list[str] | None = None,
+        policy: dict[str, Any] | None = None,
+    ) -> list[dict | None]:
+        """Read multiple records, returning results in caller-supplied key order.
+
+        Same network behavior as :meth:`batch_read` but returns
+        ``list[Optional[dict]]`` — one slot per input key, in input order,
+        with ``None`` for missing records — instead of the unordered
+        ``dict`` keyed by ``user_key``. Saves callers from doing N
+        ``dict.get(user_pk)`` lookups after every batch read.
+
+        Reordering happens in Rust via a 20-byte digest HashMap and a
+        positional walk over the input digests — single GIL acquisition.
+
+        Args:
+            keys: List of ``(namespace, set, primary_key)`` tuples.
+            bins: Optional list of bin names; ``None`` reads all bins;
+                an empty list performs an existence check.
+            policy: Optional batch policy dict.
+
+        Returns:
+            ``list[Optional[dict]]`` of the same length as ``keys``. Each
+            entry is the bins dict for the record at that input position,
+            or ``None`` if the record was not found.
+
+        Example:
+            ```python
+            user_keys = [("test", "users", f"u{i}") for i in range(100)]
+            records = await client.batch_read_ordered(user_keys)
+            # records[0] is for u0, records[1] for u1, …
+            for i, bins in enumerate(records):
+                if bins is None:
+                    print(f"u{i} missing")
+                else:
+                    print(f"u{i}: {bins}")
+            ```
+        """
+        return await self._inner.batch_read_ordered(keys, bins, policy)
+
     @catch_unexpected("AsyncClient.batch_write_numpy")
     async def batch_write_numpy(
         self, data, namespace: str, set_name: str, _dtype, key_field: str = "_key", policy=None, retry: int = 0

--- a/tests/integration/test_batch_read_ordered.py
+++ b/tests/integration/test_batch_read_ordered.py
@@ -1,0 +1,94 @@
+"""Integration tests for batch_read_ordered on both Client and AsyncClient.
+
+Verifies position-preserved list return: each input key maps to its bins
+dict at the same index, or ``None`` if not found.
+"""
+
+import pytest
+
+NS = "test"
+SET = "bro"
+
+
+@pytest.fixture(autouse=True)
+async def _seed_records(async_client, async_cleanup):
+    """Seed even-indexed records (0, 2, 4, 6, 8). Odd indices are missing."""
+    keys = []
+    for i in range(10):
+        k = (NS, SET, f"o_{i}")
+        if i % 2 == 0:
+            async_cleanup.append(k)
+            await async_client.put(k, {"i": i, "name": f"name_{i}"})
+        keys.append(k)
+    yield keys
+
+
+class TestBatchReadOrderedAsync:
+    async def test_preserves_order(self, async_client, _seed_records):
+        keys = _seed_records
+        result = await async_client.batch_read_ordered(keys)
+        assert len(result) == len(keys)
+        for i, bins in enumerate(result):
+            if i % 2 == 0:
+                assert bins is not None
+                assert bins["i"] == i
+            else:
+                assert bins is None
+
+    async def test_missing_keys_are_none(self, async_client, _seed_records):
+        # All missing
+        keys = [(NS, SET, f"o_{i}") for i in (1, 3, 5)]
+        result = await async_client.batch_read_ordered(keys)
+        assert result == [None, None, None]
+
+    async def test_duplicate_keys_each_get_a_slot(self, async_client, _seed_records):
+        """Duplicate input keys must each receive their own slot in the
+        output (server-side dedup must not propagate to the slot count)."""
+        k0 = (NS, SET, "o_0")
+        result = await async_client.batch_read_ordered([k0, k0, k0])
+        assert len(result) == 3
+        assert all(r is not None and r["i"] == 0 for r in result)
+
+    async def test_bins_filter(self, async_client, _seed_records):
+        keys = [(NS, SET, "o_0"), (NS, SET, "o_2")]
+        result = await async_client.batch_read_ordered(keys, bins=["i"])
+        assert len(result) == 2
+        for bins in result:
+            assert bins is not None
+            assert "i" in bins
+            assert "name" not in bins
+
+    async def test_empty_keys_returns_empty_list(self, async_client, _seed_records):
+        result = await async_client.batch_read_ordered([])
+        assert result == []
+
+
+class TestBatchReadOrderedSync:
+    def test_preserves_order(self, client, cleanup):
+        keys = [(NS, "bro_sync", f"o_{i}") for i in range(6)]
+        for i, k in enumerate(keys):
+            if i % 2 == 0:
+                cleanup.append(k)
+                client.put(k, {"i": i})
+
+        result = client.batch_read_ordered(keys)
+        assert len(result) == 6
+        for i, bins in enumerate(result):
+            if i % 2 == 0:
+                assert bins is not None and bins["i"] == i
+            else:
+                assert bins is None
+
+    def test_equivalent_to_dict_lookup(self, client, cleanup):
+        """Reordered result must equal the same lookup done via the
+        regular batch_read dict — anything else means the reorder
+        introduced a bug."""
+        keys = [(NS, "bro_sync_eq", f"o_{i}") for i in range(5)]
+        for i, k in enumerate(keys):
+            cleanup.append(k)
+            client.put(k, {"i": i})
+
+        ordered = client.batch_read_ordered(keys)
+        dict_form = client.batch_read(keys)
+        manual = [dict_form.get(f"o_{i}") for i in range(5)]
+        assert ordered == manual


### PR DESCRIPTION
## Summary

Addresses **B. \`batch_read_ordered\`** from issue #347 — ⭐⭐⭐ ROI item.

\`batch_read_ordered(keys, bins=None, policy=None)\` keeps the single-batch network behavior of \`batch_read\` but returns \`list[Optional[dict]]\` — one slot per input key, in input order, with \`None\` for missing records — instead of the unordered \`dict\` keyed by \`user_key\`.

## Motivation

The downstream lookup loop that \`batch_read\` consumers end up writing:

\`\`\`python
result = await client.batch_read(keys)
materialized = [result.get(user_pk) for _, _, user_pk in keys]
\`\`\`

For a 720-key batch this is 720 Python-side dict lookups per request — small per item, meaningful in aggregate, easy to get subtly wrong (stringifying \`user_key\`, handling missing slots, type coercion when the user_key was an int). The new API moves the same logic into Rust: a 20-byte digest \`HashMap\` built from the result vector, then a positional walk over the input digests. Single GIL acquisition during the materialize step.

## API

\`\`\`python
async def batch_read_ordered(
    self,
    keys: list[tuple[str, str, Any]],
    bins: Optional[list[str]] = None,
    policy: Optional[dict[str, Any]] = None,
) -> list[Optional[dict]]
\`\`\`

Each result element is the bins dict for the record at that input position, or \`None\` if the record was not found. Duplicate input keys each receive their own slot (server-side dedup does not propagate).

## Implementation

| File | Change |
|---|---|
| \`rust/src/batch_types.rs\` | New \`PendingBatchReadOrdered\` carrying input digests + results; \`IntoPyObject\` builds the digest → record-index \`HashMap\` and walks input digests to materialize \`list[Optional[dict]]\` |
| \`rust/src/async_client.rs\` | New \`batch_read_ordered\` method with stage-timer instrumentation on \`key_parse\`, \`future_into_py_setup\`, \`tokio_schedule_delay\`, \`limiter_wait\`, \`io\`, \`spawn_blocking_delay\`, \`into_pyobject\` |
| \`rust/src/client.rs\` | Sync counterpart via \`RUNTIME.block_on\` |
| \`src/aerospike_py/_async_client.py\` | Wrapper that returns the list directly (no \`as_dict\` step needed) |
| \`src/aerospike_py/__init__.pyi\` | Type stubs on both \`Client\` and \`AsyncClient\` |
| \`tests/integration/test_batch_read_ordered.py\` | 7 new tests (sync × 2, async × 5) |

## Test plan

- [x] \`cargo check\` — clean
- [x] \`make test-unit\` — 894 pass + sync/async method parity (added on both sides)
- [x] \`test_batch_read_ordered.py\` — 7/7 pass against local Aerospike CE 8.1
  - Async + sync: order preservation with missing-key holes
  - Async: missing-only → all \`None\`
  - Async: duplicate input keys → each receives its own slot
  - Async: bins filter applies
  - Async: empty input → empty list
  - Sync: equivalence to \`[dict_result.get(user_pk) for ...]\` (the exact pattern this API is meant to replace)
- [x] Existing \`test_batch.py\` + \`test_batch_handle.py\` — 54/54 pass (no regression)
- [ ] CI: full test matrix

## Observability

All stages labeled \`batch_read_ordered\` for separate observability via \`AEROSPIKE_PY_INTERNAL_METRICS=1\`. Stages mirror \`batch_read\`: \`key_parse\`, \`future_into_py_setup\`, \`tokio_schedule_delay\`, \`limiter_wait\`, \`io\`, \`spawn_blocking_delay\`, \`into_pyobject\`.

## Relation to #352 (\`batch_read_many\`)

\`batch_read_many\` and \`batch_read_ordered\` are complementary:

- \`batch_read_many\` — different key-groups (e.g. one per FV) collapsed into one network round-trip
- \`batch_read_ordered\` — single batch with positional output rather than dict output

They compose: a future \`batch_read_many_ordered\` could combine both. Not in this PR — kept each surface minimal.

🤖 Authored with [Claude Code](https://claude.com/claude-code)