### PR TITLE
fix: correctness and consistency fixes from project-wide review

### DIFF
--- a/docs/docs/api/constants.md
+++ b/docs/docs/api/constants.md
@@ -22,12 +22,12 @@ import aerospike_py as aerospike
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `POLICY_EXISTS_IGNORE` | 0 | Write regardless (default) |
-| `POLICY_EXISTS_UPDATE` | 1 | Update existing |
-| `POLICY_EXISTS_UPDATE_ONLY` | 2 | Fail if not exists |
-| `POLICY_EXISTS_REPLACE` | 3 | Replace all bins |
-| `POLICY_EXISTS_REPLACE_ONLY` | 4 | Replace only if exists |
-| `POLICY_EXISTS_CREATE_ONLY` | 5 | Fail if exists |
+| `POLICY_EXISTS_IGNORE` | 0 | Write regardless; create or update (default) |
+| `POLICY_EXISTS_UPDATE` | 1 | Alias of `POLICY_EXISTS_UPDATE_ONLY` |
+| `POLICY_EXISTS_UPDATE_ONLY` | 1 | Update only; fail if the record does not exist |
+| `POLICY_EXISTS_REPLACE` | 2 | Replace all bins; create or update |
+| `POLICY_EXISTS_REPLACE_ONLY` | 3 | Replace only; fail if the record does not exist |
+| `POLICY_EXISTS_CREATE_ONLY` | 4 | Create only; fail if the record exists |
 
 ### Generation
 

--- a/rust/src/bug_report.rs
+++ b/rust/src/bug_report.rs
@@ -14,12 +14,16 @@ fn shell_escape(s: &str) -> String {
 }
 
 /// Truncate and sanitize a string for use in a GitHub issue title.
+///
+/// Truncation is performed on character boundaries, not byte indices, so
+/// multi-byte UTF-8 input (e.g. non-ASCII error messages) never panics.
 fn sanitize_for_title(s: &str, max_len: usize) -> String {
     let cleaned: String = s.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
-    if cleaned.len() <= max_len {
+    if cleaned.chars().count() <= max_len {
         cleaned
     } else {
-        format!("{}...", &cleaned[..max_len - 3])
+        let truncated: String = cleaned.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{truncated}...")
     }
 }
 
@@ -83,6 +87,16 @@ mod tests {
     fn test_sanitize_exact_length() {
         let exact = "a".repeat(80);
         assert_eq!(sanitize_for_title(&exact, 80), exact);
+    }
+
+    #[test]
+    fn test_sanitize_multibyte_does_not_panic() {
+        // Each Korean syllable is 3 bytes in UTF-8; a byte-index slice at
+        // `max_len - 3` would fall mid-character and panic.
+        let long = "한글".repeat(60); // 120 chars, 360 bytes
+        let result = sanitize_for_title(&long, 80);
+        assert!(result.ends_with("..."));
+        assert_eq!(result.chars().count(), 80);
     }
 
     #[test]

--- a/rust/src/policy/client_policy.rs
+++ b/rust/src/policy/client_policy.rs
@@ -40,10 +40,16 @@ pub fn parse_client_policy(config: &Bound<'_, PyDict>) -> PyResult<ClientPolicy>
 
             let auth_mode = if let Some(mode) = config.get_item("auth_mode")? {
                 let mode_val: i32 = mode.extract()?;
-                if mode_val == 1 {
-                    AuthMode::External(username, password)
-                } else {
-                    AuthMode::Internal(username, password)
+                match mode_val {
+                    0 => AuthMode::Internal(username, password),
+                    1 => AuthMode::External(username, password),
+                    2 => AuthMode::PKI,
+                    other => {
+                        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                            "auth_mode must be AUTH_INTERNAL (0), AUTH_EXTERNAL (1), \
+                             or AUTH_PKI (2); got {other}"
+                        )));
+                    }
                 }
             } else {
                 AuthMode::Internal(username, password)

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -243,7 +243,7 @@ fn execute_query_collect(
         "query" => "Query.query",
         _ => "Query.execute",
     };
-    let result: Result<Vec<_>, AsError> = catch_panic_sync(panic_op, || {
+    let panic_result: PyResult<Result<Vec<_>, AsError>> = catch_panic_sync(panic_op, || {
         Ok(py.detach(|| {
             RUNTIME.block_on(async {
                 let rs = client
@@ -257,11 +257,14 @@ fn execute_query_collect(
                 Ok(results)
             })
         }))
-    })?;
+    });
 
-    match &result {
-        Ok(_) => timer.finish(""),
-        Err(e) => timer.finish(&crate::metrics::error_type_from_aerospike_error(e)),
+    // Finish metrics and end the OTel span on every path — including a
+    // caught panic — before propagating any error.
+    match &panic_result {
+        Ok(Ok(_)) => timer.finish(""),
+        Ok(Err(e)) => timer.finish(&crate::metrics::error_type_from_aerospike_error(e)),
+        Err(_) => {} // panic caught: timer left unrecorded (no Drop impl)
     }
 
     #[cfg(feature = "otel")]
@@ -269,13 +272,13 @@ fn execute_query_collect(
         use opentelemetry::trace::TraceContextExt;
         let cx = opentelemetry::Context::current().with_span(otel_span);
         let span_ref = TraceContextExt::span(&cx);
-        if let Err(e) = &result {
+        if let Ok(Err(e)) = &panic_result {
             crate::tracing::otel_impl::record_error_on_span(&span_ref, e);
         }
         span_ref.end();
     }
 
-    result.map_err(as_to_pyerr)
+    panic_result?.map_err(as_to_pyerr)
 }
 
 /// Execute a query/scan and collect all results as a Python list.

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -213,6 +213,31 @@ fn execute_query_collect(
     debug!("Executing {}", op_name);
 
     let timer = crate::metrics::OperationTimer::start(op_name, namespace, set_name);
+
+    // Start the OTel span *before* the operation runs so the recorded span
+    // duration reflects actual query latency. Previously the span was created
+    // after `block_on` returned, yielding a near-zero, meaningless duration.
+    #[cfg(feature = "otel")]
+    let otel_span = {
+        use opentelemetry::trace::{SpanKind, Tracer};
+        use opentelemetry::KeyValue;
+        let tracer = crate::tracing::otel_impl::get_tracer();
+        let span_name = format!("{} {}.{}", op_name.to_uppercase(), namespace, set_name);
+        tracer
+            .span_builder(span_name)
+            .with_kind(SpanKind::Client)
+            .with_attributes(vec![
+                KeyValue::new("db.system.name", "aerospike"),
+                KeyValue::new("db.namespace", namespace.to_string()),
+                KeyValue::new("db.collection.name", set_name.to_string()),
+                KeyValue::new("db.operation.name", op_name.to_uppercase()),
+                KeyValue::new("server.address", conn_info.server_address.clone()),
+                KeyValue::new("server.port", conn_info.server_port),
+                KeyValue::new("db.aerospike.cluster_name", conn_info.cluster_name.clone()),
+            ])
+            .start(&tracer)
+    };
+
     let panic_op: &'static str = match op_name {
         "scan" => "Query.scan",
         "query" => "Query.query",
@@ -241,25 +266,9 @@ fn execute_query_collect(
 
     #[cfg(feature = "otel")]
     {
-        use opentelemetry::trace::{SpanKind, TraceContextExt, Tracer};
-        use opentelemetry::KeyValue;
-        let tracer = crate::tracing::otel_impl::get_tracer();
-        let span_name = format!("{} {}.{}", op_name.to_uppercase(), namespace, set_name);
-        let span = tracer
-            .span_builder(span_name)
-            .with_kind(SpanKind::Client)
-            .with_attributes(vec![
-                KeyValue::new("db.system.name", "aerospike"),
-                KeyValue::new("db.namespace", namespace.to_string()),
-                KeyValue::new("db.collection.name", set_name.to_string()),
-                KeyValue::new("db.operation.name", op_name.to_uppercase()),
-                KeyValue::new("server.address", conn_info.server_address.clone()),
-                KeyValue::new("server.port", conn_info.server_port),
-                KeyValue::new("db.aerospike.cluster_name", conn_info.cluster_name.clone()),
-            ])
-            .start(&tracer);
-        let cx = opentelemetry::Context::current().with_span(span);
-        let span_ref = opentelemetry::trace::TraceContextExt::span(&cx);
+        use opentelemetry::trace::TraceContextExt;
+        let cx = opentelemetry::Context::current().with_span(otel_span);
+        let span_ref = TraceContextExt::span(&cx);
         if let Err(e) = &result {
             crate::tracing::otel_impl::record_error_on_span(&span_ref, e);
         }

--- a/rust/src/runtime.rs
+++ b/rust/src/runtime.rs
@@ -104,6 +104,9 @@ pub fn init_async_runtime() {
         workers
     );
     let mut builder = tokio::runtime::Builder::new_multi_thread();
-    builder.worker_threads(workers).enable_all();
+    // Enable only the IO and time drivers, matching the sync `RUNTIME` above:
+    // `enable_all()` additionally arms the signal driver, which can interfere
+    // with Python's own signal handling.
+    builder.worker_threads(workers).enable_io().enable_time();
     pyo3_async_runtimes::tokio::init(builder);
 }

--- a/rust/src/types/partition_filter.rs
+++ b/rust/src/types/partition_filter.rs
@@ -79,7 +79,7 @@ pub fn partition_filter_by_id(partition_id: usize) -> PyResult<PyPartitionFilter
 /// `count == 0` is permitted (yields an empty filter).
 #[pyfunction]
 pub fn partition_filter_by_range(begin: usize, count: usize) -> PyResult<PyPartitionFilter> {
-    if begin >= PARTITIONS && count > 0 {
+    if begin >= PARTITIONS {
         return Err(PyValueError::new_err(format!(
             "begin must be in [0, {PARTITIONS}), got {begin}"
         )));
@@ -133,6 +133,8 @@ mod tests {
             assert!(partition_filter_by_range(4000, 1000).is_err());
             assert!(partition_filter_by_range(0, 4096).is_ok());
             assert!(partition_filter_by_range(0, 0).is_ok());
+            // begin out of range is rejected even when count is 0.
+            assert!(partition_filter_by_range(PARTITIONS, 0).is_err());
         });
     }
 

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -16,6 +16,7 @@ from aerospike_py import exception as exception
 from aerospike_py import list_operations as list_operations
 from aerospike_py import map_operations as map_operations
 from aerospike_py import hll_operations as hll_operations
+from aerospike_py import bit_operations as bit_operations
 from aerospike_py import predicates as predicates
 from aerospike_py.numpy_batch import NumpyBatchRecords as NumpyBatchRecords
 from aerospike_py.types import (


### PR DESCRIPTION
## Summary

A project-wide code review surfaced several independent correctness and consistency issues. This PR fixes them in one focused pass. Each change is small and self-contained; the batch-result-handling work is intentionally **out of scope** (tracked separately on `fix/code-review-2026-05-16-batch-result-handling`).

| Area | Fix |
|------|-----|
| `bug_report.rs` | `sanitize_for_title` sliced strings by **byte index**, panicking on multi-byte UTF-8 error messages — the exact path meant to *avoid* panics. Now truncates on character boundaries. |
| `query.rs` | The OTel span in `execute_query_collect` was created **after** `block_on` returned, so every query span had a near-zero, meaningless duration. The span now starts before the operation. |
| `client_policy.rs` | `auth_mode` silently fell back to `Internal` for any value other than `1`, so `AUTH_PKI` (2) was silently downgraded. Now maps `0→Internal`, `1→External`, `2→PKI`, and raises `ValueError` on unknown values. |
| `partition_filter.rs` | `partition_filter_by_range` accepted `begin >= 4096` when `count == 0`, violating the documented `[0, 4096)` contract and diverging from `partition_filter_by_id`. Now rejected unconditionally. |
| `runtime.rs` | The async Tokio runtime used `enable_all()` while the sync `RUNTIME` deliberately uses `enable_io()+enable_time()` (documented, to avoid the signal driver). Aligned for consistency. |
| `__init__.pyi` | `bit_operations` is re-exported at runtime but was missing from the type stub, so type checkers/IDEs flagged `aerospike_py.bit_operations` as unknown. Added. |
| `docs/api/constants.md` | `POLICY_EXISTS_*` values in the docs table did not match the code (`UPDATE_ONLY`/`REPLACE`/`REPLACE_ONLY`/`CREATE_ONLY` were all off by one). Corrected to match `constants.rs`.

## Note for reviewers

`POLICY_EXISTS_UPDATE` and `POLICY_EXISTS_UPDATE_ONLY` currently share the value `1` (both map to `RecordExistsAction::UpdateOnly`). The integration tests (`TestExistsPolicy`) and unit tests assert this behavior, so it appears intentional — this PR only corrects the **docs** to reflect reality rather than changing the constant. If `POLICY_EXISTS_UPDATE` was meant to be a distinct create-or-update value, that is a separate (behavior-changing) decision and is left untouched here.

## Test plan

- [x] `cargo check` + `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 160 passed (incl. new `sanitize_for_title` multi-byte test and `partition_filter_by_range` out-of-range test)
- [x] `make test-unit` — 886 passed
- [x] `make typecheck` (pyright) — 0 errors
- [x] `ruff check` + `ruff format --check` + `cargo fmt --check`
- [x] `docs-build` — Docusaurus `en` + `ko` built, no broken links
- [x] perf-impact review — `low`, no per-request/per-record overhead

perf-impact: low