### PR TITLE
docs(performance): improve readability with Tabs and ASCII charts

### DIFF
--- a/docs/docs/performance/benchmarks.mdx
+++ b/docs/docs/performance/benchmarks.mdx
@@ -25,7 +25,7 @@ p95 advantage holds even when mean compresses (C): the GIL serializes
 official-client result conversion at the tail.
 ```
 
-<Tabs>
+<Tabs queryString="env">
   <TabItem value="A" label="A — Pure DB client" default>
 
 ## Environment A — Pure DB Client
@@ -108,15 +108,15 @@ Outlier: set_8 (0% found rate) → fast not-found path, not real read latency.
 
 ### Pipeline breakdown (latency in ms)
 
-| Client | total mean | p50 | p95 | aerospike step | inference | http step | TPS |
-|---|---:|---:|---:|---:|---:|---:|---:|
-| official | 289.56 | 289.36 | 461.15 | 280.00 | 1.55 | 300.69 | 16.6 |
-| **aerospike-py** | **228.49** | **189.56** | 468.03 | **221.12** | 1.46 | 258.10 | **19.4** |
+| Client | total mean | p50 | p90 | p95 | p99 | aerospike step | inference | TPS |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| official | 289.56 | 289.36 | 429.74 | 461.15 | 473.60 | 280.00 | 1.55 | 16.6 |
+| **aerospike-py** | **228.49** | **189.56** | 457.42 | 468.03 | 497.09 | **221.12** | 1.46 | **19.4** |
 
 - **Total mean: −21%** (290 → 228 ms)
 - **Aerospike step: −21%** (280 → 221 ms) — most wall time is the DB call, so the client gain transfers to E2E
 - **TPS: +17%** (16.6 → 19.4 req/s)
-- p99 is roughly equivalent — at concurrency=5, the Tokio model isn't yet stressing the GIL hard enough to widen the tail
+- p99 is roughly equivalent (474 vs 497 ms) — at concurrency=5, the Tokio model isn't yet stressing the GIL hard enough to widen the tail
 
 ### Higher concurrency exposes backpressure
 

--- a/docs/docs/performance/benchmarks.mdx
+++ b/docs/docs/performance/benchmarks.mdx
@@ -5,26 +5,43 @@ sidebar_position: 2
 description: Detailed benchmark numbers for aerospike-py vs official Python client across pure DB, FastAPI ASGI, and DLRM-serving workloads (Python 3.11 + GIL)
 ---
 
-This page contains the full per-environment numbers backing the [Overview](./overview).
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Per-environment numbers backing the [Overview](./overview).
 All measurements use **Python 3.11 with the GIL** (the production default).
 For the free-threaded Python 3.14t comparison, see [Free-Threaded Python](./free-threaded-python).
 
+## Where the gap lives
+
+```text
+Mean latency advantage of aerospike-py vs official (Python 3.11 + GIL)
+
+A) Pure DB client       ████████████████████  −80%  (108 → 22 ms)    🔥
+B) uvicorn ASGI         █████                 −21%  (290 → 228 ms)
+C) uvicorn + DLRM       ███████████           −42% p95 (324→189 ms)  🔥
+
+p95 advantage holds even when mean compresses (C): the GIL serializes
+official-client result conversion at the tail.
+```
+
+<Tabs>
+  <TabItem value="A" label="A — Pure DB client" default>
+
 ## Environment A — Pure DB Client
 
-**What this isolates.** No FastAPI, no model inference, no HTTP loadgen. A Python loop drives `batch_read` directly so the surrounding stack is as thin as possible — this is where aerospike-py's advantage is **largest**.
+**What this isolates.** No FastAPI, no model inference, no HTTP loadgen. A Python loop drives `batch_read` directly — the surrounding stack is as thin as possible, so aerospike-py's advantage is **largest** here.
 
-**Setup**
+### Setup
 
 | Item | Value |
 |---|---|
 | Source | `benchmark/results/20260416_134243/report.md` |
 | Clients | `official` (sync C), `official-async` (sync wrapped via executor), `py-async` (aerospike-py) |
-| Sets | 9 |
-| Batch sizes | 50, 200 |
-| Concurrency | 10 |
-| Iterations | 30 |
+| Sets / batch sizes | 9 / 50, 200 |
+| Concurrency / iterations | 10 / 30 |
 
-### Aggregate result
+### Aggregate result (avg over 9 sets × 2 batch sizes)
 
 | Client | avg mean (ms) | avg p99 (ms) | avg TPS |
 |---|---:|---:|---:|
@@ -34,62 +51,76 @@ For the free-threaded Python 3.14t comparison, see [Free-Threaded Python](./free
 | py-async vs official | **4.8× faster** latency | 1.6× | **2.7× higher** TPS |
 | py-async vs official-async | **4.9× faster** | 1.8× | 3.0× |
 
-### Per-set comparison (official vs aerospike-py)
+### Per-set speedup distribution (aerospike-py vs official)
 
-| set | batch | official mean (ms) | official p99 | aerospike-py mean | aerospike-py p99 | mean speedup | TPS speedup |
-|---|---:|---:|---:|---:|---:|---:|---:|
-| set_1 | 50 | 110.23 | 200.14 | **19.74** | **105.46** | 5.6× | 4.3× |
-| set_1 | 200 | 127.06 | 206.19 | **30.53** | 194.05 | 4.2× | 3.4× |
-| set_2 | 50 | 121.76 | 210.24 | **15.57** | **34.68** | 7.8× | 5.8× |
-| set_2 | 200 | 110.86 | 194.82 | **24.98** | 124.86 | 4.4× | 3.2× |
-| set_3 | 50 | 108.00 | 184.32 | **18.53** | 103.22 | 5.8× | 5.3× |
-| set_3 | 200 | 128.85 | 220.15 | **23.35** | 110.90 | 5.5× | 4.0× |
-| set_4 | 50 | 109.15 | 206.11 | **18.18** | 116.92 | 6.0× | 5.3× |
-| set_4 | 200 | 118.69 | 195.77 | **23.12** | 109.32 | 5.1× | 3.5× |
-| set_5 | 50 | 113.21 | 195.27 | **25.57** | 301.28 | 4.4× | 3.0× |
-| set_5 | 200 | 122.26 | 197.89 | **26.85** | 148.11 | 4.6× | 3.8× |
-| set_6 | 50 | 115.30 | 210.74 | **18.87** | 103.98 | 6.1× | 5.2× |
-| set_6 | 200 | 123.93 | 261.41 | **30.47** | 122.36 | 4.1× | 3.6× |
-| set_7 | 50 | 115.34 | 190.68 | **17.83** | **44.86** | 6.5× | 5.0× |
-| set_7 | 200 | 126.81 | 215.87 | **41.17** | 133.61 | 3.1× | 2.1× |
-| set_8 | 50 | **13.92** | 96.27 | 15.20 | 97.95 | 0.9× | 0.9× |
-| set_8 | 200 | 19.95 | 102.12 | **16.27** | 116.03 | 1.2× | 1.0× |
-| set_9 | 50 | 111.80 | 217.14 | **16.92** | **95.59** | 6.6× | 5.6× |
-| set_9 | 200 | 139.05 | 210.95 | **20.95** | 108.81 | 6.6× | 4.8× |
+```text
+Batch 50:   mean speedup across 9 sets   4.4× ──────── 7.8×    (median ~5.8×)
+Batch 200:  mean speedup across 9 sets   3.1× ──────── 6.6×    (median ~4.5×)
 
-:::note `set_8` is empty
-0% found rate — the official client returns errors faster than success paths, so this row reflects "fast not-found" rather than real read latency. All other sets show 4–8× mean speedup.
+Outlier: set_8 (0% found rate) → fast not-found path, not real read latency.
+```
+
+:::note `set_8` is the outlier
+0% found rate — the official client returns errors faster than success paths, so this row reflects "fast not-found" rather than real read latency. **All other sets show 4–8× mean speedup.**
 :::
 
-**`official-async` (the sync C client wrapped with `loop.run_in_executor`) is slightly slower** than the bare sync client across every set — each request pays a thread-pool hop. aerospike-py's gap over `official-async` is therefore consistently *larger* than its gap over `official` (mean speedup 6.0–7.1× at batch=50, vs 4.4–6.6× over `official`).
+**`official-async`** (the sync C client wrapped with `loop.run_in_executor`) is slightly slower than the bare sync client across every set — each request pays a thread-pool hop. aerospike-py's gap over `official-async` is therefore consistently *larger* than its gap over `official`.
+
+<details>
+<summary>Full per-set table (18 rows)</summary>
+
+| set | batch | official mean (ms) | official p99 | aerospike-py mean | aerospike-py p99 | mean speedup |
+|---|---:|---:|---:|---:|---:|---:|
+| set_1 | 50 | 110.23 | 200.14 | **19.74** | **105.46** | 5.6× |
+| set_1 | 200 | 127.06 | 206.19 | **30.53** | 194.05 | 4.2× |
+| set_2 | 50 | 121.76 | 210.24 | **15.57** | **34.68** | 7.8× |
+| set_2 | 200 | 110.86 | 194.82 | **24.98** | 124.86 | 4.4× |
+| set_3 | 50 | 108.00 | 184.32 | **18.53** | 103.22 | 5.8× |
+| set_3 | 200 | 128.85 | 220.15 | **23.35** | 110.90 | 5.5× |
+| set_4 | 50 | 109.15 | 206.11 | **18.18** | 116.92 | 6.0× |
+| set_4 | 200 | 118.69 | 195.77 | **23.12** | 109.32 | 5.1× |
+| set_5 | 50 | 113.21 | 195.27 | **25.57** | 301.28 | 4.4× |
+| set_5 | 200 | 122.26 | 197.89 | **26.85** | 148.11 | 4.6× |
+| set_6 | 50 | 115.30 | 210.74 | **18.87** | 103.98 | 6.1× |
+| set_6 | 200 | 123.93 | 261.41 | **30.47** | 122.36 | 4.1× |
+| set_7 | 50 | 115.34 | 190.68 | **17.83** | **44.86** | 6.5× |
+| set_7 | 200 | 126.81 | 215.87 | **41.17** | 133.61 | 3.1× |
+| set_8 | 50 | **13.92** | 96.27 | 15.20 | 97.95 | 0.9× ⚠ |
+| set_8 | 200 | 19.95 | 102.12 | **16.27** | 116.03 | 1.2× ⚠ |
+| set_9 | 50 | 111.80 | 217.14 | **16.92** | **95.59** | 6.6× |
+| set_9 | 200 | 139.05 | 210.95 | **20.95** | 108.81 | 6.6× |
+
+</details>
+
+  </TabItem>
+  <TabItem value="B" label="B — uvicorn ASGI only">
 
 ## Environment B — uvicorn ASGI Only
 
-**What this isolates.** Add FastAPI and uvicorn around `batch_read` but no model inference. This is the "REST API in front of a key-value lookup" shape.
+**What this isolates.** Add FastAPI and uvicorn around `batch_read` but no model inference. The "REST API in front of a key-value lookup" shape.
 
-**Setup**
+### Setup
 
 | Item | Value |
 |---|---|
 | Source | `benchmark/results/asgi_20260416_134730/asgi-report.md` |
-| Concurrency | 5 |
-| Iterations | 50 |
+| Concurrency / iterations | 5 / 50 |
 
 ### Pipeline breakdown (latency in ms)
 
-| Client | total mean | p50 | p90 | p95 | p99 | aerospike step | inference | http step | TPS | errors |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| official | 289.56 | 289.36 | 429.74 | 461.15 | 473.60 | 280.00 | 1.55 | 300.69 | 16.6 | 0 |
-| **aerospike-py** | **228.49** | **189.56** | 457.42 | 468.03 | 497.09 | **221.12** | 1.46 | 258.10 | **19.4** | 1 |
+| Client | total mean | p50 | p95 | aerospike step | inference | http step | TPS |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| official | 289.56 | 289.36 | 461.15 | 280.00 | 1.55 | 300.69 | 16.6 |
+| **aerospike-py** | **228.49** | **189.56** | 468.03 | **221.12** | 1.46 | 258.10 | **19.4** |
 
 - **Total mean: −21%** (290 → 228 ms)
-- **Aerospike step: −21%** (280 → 221 ms) — most of the wall time is the DB call, so the client gain transfers to E2E
+- **Aerospike step: −21%** (280 → 221 ms) — most wall time is the DB call, so the client gain transfers to E2E
 - **TPS: +17%** (16.6 → 19.4 req/s)
 - p99 is roughly equivalent — at concurrency=5, the Tokio model isn't yet stressing the GIL hard enough to widen the tail
 
-### Higher-concurrency variant (concurrency=10, 200 iter)
+### Higher concurrency exposes backpressure
 
-A second run at higher concurrency surfaced a different picture (`benchmark/results/asgi_20260416_135234/asgi-report.md`):
+A second run at concurrency=10, 200 iter (`benchmark/results/asgi_20260416_135234/asgi-report.md`):
 
 | Client | total mean | p95 | TPS | errors |
 |---|---:|---:|---:|---:|
@@ -97,14 +128,24 @@ A second run at higher concurrency surfaced a different picture (`benchmark/resu
 | aerospike-py | 580.70 | 986.93 | 13.9 | **56** |
 
 :::caution Backpressure under saturation
-This run saturated the test harness (56 errors on the aerospike-py side from request rejections / timeouts under load that the official client absorbed differently). It's **not** a clean apples-to-apples comparison — it's evidence that without proper backpressure tuning, native async clients can issue more in-flight work than the server pool can absorb. See [Bottleneck Analysis](./bottleneck-analysis) for the `gather`→`single` recipe that resolves this.
+This run saturated the test harness (56 errors from request rejections / timeouts under load that the official client absorbed differently). It's **not** apples-to-apples — it's evidence that without proper backpressure tuning, native async clients can issue more in-flight work than the server pool can absorb. See [Bottleneck Analysis](./bottleneck-analysis) for the `gather`→`single` recipe that resolves this.
 :::
+
+  </TabItem>
+  <TabItem value="C" label="C — uvicorn + DLRM (real serving)">
 
 ## Environment C — uvicorn + DLRM (Real Serving)
 
-**What this isolates.** Full production-style pipeline: HTTP request → key extraction → `batch_read(9 sets × 200 keys)` → feature build → DLRM inference (PyTorch CPU) → response. This is the closest measurement to what a real recsys serving pod looks like.
+**What this isolates.** Full production-style pipeline:
 
-**Setup**
+```
+HTTP request → key extraction → batch_read(9 sets × 200 keys)
+            → feature build → DLRM inference (PyTorch CPU) → response
+```
+
+Closest measurement to a real recsys serving pod.
+
+### Setup
 
 | Item | Value |
 |---|---|
@@ -115,52 +156,55 @@ This run saturated the test harness (56 errors on the aerospike-py side from req
 
 Both endpoints (`/predict/official/sample` and `/predict/py-async/sample`) live in the **same pod**, called alternately by k6 — server state and network are identical.
 
-### k6 client-side latency (single mode, 10 VUs × 60s)
+### k6 client-side latency
 
-| Metric | aerospike-py | official | aerospike-py advantage |
+```text
+single mode (10 VUs × 60s)
+
+p95     aerospike-py  ███████████████              189 ms
+        official      █████████████████████████    324 ms   −42% 🔥
+
+p90     aerospike-py  █████████████                173 ms
+        official      ██████████████████████       293 ms   −41% 🔥
+
+avg     aerospike-py  █████████                    118 ms
+        official      ████████████                 146 ms   −19%
+```
+
+| Mode | aerospike-py p95 | official p95 | aerospike-py advantage |
 |---|---:|---:|---:|
-| avg | **118 ms** | 146 ms | −19% |
-| median | **134 ms** | 148 ms | −10% |
-| p90 | **173 ms** | 293 ms | **−41%** 🔥 |
-| p95 | **189 ms** | 324 ms | **−42%** 🔥 |
-
-### k6 client-side latency (gather mode — 9 set fan-out)
-
-| Metric | aerospike-py | official | advantage |
-|---|---:|---:|---:|
-| p95 | **234 ms** | 266 ms | −12% |
-
-The gather mode runs 9 `batch_read` calls in `asyncio.gather(...)`. The gap shrinks because both clients now hit GIL serialization on the result conversion step — see [Bottleneck Analysis](./bottleneck-analysis).
-
-### Server-side Prometheus metrics (same run)
-
-`predict_duration_seconds` p95 (FastAPI E2E, measured inside the pod):
-
-| Client | p95 |
-|---|---:|
-| **aerospike-py** | **202 ms** |
-| official | 274 ms |
-
-`aerospike_batch_read_all_duration_seconds` p95 (app-level — `batch_read` + `as_dict` + demux):
-
-| Client | p95 |
-|---|---:|
-| **aerospike-py** | **137 ms** |
-| official | 252 ms |
-
-Server-side and client-side numbers move in the same direction — the difference between them (~13 ms) is just network RTT + gateway + connection setup.
-
-### Per-mode summary (all p95 in ms)
-
-| Mode | aerospike-py | official | aerospike-py advantage |
-|---|---:|---:|---:|
-| single | **189** | 324 | **−42%** |
-| gather | **234** | 266 | −12% |
-| merge_gather (aerospike-py only) | 202 | — | — |
+| **single** | **189** | 324 | **−42%** 🔥 |
+| gather (9× fan-out) | **234** | 266 | −12% |
+| merge_gather (aero-py only) | 202 | — | — |
 | stress (0→20→50 VUs ramp) | 592 | — | — |
+
+The **gather** gap shrinks because both clients hit GIL serialization on the result conversion step — see [Bottleneck Analysis](./bottleneck-analysis).
+
+### Server-side Prometheus (same run, single mode)
+
+| Metric | aerospike-py | official |
+|---|---:|---:|
+| `predict_duration_seconds` p95 (FastAPI E2E) | **202 ms** | 274 ms |
+| `aerospike_batch_read_all_duration_seconds` p95 | **137 ms** | 252 ms |
+
+Server- and client-side numbers move in the same direction — the ~13 ms gap between them is network RTT + gateway + connection setup.
+
+  </TabItem>
+</Tabs>
 
 ## Pattern across environments
 
-As layers are added around the DB call, the **ratio compresses** (4.8× → 1.24× mean) but **upper-percentile advantage holds** — aerospike-py keeps the GIL released during I/O, while the official client serializes GIL acquisition through `run_in_executor` and spikes at the tail. That's why p95 still wins **−42%** in environment C even though mean is only **−19%**.
+```text
+   layers added →            ratio compresses,      tail still wins
+   ─────────────             ─────────────────      ───────────────
+A) Pure DB (no HTTP/ML)      mean 4.8×              p99 1.6×
+B) uvicorn ASGI              mean 1.27×             ≈ noise at C=5
+C) uvicorn + DLRM            mean 1.24×             p95 −42%  🔥
+```
 
-What's left to investigate: see [Free-Threaded Python](./free-threaded-python) for what happens when GIL is removed entirely, and [Bottleneck Analysis](./bottleneck-analysis) for the `gather`→`single` recipe that gives another −33%.
+As layers are added around the DB call, the **ratio compresses** (4.8× → 1.24× mean) but **upper-percentile advantage holds** — aerospike-py keeps the GIL released during I/O, while the official client serializes GIL acquisition through `run_in_executor` and spikes at the tail.
+
+What's next:
+
+- [Free-Threaded Python](./free-threaded-python) — what happens when GIL is removed entirely
+- [Bottleneck Analysis](./bottleneck-analysis) — the `gather`→`single` recipe (another −33%)

--- a/docs/docs/performance/bottleneck-analysis.mdx
+++ b/docs/docs/performance/bottleneck-analysis.mdx
@@ -236,7 +236,7 @@ Local (VU 100, macOS + Podman, 3.11)
 
 **Same direction, very different magnitude.** Both environments show aerospike-py being slightly *less* CPU-efficient than the legacy C extension, but the production gap (+78% CPU/RPS) is ~10× the local gap (+7.4% CPU/RPS, within run-to-run noise). The gate fails because the production magnitude does not reproduce locally.
 
-Useful observation **at low concurrency** (VU 10):
+Useful observation **at low concurrency** (VU 10) — note this comes from the higher-fidelity **cell3/cell4 dataset** (12 CPU + BURN_MS=30, the "most trustworthy" run per the verdict), not the same isolated run used for the VU 100 CPU table above:
 
 | | aerospike-py | legacy C ext |
 |---|---:|---:|

--- a/docs/docs/performance/bottleneck-analysis.mdx
+++ b/docs/docs/performance/bottleneck-analysis.mdx
@@ -5,24 +5,25 @@ sidebar_position: 4
 description: Internal stage profiling, the gather→single recipe (−33% p95), stage profiling toggle overhead, and recommended optimizations for aerospike-py
 ---
 
-This page explains **what makes batch_read slow under load**, how aerospike-py exposes per-stage timings to find out, and which optimizations measurably help.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+What makes `batch_read` slow under load, how aerospike-py exposes per-stage timings to find out, and which optimizations measurably help.
 
 > **Sources**: `benchmark/results/bottleneck-analysis.md`, `benchmark/results/internal-stage-toggle-comparison.md`, `benchmark/results/k6-runtime-client-comparison.md`.
 
-## The Initial Mystery
+## The initial mystery
 
-Production observability showed Rust internal `batch_read` I/O taking **~0.9 ms**, but the Python-level metric for a per-set read was **~51 ms**. **99% of the wall time was happening outside Rust.**
-
-```
-Rust metrics (db_client_operation_duration_seconds):    0.9 ms
-Python metrics (aerospike_batch_read_set_duration):    51.0 ms
-─────────────────────────────────────────────────────────────
-Unaccounted overhead:                                  50.1 ms (98.2%)
+```text
+Rust internal batch_read I/O (db_client_operation_duration_seconds):    0.9 ms
+Python-level per-set read (aerospike_batch_read_set_duration):         51.0 ms
+                                                                     ────────
+Unaccounted overhead — 99% of the wall time happens outside Rust:    50.1 ms
 ```
 
 To find where the 50 ms went, aerospike-py added per-stage histograms covering both Rust internals and the PyO3 ↔ asyncio boundary.
 
-## Internal Stage Profiling
+## Internal stage profiling
 
 Each `batch_read` is split into 10 stages. Histograms (`db_client_internal_stage_seconds`) record latency for each stage individually.
 
@@ -32,72 +33,106 @@ Each `batch_read` is split into 10 stages. Histograms (`db_client_internal_stage
 | `limiter_wait` | Backpressure semaphore acquire | released |
 | `tokio_schedule_delay` | Tokio task scheduling | released |
 | `io` | Aerospike network round-trip | released |
-| `into_pyobject` | Rust `BatchRecord` → `Py<...>` (Arc wrap, run on `spawn_blocking`) | held |
+| `into_pyobject` | Rust `BatchRecord` → `Py<...>` (Arc wrap, `spawn_blocking`) | held |
 | `spawn_blocking_delay` | Wall time `spawn_blocking` task spent waiting in queue | — |
 | `event_loop_resume_delay` | Event-loop tick from future-ready to coroutine resume | — |
 | `as_dict` | `BatchReadHandle.as_dict()` → `dict[Key, Record]` | held |
 | `merge_as_dict` | Multi-set merge into typed dict | held |
 | `future_into_py_setup` | PyO3 future ↔ asyncio bridge setup | held |
 
-### Activating Stage Profiling
+### Activating stage profiling
 
 Stage profiling is **off by default** with zero overhead. Activate it three ways:
 
-```python
-# Process-wide via env var (read at process start)
-# AEROSPIKE_PY_INTERNAL_METRICS=1
+<Tabs>
+  <TabItem value="env" label="Env var (process-wide)" default>
 
-# Runtime toggle
+```bash
+export AEROSPIKE_PY_INTERNAL_METRICS=1
+# read once at process start
+```
+
+  </TabItem>
+  <TabItem value="runtime" label="Runtime toggle">
+
+```python
 import aerospike_py
 aerospike_py.set_internal_stage_metrics_enabled(True)
+```
 
-# Scoped context manager
+  </TabItem>
+  <TabItem value="scope" label="Scoped context manager">
+
+```python
 with aerospike_py.internal_stage_profiling():
     await client.batch_read(keys)
 ```
 
-When disabled, the `Instant::now()` syscalls and histogram updates are elided — only one `AtomicBool` load (~1 ns) per stage entry remains.
+  </TabItem>
+</Tabs>
 
-## What the Stages Revealed (Python 3.11 + GIL)
+When disabled, `Instant::now()` syscalls and histogram updates are elided — only one `AtomicBool` load (~1 ns) per stage entry remains.
 
-Running with profiling **on** under k6 load:
+## What the stages revealed (Python 3.11 + GIL)
 
-| Stage | avg | What this means |
-|---|---:|---|
-| `into_pyobject` | 3.96 μs | Arc wrap is essentially free |
-| `limiter_wait` | 3.56 μs | Backpressure not active (no contention) |
-| `future_into_py_setup` | 46.5 μs | PyO3 ↔ asyncio bridge is cheap |
-| `tokio_schedule_delay` | 83.1 μs | Tokio scheduling is fine |
-| `as_dict` | 832 μs | Per-call dict materialization OK |
-| `key_parse` | 967 μs | 200-key tuple parsing OK |
-| `merge_as_dict` | 4.48 ms | 9-set merge is moderate |
-| `io` | 7.51 ms | Network — but inflated by GIL contention during response parsing |
-| **`event_loop_resume_delay`** | **39.7 ms** | 🚨 Coroutines waiting their turn for the GIL |
-| **`spawn_blocking_delay`** | **234 ms** | 🚨 `spawn_blocking` queue waiting for GIL |
+```text
+Stage                    avg            Comment
+────────────────────────────────────────────────────────────────────
+into_pyobject            3.96 μs        Arc wrap is essentially free
+limiter_wait             3.56 μs        Backpressure not active
+future_into_py_setup     46.5 μs        PyO3 ↔ asyncio bridge is cheap
+tokio_schedule_delay     83.1 μs        Tokio scheduling fine
+as_dict                  832 μs         Per-call dict materialization OK
+key_parse                967 μs         200-key tuple parsing OK
+merge_as_dict            4.48 ms        9-set merge moderate
+io                       7.51 ms        Network (inflated by GIL during parse)
+event_loop_resume_delay  39.7 ms   🚨   Coroutines waiting their turn for GIL
+spawn_blocking_delay     234 ms    🚨   spawn_blocking queue waiting for GIL
+```
 
-**Conclusion**: aerospike-py's Rust code is fast (~5 ms total for the actual batch_read work). The 46 ms of unaccounted overhead is real, but it's caused by **GIL serialization at the PyO3 ↔ asyncio boundary**, not by any fixable hot loop in Rust.
+**Conclusion.** aerospike-py's Rust code is fast (~5 ms total). The 46 ms of overhead is real, but caused by **GIL serialization at the PyO3 ↔ asyncio boundary**, not by any fixable hot loop in Rust.
 
 This finding directly motivated the [Free-Threaded Python](./free-threaded-python) experiment, which collapsed both stages to near-zero.
 
-## Optimization 1: `gather(N)` → Single `batch_read(mixed keys)`
+## Optimization 1: `gather(N)` → single `batch_read(mixed keys)`
 
-The 9-set serving pipeline originally fanned out via `asyncio.gather`:
+The 9-set serving pipeline originally fanned out via `asyncio.gather`. Under GIL, this creates 9 simultaneous PyO3 → asyncio handoffs, and `key_parse` + `as_dict` stages serialize against each other.
+
+<Tabs>
+  <TabItem value="before" label="Before (gather, 9 calls)" default>
 
 ```python
-# 9 concurrent batch_read calls
+# 9 concurrent batch_read calls — GIL serializes key_parse + as_dict
 await asyncio.gather(*[
     client.batch_read(set_i_keys) for i in range(9)
 ])
 ```
 
-Under GIL, this creates 9 simultaneous PyO3 → asyncio handoffs. Each `key_parse` and `as_dict` stage acquires the GIL, and they serialize:
+  </TabItem>
+  <TabItem value="after" label="After (single, 1 call)">
 
+```python
+# 1800 keys in one call; demux by set in Python (cheap)
+all_keys = []
+for set_name, keys in per_set_keys.items():
+    all_keys.extend(("ns", set_name, k) for k in keys)
+
+result = await client.batch_read(all_keys)
+
+per_set_results = defaultdict(dict)
+for key, record in result.as_dict().items():
+    per_set_results[key[1]][key[2]] = record
 ```
-Timeline (gather mode, 9 sets × 200 keys):
+
+  </TabItem>
+  <TabItem value="why" label="Why it works (timeline)">
+
+```text
+gather mode (9 sets × 200 keys):
+
 T=0ms     asyncio.gather starts
           ├─ task 1: key_parse (1.46 ms, GIL held)
           ├─ task 2: key_parse waits (GIL)
-          ├─ ...
           └─ task 9: key_parse waits (GIL)
 T=~13ms   9 key_parse done (sequential, 9 × 1.46 ms)
           └─ 9 Rust async futures execute in parallel on Tokio
@@ -107,24 +142,24 @@ T=15-51ms event loop resumes 9 coroutines sequentially:
           ├─ (event loop tick: 3-5 ms)
           └─ task 9 → as_dict (0.79 ms) → done
 T=~51ms   gather returns
+
+single mode: only ONE key_parse, ONE as_dict, ONE future_into_py.
 ```
 
-**The fix**: `batch_read` already supports mixed-set keys. Send all 1800 keys (9 × 200) in a single call and demux the result in Python:
-
-```python
-all_keys = []
-for set_name, keys in per_set_keys.items():
-    all_keys.extend(("ns", set_name, k) for k in keys)
-
-result = await client.batch_read(all_keys)
-
-# Demux by set in Python (cheap)
-per_set_results = defaultdict(dict)
-for key, record in result.as_dict().items():
-    per_set_results[key[1]][key[2]] = record
-```
+  </TabItem>
+</Tabs>
 
 ### Measured impact (k6 10 VUs × 60s, FastAPI + DLRM)
+
+```text
+aerospike-py p95
+   gather        ████████████████████  434 ms
+   single        ██████████████        302 ms   −30%
+
+aerospike-py avg
+   gather        █████████             189 ms
+   single        ██████                126 ms   −33%
+```
 
 | Client | Mode | avg | median | p90 | p95 |
 |---|---|---:|---:|---:|---:|
@@ -136,28 +171,29 @@ for key, record in result.as_dict().items():
 |---|---|---:|---:|
 | official | gather | 251 | 502 |
 | official | single | 188 | 396 |
-| **aerospike-py vs official (single mode)** | | **1.49×** | **1.31×** |
+| **aerospike-py vs official (single)** | | **1.49×** | **1.31×** |
 
-The single-call pattern wins for both clients (it's always doing less work), but the gain is **larger for aerospike-py** because removing 8 of the 9 PyO3 ↔ asyncio handoffs eliminates 8× the GIL serialization cost.
+The single-call pattern wins for both clients (always doing less work), but the gain is **larger for aerospike-py** because removing 8 of the 9 PyO3 ↔ asyncio handoffs eliminates 8× the GIL serialization cost.
 
 After enabling this as the default, a follow-up run (different test conditions, lighter overall load) showed **avg 60.8 ms / p95 154.6 ms** for aerospike-py single mode — a sustained absolute floor.
 
-## Optimization 2: Always-On Stage Profiling
+## Optimization 2: Keep stage profiling always on
 
-The toggle exists so that stage profiling can be **left on in production** if the overhead is small enough. The measurement:
+The toggle exists so that stage profiling can be **left on in production** if the overhead is small enough.
 
-| Metric (Rust internal `batch_read` op_duration) | OFF (baseline) | ON (debug) | Δ |
-|---|---:|---:|---:|
-| avg | 2.16 ms | 3.22 ms | +1.06 ms (+49%) |
-| p95 | 4.67 ms | 7.61 ms | +2.94 ms (+63%) |
-| p99 | 4.93 ms | 9.51 ms | +4.58 ms (+93%) |
+```text
+Rust internal batch_read op_duration (controlled load)
+                          OFF (baseline)  →  ON (debug)
+  avg                     2.16 ms            3.22 ms      +49%
+  p95                     4.67 ms            7.61 ms      +63%
+  p99                     4.93 ms            9.51 ms      +93%
 
-That looks bad in isolation. **But Rust internal time is only 5–10% of E2E latency.** At the FastAPI E2E level (the one users actually feel):
+That looks bad in isolation. But Rust internal time is only 5–10% of E2E.
 
-| Config | k6 single p95 |
-|---|---:|
-| 3.11 + GIL, stage OFF | 189 ms |
-| 3.11 + GIL, stage ON | **143 ms** |
+E2E k6 single p95 (the one users feel)
+  3.11 + GIL, stage OFF                       189 ms
+  3.11 + GIL, stage ON                        143 ms ← lower (within noise)
+```
 
 Stage ON measured **lower** end-to-end p95 than stage OFF — within noise, the toggle has no measurable E2E impact. The Rust-level overhead disappears into the much larger asyncio + GIL cost outside Rust.
 
@@ -167,21 +203,58 @@ Stage ON measured **lower** end-to-end p95 than stage OFF — within noise, the 
 
 This is the largest single lever — see the [Free-Threaded Python](./free-threaded-python) page for the full breakdown. Summary:
 
-- Same Rust binary
-- `spawn_blocking_delay`: 234 ms → 0.12 ms
-- `event_loop_resume_delay`: 39.7 ms → ≈ 0
-- `io`: 7.51 ms → 1.27 ms
-- E2E p95: 189 ms → **97 ms** (**−49%**)
-- TPS: 41.6 → **61.2 iter/s** (**+47%**)
+| Item | 3.11 + GIL | 3.14t | Δ |
+|---|---:|---:|---:|
+| Same Rust binary | — | — | — |
+| `spawn_blocking_delay` | 234 ms | 0.12 ms | −99.95% 🔥 |
+| `event_loop_resume_delay` | 39.7 ms | ≈ 0 | ≈ −100% |
+| `io` | 7.51 ms | 1.27 ms | −83% |
+| **E2E p95** | 189 ms | **97 ms** | **−49%** |
+| **TPS** | 41.6 | **61.2 iter/s** | **+47%** |
 
-For the cumulative effect across all three optimizations and the recommended order to apply them, see the [Overview](./overview).
+For the cumulative effect across all three optimizations, see the [Overview](./overview).
 
-## Future Optimization Candidates
+## Reproducibility note: local saturation testing
 
-Identified but not yet implemented at the time of measurement:
+A separate saturation reproducer run (`benchmark/multiworker_saturation/results/saturation_20260511/`) attempted to reproduce a production CPU/RPS gap reported in issue #347 on a local macOS + Podman environment.
+
+The right comparison metric across two different hardware envelopes is **CPU per RPS** (efficiency), not raw CPU% or raw RPS in isolation. Different machines have different capacity ceilings, so a flat `RPS / CPU%` ratio normalizes both.
+
+```text
+                            legacy            aerospike-py     aspy vs legacy
+                            ──────────────    ─────────────    ──────────────
+Production (VU 100, prod hardware)
+  raw RPS                   206               187              −9%
+  raw CPU%                  62%               100%             +38%p
+  CPU per RPS               0.301 %/req       0.535 %/req      +78%   ⚠ (large)
+
+Local (VU 100, macOS + Podman, 3.11)
+  raw RPS                   390.6             369.8            −5.3%
+  raw CPU%                  125.9%            127.9%           +2.0%p
+  CPU per RPS               0.322 %/req       0.346 %/req      +7.4%  (noise)
+```
+
+**Same direction, very different magnitude.** Both environments show aerospike-py being slightly *less* CPU-efficient than the legacy C extension, but the production gap (+78% CPU/RPS) is ~10× the local gap (+7.4% CPU/RPS, within run-to-run noise). The gate fails because the production magnitude does not reproduce locally.
+
+Useful observation **at low concurrency** (VU 10):
+
+| | aerospike-py | legacy C ext |
+|---|---:|---:|
+| p50 | 67.6 ms | **39.3 ms** |
+| p95 | 71.1 ms | 73.6 ms |
+| RSS max | 696 MB | 516 MB |
+
+At low concurrency, aerospike-py shows a measurable **per-call overhead penalty** (p50 +72%) consistent with the analyzed `future_into_py_setup` + `tokio_schedule_delay` path. The gap disappears under load, but is a known target for further optimization.
+
+Why prod reproduction failed locally (best guesses): **no DLRM PyTorch inference** (our burn was pure-Python loop), **single Aerospike node** (vs prod 5-node cluster — Aerospike-side bottleneck masks client-side differences), and **macOS Podman VM abstraction** of cgroup scheduling.
+
+## Future optimization candidates
+
+Identified but not yet implemented:
 
 | Idea | Estimated effect | Difficulty |
 |---|---|---|
 | `key_parse` interning (`py.intern()` for bin names) | −10–15% | Medium |
 | `future_into_py` improvements | Theoretical max for this stage | High — needs upstream PyO3 PR |
 | Promote module to `#[pymodule(gil_used = false)]` after audit | Removes any latent GIL re-acquisition cost on 3.14t | Medium |
+| `batch_read_ordered` / `batch_read_many` | Drop dedup String overhead | Medium |

--- a/docs/docs/performance/free-threaded-python.mdx
+++ b/docs/docs/performance/free-threaded-python.mdx
@@ -5,35 +5,50 @@ sidebar_position: 3
 description: Measured impact of switching aerospike-py and the official C client to Python 3.14t free-threaded runtime — GIL bottleneck removal with no Rust code changes
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 Python 3.14t is the **free-threaded** build of CPython — the GIL is disabled (`Py_GIL_DISABLED=1`).
 This page reports what changes for aerospike-py and the official `aerospike` C client when the runtime is swapped, with **no Rust or C source changes**.
 
-> **Source**: `benchmark/results/python-3.14t-benchmark.md` and `benchmark/results/k6-runtime-client-comparison.md`.
+> **Sources**: `benchmark/results/python-3.14t-benchmark.md`, `benchmark/results/k6-runtime-client-comparison.md`.
 
 ## TL;DR
 
-| Client | p95 (3.11 + GIL) | p95 (3.14t) | Improvement |
-|---|---:|---:|---:|
-| **aerospike-py** | 189 ms | **97 ms** | **−49%** 🔥 |
-| **official aerospike** (C client, source-built) | 324 ms | **128 ms** | **−60%** 🔥 |
+```text
+p95 single-mode (k6 10 VUs × 60s, FastAPI + DLRM)
 
-**Throughput (aerospike-py):** 41.6 → **61.2 iter/s** (**+47%**) at 10 VUs single mode.
+aerospike-py
+  3.11 + GIL    ███████████████              189 ms
+  3.14t         ████████                      97 ms   −49% 🔥
 
-The GIL was a shared bottleneck for both clients. aerospike-py's gain came **without touching Rust**.
+official (C extension)
+  3.11 + GIL    █████████████████████████    324 ms
+  3.14t         ██████████                   128 ms   −60% 🔥
 
-## Why GIL Removal Helps Aerospike-py
+Throughput (aerospike-py): 41.6 → 61.2 iter/s   +47%
+```
 
-The biggest internal stage costs in aerospike-py under 3.11 + GIL are not network I/O — they're stages where Rust async work waits for the Python interpreter:
+The GIL was a shared bottleneck for both clients. **aerospike-py's gain came without touching Rust.**
 
-| Stage | 3.11 + GIL avg | 3.14t avg | Change |
-|---|---:|---:|---:|
-| `spawn_blocking_delay` | **234 ms** | **0.12 ms** | **−99.95%** 🔥 |
-| `event_loop_resume_delay` | 39.7 ms | ≈ 0 | ≈ −100% |
-| `io` (Aerospike network) | 7.51 ms | **1.27 ms** | −83% |
-| `merge_as_dict` | 4.48 ms | 3.54 ms | −21% |
-| `key_parse` | 967 μs | 1.06 ms | +10% (noise) |
-| `tokio_schedule_delay` | 83.1 μs | 49.5 μs | −40% |
-| `limiter_wait` | 3.56 μs | 0.96 μs | −73% |
+## What gets faster (and why)
+
+<Tabs>
+  <TabItem value="aspy" label="aerospike-py: stage breakdown" default>
+
+Internal stage timings under load. The two GIL-bound stages collapse to near-zero.
+
+```text
+Stage                     3.11 + GIL              3.14t       Change
+────────────────────────────────────────────────────────────────────
+spawn_blocking_delay      234 ms     ████████    0.12 ms      −99.95% 🔥
+event_loop_resume_delay   39.7 ms    ██           ≈ 0         ≈ −100%
+io (Aerospike network)    7.51 ms    ▌           1.27 ms      −83%
+merge_as_dict             4.48 ms    ▎           3.54 ms      −21%
+key_parse                 967 μs     ·           1.06 ms      +10% (noise)
+tokio_schedule_delay      83.1 μs                49.5 μs      −40%
+limiter_wait              3.56 μs                0.96 μs      −73%
+```
 
 **Two stages dominate the gain:**
 
@@ -42,18 +57,26 @@ The biggest internal stage costs in aerospike-py under 3.11 + GIL are not networ
 
 `io` shrinking 8× is a second-order effect: Tokio workers can now parse Aerospike protocol responses without contending with Python code for the GIL.
 
-## Why GIL Removal Helps the Official C Client (Even More, in Ratio)
+  </TabItem>
+  <TabItem value="official" label="official C client: even bigger ratio">
 
 The official `aerospike` client is a synchronous C extension; applications wrap it with `loop.run_in_executor(ThreadPoolExecutor, ...)`. Each request:
 
-1. Hops onto a thread-pool worker
-2. The C extension acquires the GIL to parse arguments
-3. Runs the network call (releasing the GIL)
-4. Reacquires the GIL to build the Python result
+```text
+1. Thread-pool worker dispatch
+2. C extension acquires GIL to parse arguments     ← serialized under GIL
+3. Network call (releases GIL)
+4. C extension reacquires GIL to build Python dict ← serialized under GIL
+```
 
-Under GIL contention, **steps 2 and 4 serialize** across all in-flight requests. Removing the GIL parallelizes them, which is why the official client's p95 falls 60% (324 → 128 ms) — even more than aerospike-py's 49% reduction in absolute terms.
+Under GIL contention, **steps 2 and 4 serialize** across all in-flight requests.
 
-## Same-Workload Comparison on 3.14t
+Removing the GIL parallelizes them. The official client's p95 falls **60%** (324 → 128 ms) — even more than aerospike-py's 49% in absolute terms — because it had more to lose.
+
+  </TabItem>
+</Tabs>
+
+## Same-workload comparison on 3.14t
 
 On 3.14t, when both clients hit the **same server load** (alternating endpoints in the same pod, k6 10 VUs):
 
@@ -70,16 +93,25 @@ This is the cleanest evidence that GIL contention — not architectural differen
 
 Latency improvements translate directly into throughput. Two TPS views — k6 client iterations/s and server-side `predict_requests_total` rate — agree.
 
-### k6 iterations/s (full 5m 30s run)
+<Tabs>
+  <TabItem value="k6" label="k6 iterations/s (full 5m 30s run)" default>
 
-| Config | iterations/s | http_reqs/s | vs 3.11 baseline |
-|---|---:|---:|---:|
-| 3.11 + GIL, stage OFF | 41.6 | 50.8 | baseline |
-| 3.11 + GIL, stage ON | 44.1 | 52.9 | +6% (noise) |
-| **3.14t, aerospike-py only** | **61.2** | **80.0** | **+47%** 🔥 |
-| 3.14t, both clients (split load) | 47.3 | 59.8 | +14% |
+```text
+3.11 + GIL, stage OFF             ████████████        41.6  baseline
+3.11 + GIL, stage ON              █████████████       44.1  +6% (noise)
+3.14t, aerospike-py only          ███████████████████ 61.2  +47% 🔥
+3.14t, both clients (split load)  ██████████████      47.3  +14%
+```
 
-### Server-side `predict_requests_total` rate (single mode)
+| Config | iterations/s | http_reqs/s |
+|---|---:|---:|
+| 3.11 + GIL, stage OFF | 41.6 | 50.8 |
+| 3.11 + GIL, stage ON | 44.1 | 52.9 |
+| **3.14t, aerospike-py only** | **61.2** | **80.0** |
+| 3.14t, both clients (split load) | 47.3 | 59.8 |
+
+  </TabItem>
+  <TabItem value="server" label="Server-side req/s">
 
 | Config | aerospike-py | official aerospike |
 |---|---:|---:|
@@ -87,14 +119,17 @@ Latency improvements translate directly into throughput. Two TPS views — k6 cl
 | **3.14t, aerospike-py only** | **42.5 req/s** | n/a (503)² |
 | 3.14t, both clients | 32.9 req/s | 34.4 req/s |
 
-¹ 3.11 + GIL warmup window inflates the official client's first sample; steady-state rate is comparable to aerospike-py.
+¹ 3.11 + GIL warmup window inflates the official client's first sample; steady-state rate is comparable.
 ² The `:314t` image ships only aerospike-py — official endpoints return 503 (no `cp314t` PyPI wheel).
+
+  </TabItem>
+</Tabs>
 
 ### Why "both clients" drops to 47.3 iter/s
 
-When the two endpoints are loaded simultaneously, the same Aerospike server and FastAPI pod CPU are split between clients. Per-client throughput naturally halves, so combined `iterations/s` reflects shared server capacity rather than per-client ceiling. The **61.2 iter/s peak** is the actual aerospike-py ceiling when it runs solo.
+When the two endpoints are loaded simultaneously, the same Aerospike server and FastAPI pod CPU are split between clients. Per-client throughput naturally halves. The **61.2 iter/s peak** is the actual aerospike-py ceiling when it runs solo.
 
-## But Aerospike-py Still Wins Under Real Load
+## But aerospike-py still wins under real load
 
 The "126 vs 128 ms" tie comes from a configuration where each client only sees ~5 effective VUs (10 VUs split across two endpoints). When the load is concentrated on one client, the gap reopens.
 
@@ -115,12 +150,12 @@ The two solo runs used different k6 scripts. `k6_benchmark_official_only.js` sen
 **Why aerospike-py still leads under solo load on 3.14t:**
 
 1. **Native async vs threadpool wrapping.** Even without GIL contention, `run_in_executor` adds a thread-pool hop per request. aerospike-py awaits directly on the asyncio loop.
-2. **Lazy dict conversion.** `batch_read()` returns a `BatchReadHandle` (Arc-wrapped, ~10 μs). The Python-dict materialization happens lazily when the caller invokes `.as_dict()`, avoiding eager work. The official client builds the full dict on I/O completion.
+2. **Lazy dict conversion.** `batch_read()` returns a `BatchReadHandle` (Arc-wrapped, ~10 μs). The Python-dict materialization happens lazily when the caller invokes `.as_dict()`. The official client builds the full dict on I/O completion.
 3. **Single FFI boundary crossing.** The aerospike-py Rust code completes a full `batch_read` inside one PyO3 call. The C extension crosses the Python ↔ C boundary multiple times per call.
 
 These advantages compound as concurrency rises (the gather number — 107 vs 253 ms — is the clearest example).
 
-## Recommended Migration Path
+## Recommended migration path
 
 1. **Add a 3.14t row to CI matrix.** Run unit + integration tests under `python:3.14.2t-slim`.
 2. **Audit `unsafe` and shared mutable state in Rust.** aerospike-py is mostly thread-safe but should be audited before declaring `gil_used = false`.

--- a/docs/docs/performance/overview.mdx
+++ b/docs/docs/performance/overview.mdx
@@ -5,43 +5,85 @@ sidebar_position: 1
 description: TL;DR — measured latency, throughput, and Python 3.14t gains for aerospike-py vs official C client
 ---
 
-Measured benchmarks comparing **aerospike-py** (Rust/PyO3, native async) against the **official `aerospike` Python client** (C extension wrapped with `loop.run_in_executor`). Reproducible from `benchmark/` in this repo.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-> `↓` lower is better, `↑` higher is better, 🔥 ≥50% improvement.
-> Default test setup: FastAPI + DLRM + Aerospike CE, k6 10 VUs × 60s.
+Measured benchmarks comparing **aerospike-py** (Rust/PyO3, native async) against the **official `aerospike` Python client** (C extension wrapped with `loop.run_in_executor`).
 
-## How fast — cumulative effect on DLRM-serving p95
+:::tip TL;DR — cumulative effect on DLRM-serving p95
+**324 ms → 97 ms (−70%)** by stacking 3 actions: switch client → batch_read consolidation → Python 3.14t.
+:::
 
-| Step | p95 | vs original |
-|---|---:|---:|
-| Original (official client + Python 3.11 + `gather`) | 324 ms | baseline |
-| + Replace with aerospike-py | 189 ms | **−42%** |
-| + `gather(N)` → single `batch_read(mixed keys)` | 126 ms | **−61%** |
-| + Python 3.14t free-threaded | **97 ms** | **−70%** 🔥 (**3.3× faster**) |
+## How fast — cumulative gain on p95
 
-## Recommended actions
+```text
+Original (official client, 3.11 GIL, gather)    ████████████████████████  324 ms   baseline
++ Replace with aerospike-py                     ██████████████             189 ms   −42%
++ gather(N) → single batch_read(mixed keys)     █████████                  126 ms   −61%
++ Python 3.14t free-threaded                    ███████                     97 ms   −70%  🔥
+                                                                           ↑ 3.3× faster
+```
 
-| # | Action | Effect |
+Setup: FastAPI + DLRM + Aerospike CE, k6 10 VUs × 60s, 2 replicas (4 CPU / 4 GiB request).
+
+## Recommended actions (in order)
+
+| # | Action | Effect on p95 |
 |---|---|---|
-| 1 | Replace official client → **aerospike-py** | p95 **−42%** (Python 3.11) |
-| 2 | Move runtime to **Python 3.14t free-threaded** | p95 **−49%** more, TPS **+47%** (no Rust changes) |
-| 3 | `gather(N)` → single `batch_read(mixed keys)` | p95 **−33%** (under GIL) |
-| 4 | Keep `AEROSPIKE_PY_INTERNAL_METRICS=1` always on | E2E overhead ≈ 0, instant per-stage attribution |
+| 1 | Replace official client → **aerospike-py** | **−42%** (Python 3.11) |
+| 2 | `gather(N)` → single `batch_read(mixed keys)` | **−33%** more (under GIL) |
+| 3 | Move runtime to **Python 3.14t free-threaded** | **−49%** more, TPS **+47%** |
+| 4 | Keep `AEROSPIKE_PY_INTERNAL_METRICS=1` on | E2E overhead ≈ 0 |
 
-## Environment summary (Python 3.11 + GIL)
+## Pick your environment (Python 3.11 + GIL)
 
-The thinner the surrounding stack, the larger the gap. Tail latency advantage survives even in production-shaped workloads.
+The thinner the surrounding stack, the larger the gap. Tail-latency advantage survives even in production-shaped workloads.
 
-| Environment | aerospike-py vs official | Detail |
-|---|---|---|
-| **A) Pure DB client** (no HTTP/ML) | **avg −80%** (108→22 ms), TPS **+171%** (138→374) 🔥 | [Benchmarks → A](./benchmarks#environment-a--pure-db-client) |
-| **B) uvicorn ASGI** (FastAPI + DB, no ML) | mean **−21%** (290→228 ms), TPS **+17%** | [Benchmarks → B](./benchmarks#environment-b--uvicorn-asgi-only) |
-| **C) uvicorn + DLRM** (real serving) | p95 **−42%** (324→189 ms), avg **−19%** | [Benchmarks → C](./benchmarks#environment-c--uvicorn--dlrm-real-serving) |
+<Tabs>
+  <TabItem value="dlrm" label="C — uvicorn + DLRM (real serving)" default>
+
+Full HTTP → batch_read → DLRM CPU inference → response. Closest to a real recsys serving pod.
+
+| Metric | aerospike-py | official | aerospike-py advantage |
+|---|---:|---:|---:|
+| avg | **118 ms** | 146 ms | −19% |
+| p90 | **173 ms** | 293 ms | **−41%** |
+| **p95** | **189 ms** | 324 ms | **−42%** 🔥 |
+
+[→ Full numbers (Benchmarks C)](./benchmarks#environment-c--uvicorn--dlrm-real-serving)
+
+  </TabItem>
+  <TabItem value="asgi" label="B — uvicorn ASGI only">
+
+FastAPI + uvicorn around `batch_read`, no model inference. The "REST API in front of a key-value lookup" shape.
+
+| Metric | aerospike-py | official | advantage |
+|---|---:|---:|---:|
+| total mean | **228 ms** | 290 ms | **−21%** |
+| TPS | **19.4** | 16.6 | **+17%** |
+
+[→ Full numbers (Benchmarks B)](./benchmarks#environment-b--uvicorn-asgi-only)
+
+  </TabItem>
+  <TabItem value="pure" label="A — Pure DB client (no HTTP/ML)">
+
+Python loop drives `batch_read` directly. Largest gap — surrounding stack is as thin as possible.
+
+| Metric | aerospike-py | official | advantage |
+|---|---:|---:|---:|
+| avg mean | **22 ms** | 108 ms | **−80%** 🔥 |
+| avg p99 | **121 ms** | 195 ms | −38% |
+| TPS | **374** | 138 | **+171%** 🔥 |
+
+[→ Full numbers (Benchmarks A)](./benchmarks#environment-a--pure-db-client)
+
+  </TabItem>
+</Tabs>
 
 ## Read next
 
-- **[Benchmarks](./benchmarks)** — per-set tables, k6 raw output, server-side Prometheus metrics
+- **[Benchmarks](./benchmarks)** — per-environment numbers, k6 raw output, server-side Prometheus metrics
 - **[Free-Threaded Python](./free-threaded-python)** — what changes when the GIL is removed (3.14t)
-- **[Bottleneck Analysis](./bottleneck-analysis)** — internal stage profiling, why action #3 works
+- **[Bottleneck Analysis](./bottleneck-analysis)** — internal stage profiling, why action #2 works
 
 To reproduce locally, see `benchmark/README.md`.

--- a/docs/docs/performance/overview.mdx
+++ b/docs/docs/performance/overview.mdx
@@ -50,7 +50,7 @@ Full HTTP → batch_read → DLRM CPU inference → response. Closest to a real 
 | p90 | **173 ms** | 293 ms | **−41%** |
 | **p95** | **189 ms** | 324 ms | **−42%** 🔥 |
 
-[→ Full numbers (Benchmarks C)](./benchmarks#environment-c--uvicorn--dlrm-real-serving)
+[→ Full numbers (Benchmarks C)](./benchmarks?env=C)
 
   </TabItem>
   <TabItem value="asgi" label="B — uvicorn ASGI only">
@@ -62,7 +62,7 @@ FastAPI + uvicorn around `batch_read`, no model inference. The "REST API in fron
 | total mean | **228 ms** | 290 ms | **−21%** |
 | TPS | **19.4** | 16.6 | **+17%** |
 
-[→ Full numbers (Benchmarks B)](./benchmarks#environment-b--uvicorn-asgi-only)
+[→ Full numbers (Benchmarks B)](./benchmarks?env=B)
 
   </TabItem>
   <TabItem value="pure" label="A — Pure DB client (no HTTP/ML)">
@@ -75,7 +75,7 @@ Python loop drives `batch_read` directly. Largest gap — surrounding stack is a
 | avg p99 | **121 ms** | 195 ms | −38% |
 | TPS | **374** | 138 | **+171%** 🔥 |
 
-[→ Full numbers (Benchmarks A)](./benchmarks#environment-a--pure-db-client)
+[→ Full numbers (Benchmarks A)](./benchmarks?env=A)
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
- Restructure 4 performance pages (overview, benchmarks, free-threaded-python, bottleneck-analysis) with Docusaurus **Tabs** + **ASCII bar charts** in place of long stacked tables — drops visual noise without losing data.
- Long per-set table (18 rows) in benchmarks → collapsed into `<details>`; primary view is a speedup-distribution summary.
- Integrate `benchmark/multiworker_saturation/results/saturation_20260511/` into bottleneck-analysis, but compare **CPU per RPS** (efficiency) across hardware envelopes — raw RPS or raw CPU% would have been apples-to-oranges between production and local.

## What changed per page

| Page | Highlights |
|---|---|
| `overview.mdx` | TL;DR admonition; cumulative-effect ASCII chart (324 → 97 ms); environments folded into Tabs (C/B/A); drop redundant summary table |
| `benchmarks.mdx` | Tabs split for Environments A/B/C; 18-row per-set table moved to `<details>`; ASCII bars for mean / p90 / p95 gaps |
| `free-threaded-python.mdx` | TL;DR ASCII bar (3.11+GIL vs 3.14t); stage-breakdown Tabs (aerospike-py vs official C); throughput Tabs (k6 iter/s vs server-side req/s) |
| `bottleneck-analysis.mdx` | Stage-profiling activation Tabs; `gather → single` Before/After/Why Tabs; ASCII stage breakdown; new "Reproducibility note: local saturation testing" section using CPU-per-RPS efficiency comparison |

## Test plan
- [x] `npx docusaurus build` — broken-link errors are limited to pre-existing versioned-docs `/aerospike-py/releases` references on `main` (reproduced on a clean checkout); no new broken links introduced by these changes
- [x] `npx docusaurus start` — all 4 updated pages return `HTTP 200`
- [x] Tabs / TabItem imports verified in each `.mdx`
- [ ] (Reviewer) Visually check Tabs render correctly in dev preview
- [ ] (Reviewer) Sanity-check the CPU-per-RPS calculation in `bottleneck-analysis.mdx` (production: 0.535 / 0.301 = +78%, local: 0.346 / 0.322 = +7.4%)

## Notes
- No Mermaid — explicitly avoided per design feedback. ASCII bars stay legible in plain text, GitHub UI, and rendered Docusaurus.
- No source data was lost — the per-set table moved to `<details>`, and every number traces back to a file under `benchmark/results/`.