### PR TITLE
feat(policy): add BatchPolicyInstance pyclass for pre-parsed batch policies

### DIFF
--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -711,7 +711,7 @@ impl PyAsyncClient {
         py: Python<'py>,
         keys: &Bound<'_, PyList>,
         bins: Option<Vec<String>>,
-        policy: Option<&Bound<'_, PyDict>>,
+        policy: Option<&Bound<'_, PyAny>>,
         _dtype: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         debug!("async batch_read: keys_count={}", keys.len());

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1135,13 +1135,17 @@ impl PyClient {
     // ── Batch operations ──────────────────────────────────────────
 
     /// Read multiple records. Returns BatchRecords, or NumpyBatchRecords when dtype is provided.
+    ///
+    /// `policy` accepts either a dict (back-compat) or an
+    /// `aerospike_py.BatchPolicy` pyclass instance (parsed once, reused
+    /// across calls).
     #[pyo3(signature = (keys, bins=None, policy=None, _dtype=None))]
     fn batch_read(
         &self,
         py: Python<'_>,
         keys: &Bound<'_, PyList>,
         bins: Option<Vec<String>>,
-        policy: Option<&Bound<'_, PyDict>>,
+        policy: Option<&Bound<'_, PyAny>>,
         _dtype: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Py<PyAny>> {
         debug!("batch_read: keys_count={}", keys.len());

--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::policy::batch_policy::{
     apply_record_meta, apply_record_meta_for_apply, apply_record_meta_for_delete,
-    parse_batch_delete_policy, parse_batch_read_policy, parse_batch_udf_policy,
+    parse_batch_delete_policy, parse_batch_udf_policy,
     parse_batch_write_policy,
 };
 use aerospike_core::{
@@ -439,11 +439,11 @@ pub fn prepare_batch_read_args(
     py: Python<'_>,
     keys: &Bound<'_, PyList>,
     bins: &Option<Vec<String>>,
-    policy: Option<&Bound<'_, PyDict>>,
+    policy: Option<&Bound<'_, PyAny>>,
     conn_info: &Arc<ConnectionInfo>,
 ) -> PyResult<BatchReadArgs> {
-    let batch_policy = parse_batch_policy(policy)?;
-    let read_policy = parse_batch_read_policy(policy)?;
+    let (batch_policy, read_policy) =
+        crate::policy::batch_policy::parse_batch_policy_arg(policy)?;
     let bins_selector = match bins {
         None => Bins::All,
         Some(b) if b.is_empty() => Bins::None,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -98,6 +98,7 @@ fn _aerospike(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<batch_types::PyBatchRecord>()?;
     m.add_class::<batch_types::PyBatchRecords>()?;
     m.add_class::<batch_types::PyBatchReadHandle>()?;
+    m.add_class::<policy::batch_policy::PyBatchPolicy>()?;
 
     // Register functions
     m.add_function(wrap_pyfunction!(get_metrics_text, m)?)?;

--- a/rust/src/policy/batch_policy.rs
+++ b/rust/src/policy/batch_policy.rs
@@ -15,6 +15,142 @@ use super::{
     parse_generation_policy, parse_read_touch_ttl, parse_record_exists_action, parse_replica,
 };
 
+/// Python-exposed pre-parsed batch policy.
+///
+/// Holds both the `BatchPolicy` (transport-level) and `BatchReadPolicy`
+/// (per-record-read-level) structures so callers can build a long-lived
+/// instance once (typical at service startup) and reuse it on every
+/// `batch_read` call without paying the dict-extraction cost per request.
+///
+/// Construct via the Python-side ``aerospike_py.BatchPolicy(...)``
+/// constructor. Pass it as the `policy` argument to `batch_read`,
+/// `batch_read_many`, or `batch_read_ordered`.
+#[pyo3::pyclass(name = "BatchPolicyInstance", module = "aerospike_py", frozen)]
+pub struct PyBatchPolicy {
+    pub(crate) batch_policy: BatchPolicy,
+    pub(crate) read_policy: BatchReadPolicy,
+}
+
+#[pyo3::pymethods]
+impl PyBatchPolicy {
+    /// Build a parsed batch policy from typed keyword arguments.
+    ///
+    /// Any field omitted falls back to the same default the underlying
+    /// `aerospike-core` policy would use. Unknown kwargs are rejected at
+    /// construction time so typos surface as `TypeError`, not as
+    /// silently-ignored arguments.
+    #[new]
+    #[pyo3(signature = (
+        *,
+        socket_timeout = None,
+        total_timeout = None,
+        max_retries = None,
+        timeout_delay = None,
+        allow_inline = None,
+        allow_inline_ssd = None,
+        respond_all_keys = None,
+        replica = None,
+        read_mode_ap = None,
+        read_touch_ttl_percent = None,
+        concurrency = None,
+        filter_expression = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        socket_timeout: Option<u32>,
+        total_timeout: Option<u32>,
+        max_retries: Option<usize>,
+        timeout_delay: Option<u32>,
+        allow_inline: Option<bool>,
+        allow_inline_ssd: Option<bool>,
+        respond_all_keys: Option<bool>,
+        replica: Option<i32>,
+        read_mode_ap: Option<i32>,
+        read_touch_ttl_percent: Option<i64>,
+        concurrency: Option<i64>,
+        filter_expression: Option<Py<PyAny>>,
+    ) -> PyResult<Self> {
+        let mut batch_policy = BatchPolicy::default();
+        if let Some(v) = socket_timeout {
+            batch_policy.base_policy.socket_timeout = v;
+        }
+        if let Some(v) = total_timeout {
+            batch_policy.base_policy.total_timeout = v;
+        }
+        if let Some(v) = max_retries {
+            batch_policy.base_policy.max_retries = v;
+        }
+        if let Some(v) = timeout_delay {
+            batch_policy.base_policy.timeout_delay = v;
+        }
+        if let Some(v) = allow_inline {
+            batch_policy.allow_inline = v;
+        }
+        if let Some(v) = allow_inline_ssd {
+            batch_policy.allow_inline_ssd = v;
+        }
+        if let Some(v) = respond_all_keys {
+            batch_policy.respond_all_keys = v;
+        }
+        if let Some(v) = replica {
+            batch_policy.replica = parse_replica(v);
+        }
+        if let Some(v) = read_mode_ap {
+            batch_policy.base_policy.consistency_level = parse_consistency_level(v);
+        }
+        if let Some(v) = read_touch_ttl_percent {
+            batch_policy.base_policy.read_touch_ttl = parse_read_touch_ttl(v)?;
+        }
+        if let Some(v) = concurrency {
+            batch_policy.concurrency = parse_concurrency(v)?;
+        }
+        let mut read_policy = BatchReadPolicy::default();
+        if let Some(v) = read_touch_ttl_percent {
+            read_policy.read_touch_ttl = parse_read_touch_ttl(v)?;
+        }
+        if let Some(expr_py) = filter_expression {
+            pyo3::Python::attach(|py| -> PyResult<()> {
+                let bound = expr_py.bind(py);
+                if !crate::expressions::is_expression(bound) {
+                    return Err(pyo3::exceptions::PyTypeError::new_err(
+                        "filter_expression must be an aerospike_py expression",
+                    ));
+                }
+                let expr = crate::expressions::py_to_expression(bound)?;
+                batch_policy.filter_expression = Some(expr.clone());
+                read_policy.filter_expression = Some(expr);
+                Ok(())
+            })?;
+        }
+        Ok(Self {
+            batch_policy,
+            read_policy,
+        })
+    }
+}
+
+/// Resolve the `policy` argument for batch reads — supports both the
+/// historical dict shape and the new `PyBatchPolicy` pyclass instance.
+///
+/// Returns the parsed `(BatchPolicy, BatchReadPolicy)` pair. Dict path
+/// runs the existing parser; pyclass path is a single struct clone.
+pub fn parse_batch_policy_arg(
+    policy: Option<&Bound<'_, PyAny>>,
+) -> PyResult<(BatchPolicy, BatchReadPolicy)> {
+    let Some(obj) = policy else {
+        return Ok((BatchPolicy::default(), BatchReadPolicy::default()));
+    };
+    if let Ok(pyclass) = obj.extract::<PyRef<'_, PyBatchPolicy>>() {
+        return Ok((pyclass.batch_policy.clone(), pyclass.read_policy.clone()));
+    }
+    let dict = obj.cast::<PyDict>().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err(
+            "policy must be a dict or an aerospike_py.BatchPolicy instance",
+        )
+    })?;
+    Ok((parse_batch_policy(Some(dict))?, parse_batch_read_policy(Some(dict))?))
+}
+
 /// Parse a Python policy dict into a BatchPolicy
 pub fn parse_batch_policy(policy_dict: Option<&Bound<'_, PyDict>>) -> PyResult<BatchPolicy> {
     trace!("Parsing batch policy");

--- a/src/aerospike_py/__init__.py
+++ b/src/aerospike_py/__init__.py
@@ -18,6 +18,8 @@ from aerospike_py._aerospike import (  # noqa: F401
     partition_filter_by_range,
 )
 
+from aerospike_py._aerospike import BatchPolicyInstance  # noqa: F401
+
 from aerospike_py._aerospike import (  # noqa: F401
     AerospikeError,
     ClientError,
@@ -406,6 +408,7 @@ __all__ = [
     "ReadPolicy",
     "WritePolicy",
     "BatchPolicy",
+    "BatchPolicyInstance",
     "BatchReadPolicy",
     "BatchDeletePolicy",
     "BatchDeleteMeta",

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -2176,6 +2176,47 @@ class AsyncClient:
         policy: Optional[dict[str, Any]] = None,
     ) -> None: ...
 
+class BatchPolicyInstance:
+    """Pre-parsed batch policy reusable across `batch_read*` calls.
+
+    Equivalent to the ``BatchPolicy`` TypedDict but compiled at
+    construction time so the policy is parsed exactly once and reused
+    without dict-extraction overhead on subsequent calls. Pass it as
+    the ``policy`` argument to :meth:`Client.batch_read`,
+    :meth:`AsyncClient.batch_read`, :meth:`batch_read_many`, or
+    :meth:`batch_read_ordered`. Both dict and ``BatchPolicyInstance``
+    arguments are accepted (back-compat).
+
+    Construct with kwargs only — positional args are rejected:
+
+        policy = aerospike_py.BatchPolicyInstance(
+            socket_timeout=2000,
+            total_timeout=5000,
+            max_retries=2,
+            concurrency=1,
+        )
+
+    Recommended pattern for long-lived ML services: build once at
+    startup, store on the service instance, reuse on every request.
+    """
+
+    def __init__(
+        self,
+        *,
+        socket_timeout: Optional[int] = None,
+        total_timeout: Optional[int] = None,
+        max_retries: Optional[int] = None,
+        timeout_delay: Optional[int] = None,
+        allow_inline: Optional[bool] = None,
+        allow_inline_ssd: Optional[bool] = None,
+        respond_all_keys: Optional[bool] = None,
+        replica: Optional[int] = None,
+        read_mode_ap: Optional[int] = None,
+        read_touch_ttl_percent: Optional[int] = None,
+        concurrency: Optional[int] = None,
+        filter_expression: Optional[Any] = None,
+    ) -> None: ...
+
 class PartitionFilter:
     """Opaque handle representing a subset of partitions for query/scan.
 

--- a/tests/integration/test_batch_policy_instance.py
+++ b/tests/integration/test_batch_policy_instance.py
@@ -1,0 +1,89 @@
+"""Integration tests for the BatchPolicyInstance pyclass.
+
+Verifies that a pre-parsed policy is accepted by batch_read on both
+Client and AsyncClient, and produces the same results as the
+equivalent dict-shaped policy.
+"""
+
+import aerospike_py
+import pytest
+
+NS = "test"
+SET = "bpi"
+
+
+class TestBatchPolicyInstance:
+    def test_construct_with_no_kwargs(self):
+        p = aerospike_py.BatchPolicyInstance()
+        assert isinstance(p, aerospike_py.BatchPolicyInstance)
+
+    def test_construct_with_typed_kwargs(self):
+        p = aerospike_py.BatchPolicyInstance(
+            socket_timeout=2000,
+            total_timeout=5000,
+            max_retries=3,
+            concurrency=1,
+            allow_inline=True,
+        )
+        assert isinstance(p, aerospike_py.BatchPolicyInstance)
+
+    def test_unknown_kwarg_raises(self):
+        with pytest.raises(TypeError):
+            aerospike_py.BatchPolicyInstance(definitely_not_a_field=1)  # type: ignore[call-arg]
+
+    def test_positional_args_rejected(self):
+        """Constructor is keyword-only; passing positional args raises."""
+        with pytest.raises(TypeError):
+            aerospike_py.BatchPolicyInstance(2000)  # type: ignore[misc]
+
+
+class TestBatchReadAcceptsInstance:
+    def test_sync_client_accepts_instance(self, client, cleanup):
+        keys = [(NS, SET, f"s_{i}") for i in range(3)]
+        for i, k in enumerate(keys):
+            cleanup.append(k)
+            client.put(k, {"i": i})
+
+        policy = aerospike_py.BatchPolicyInstance(socket_timeout=2000, max_retries=2)
+        result = client.batch_read(keys, policy=policy)
+        assert result == {f"s_{i}": {"i": i} for i in range(3)}
+
+    async def test_async_client_accepts_instance(self, async_client, async_cleanup):
+        keys = [(NS, SET, f"a_{i}") for i in range(3)]
+        for i, k in enumerate(keys):
+            async_cleanup.append(k)
+            await async_client.put(k, {"i": i})
+
+        policy = aerospike_py.BatchPolicyInstance(
+            socket_timeout=2000, total_timeout=5000, max_retries=2
+        )
+        result = await async_client.batch_read(keys, policy=policy)
+        assert result == {f"a_{i}": {"i": i} for i in range(3)}
+
+    async def test_instance_and_dict_produce_equivalent_results(
+        self, async_client, async_cleanup
+    ):
+        """A pyclass instance with field X = V must behave identically to
+        ``{X: V}`` dict — verifies the parser parity."""
+        keys = [(NS, SET, f"eq_{i}") for i in range(3)]
+        for i, k in enumerate(keys):
+            async_cleanup.append(k)
+            await async_client.put(k, {"i": i})
+
+        instance = aerospike_py.BatchPolicyInstance(
+            socket_timeout=2000, total_timeout=5000, max_retries=2
+        )
+        dict_policy = {
+            "socket_timeout": 2000,
+            "total_timeout": 5000,
+            "max_retries": 2,
+        }
+        from_instance = await async_client.batch_read(keys, policy=instance)
+        from_dict = await async_client.batch_read(keys, policy=dict_policy)
+        assert from_instance == from_dict
+
+    def test_invalid_policy_arg_type_raises(self, client):
+        """Anything that is not a dict, ``BatchPolicyInstance``, or None
+        should fail at the type-check boundary."""
+        with pytest.raises(TypeError):
+            client.batch_read([(NS, SET, "k")], policy="not a policy")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Addresses **I. \`BatchPolicy\` Rust struct as first-class Python class** from issue #347 (also matches the original \`compile_batch_policy\` suggestion #1).

Every \`batch_read\` call currently parses the policy dict — ~10 field lookups + \`extract\` per call. For long-lived ML services that reuse the same policy on every request, that work is wasted.

Adds \`aerospike_py.BatchPolicyInstance\` — a Python class that holds **pre-parsed** \`BatchPolicy\` and \`BatchReadPolicy\` structs. Construct once at startup, pass on every \`batch_read\`; the Rust side skips the dict parser entirely and clones the cached structs.

\`\`\`python
# Once, at service startup
POLICY = aerospike_py.BatchPolicyInstance(
    socket_timeout=2000,
    total_timeout=5000,
    max_retries=2,
    concurrency=1,
)

# Every request
result = await client.batch_read(keys, policy=POLICY)
\`\`\`

## Backward compatibility

\`batch_read\`'s \`policy\` argument now accepts **dict OR \`BatchPolicyInstance\`** — existing dict callers are unchanged. Type-checked at the Rust boundary via \`parse_batch_policy_arg\`: pyclass extraction first, dict fallback, anything else → \`TypeError\`.

## Naming choice

The public symbol is **\`BatchPolicyInstance\`** (not \`BatchPolicy\`). This avoids colliding with the existing \`BatchPolicy\` TypedDict used for static typing of dict-shaped policies. Both are now exported and serve distinct purposes:

| Symbol | Purpose |
|---|---|
| \`aerospike_py.BatchPolicy\` (TypedDict) | Static type hint for dict-shaped policies — \`policy: BatchPolicy = {...}\` |
| \`aerospike_py.BatchPolicyInstance\` (pyclass) | Runtime instance, pre-parsed at construction — \`policy = BatchPolicyInstance(...)\` |

## Scope of this PR

Signature change is limited to \`batch_read\` (sync and async). \`batch_operate\`, \`batch_write\`, \`batch_remove\`, etc. continue to accept dict only. Extending the type union to the rest of the batch surface is mechanical and left for a follow-up so this PR stays focused on the read path that issue #347 prioritizes.

## Changes

| File | Change |
|---|---|
| \`rust/src/policy/batch_policy.rs\` | New \`PyBatchPolicy\` (\`#[pyclass(name = "BatchPolicyInstance", frozen)]\`) holding pre-parsed \`(BatchPolicy, BatchReadPolicy)\`; \`#[new]\` constructor with kwargs-only typed signature; \`parse_batch_policy_arg\` helper that handles both dict and pyclass paths |
| \`rust/src/lib.rs\` | Register the new class with the \`_aerospike\` module |
| \`rust/src/client_common.rs\` | \`prepare_batch_read_args\` now takes \`Option<&Bound<'_, PyAny>>\` and goes through \`parse_batch_policy_arg\` |
| \`rust/src/client.rs\` + \`rust/src/async_client.rs\` | \`batch_read\` method signature: \`policy: Option<&Bound<'_, PyAny>>\` |
| \`src/aerospike_py/__init__.py\` | Re-export \`BatchPolicyInstance\` + add to \`__all__\` |
| \`src/aerospike_py/__init__.pyi\` | New \`BatchPolicyInstance\` type stub with kwargs-only constructor signature |
| \`tests/integration/test_batch_policy_instance.py\` | 8 new tests |

## Test plan

- [x] \`cargo check\` — clean
- [x] \`make test-unit\` — 894 pass (no regression)
- [x] \`test_batch_policy_instance.py\` — 8/8 pass against local Aerospike CE 8.1
  - Constructor: no kwargs / typed kwargs / unknown kwarg rejection / positional-arg rejection (kwargs-only)
  - Sync \`Client.batch_read\` accepts an instance
  - Async \`AsyncClient.batch_read\` accepts an instance
  - **Pyclass instance and equivalent dict policy produce identical results** (parser parity contract)
  - Invalid policy type (e.g. string) raises \`TypeError\` at the Rust boundary
- [x] Existing \`test_batch.py\` + \`test_batch_handle.py\` (54/54) pass unchanged
- [ ] CI: full test matrix

## Filter expression handling

\`filter_expression\` is also accepted at construction time and parsed once — same path as the dict-shaped version, but evaluated when the pyclass is built rather than on every call.

🤖 Authored with [Claude Code](https://claude.com/claude-code)