### PR TITLE
fix(batch): drop errored records from batch_to_dict_py and tighten retry merge

### DIFF
--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -382,7 +382,10 @@ pub fn batch_to_dict_py<'py>(
             None => continue, // skip records without user_key
         };
 
-        // Only process successful reads
+        // Skip per-record errors even if a body was returned (e.g. FilteredOut, RecordTooBig)
+        if !matches!(&br.result_code, None | Some(ResultCode::Ok)) {
+            continue;
+        }
         if let Some(record) = &br.record {
             let bins = PyDict::new(py);
             for (name, value) in &record.bins {

--- a/rust/src/client_ops.rs
+++ b/rust/src/client_ops.rs
@@ -480,7 +480,12 @@ pub async fn do_batch_write(
                 retry_results.len()
             );
         }
-        for (original_idx, retry_record) in retry_indices.iter().copied().zip(retry_results) {
+        let update_count = retry_results.len().min(retry_indices.len());
+        for (original_idx, retry_record) in retry_indices[..update_count]
+            .iter()
+            .copied()
+            .zip(retry_results)
+        {
             results[original_idx] = retry_record;
         }
     }


### PR DESCRIPTION
## Summary

Two small batch-handling correctness fixes surfaced in the 2026-05-16 code review.

## Changes

- **`rust/src/batch_types.rs` (P0)**: `batch_to_dict_py` now checks `br.result_code` before emitting the record into the result dict. Previously, error records that still carried a body (e.g. `FilteredOut`, `RecordTooBig`) would leak into `as_dict()` output as if they were successful reads. The check uses the same `matches!(&br.result_code, None | Some(ResultCode::Ok))` pattern as `found_count` (~line 286), so behavior is consistent across the file.
- **`rust/src/client_ops.rs` (P1)**: In the `do_batch_write` retry path, when `retry_results.len() != retry_indices.len()` the previous `zip` would silently truncate to the shorter side. Now `retry_indices` is explicitly sliced to `retry_results.len().min(retry_indices.len())` so the partial-batch truncation is deliberate. The pre-existing warning log on the length mismatch is unchanged.

## Test Plan

- [x] `cargo check --manifest-path rust/Cargo.toml --all-features` passes
- [x] `pre-commit run --files rust/src/batch_types.rs rust/src/client_ops.rs` passes (trim-whitespace, end-of-files, detect-private-key, cargo fmt, cargo clippy)
- [ ] Unit tests pass (`make test-unit`) — not run locally (CI will run full suite)
- [ ] Lint passes (`make lint`) — clippy ran clean via pre-commit
- [ ] Type check passes (`make typecheck`) — no Python surface changed

Manual reasoning:
- Fix #1 only adds an early-`continue` guard before the existing `if let Some(record)` arm; semantics for `ResultCode::Ok` / `None` (no per-record error) are unchanged. Records with non-OK result codes are now dropped instead of being silently surfaced as successful.
- Fix #2 changes only the slice bound for the `zip` iterator. When `retry_results.len() <= retry_indices.len()` (the partial-response case), behavior is identical to before. The new `.min()` only guards against the reverse case (`retry_results.len() > retry_indices.len()`), which would have indexed out-of-bounds via `retry_indices[..update_count]` had `update_count` not been clamped.

## Breaking Changes

None. Both changes are bug fixes on internal Rust code paths; no public Python API surface is affected.