### PR TITLE
chore(release): shift daily release schedule to KST 07:00

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -1,10 +1,10 @@
 name: Daily Release
-# Runs daily at KST 09:00 (UTC 00:00). Auto-releases if there are changes since the last release.
+# Runs daily at KST 07:00 (UTC 22:00 previous day). Auto-releases if there are changes since the last release.
 # Conventional Commits-based version bump: feat → minor, fix → patch, breaking → major
 
 on:
   schedule:
-    - cron: "0 0 * * *" # UTC 00:00 = KST 09:00
+    - cron: "0 22 * * *" # UTC 22:00 = KST 07:00
   workflow_dispatch: # manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary
- Move the daily auto-release cron from `0 0 * * *` (UTC 00:00 / KST 09:00) to `0 22 * * *` (UTC 22:00 / KST 07:00) so the release lands at 07:00 KST every morning.
- Update the file header and inline comment to match the new schedule.

## Test plan
- [ ] Confirm GitHub renders the new cron on the Actions tab (schedule shows next run at UTC 22:00).
- [ ] Manually trigger via `workflow_dispatch` to verify the release path is unaffected by the timing change.