### PR TITLE
fix: align public docs and type metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Setup
 
 ```bash
-git clone https://github.com/KimSoungRyoul/aerospike-py.git
+git clone https://github.com/aerospike-ce-ecosystem/aerospike-py.git
 cd aerospike-py
 
 # Install uv (if not already installed)
@@ -23,6 +23,14 @@ uv run maturin develop --release
 ### Start Aerospike Server
 
 Running integration and feasibility tests requires an Aerospike server (except unit tests).
+The default local path is:
+
+```bash
+make run-aerospike-ce  # starts Aerospike CE on 127.0.0.1:18710
+```
+
+If you start the container manually on Aerospike's default port, set
+`AEROSPIKE_PORT=3000` when running integration-style tests:
 
 ```bash
 podman run -d --name aerospike \

--- a/README.md
+++ b/README.md
@@ -24,13 +24,18 @@ High-performance Aerospike Python Client built with PyO3 + Rust, powered by the 
 pip install aerospike-py
 ```
 
+From a source checkout, start the local Aerospike CE container with
+`make run-aerospike-ce`; it listens on `127.0.0.1:18710`. If you start
+Aerospike manually on the default service port, use `3000` in the examples
+below instead.
+
 ### Sync Client
 
 ```python
 import aerospike_py as aerospike
 
 with aerospike.client({
-    "hosts": [("127.0.0.1", 3000)],
+    "hosts": [("127.0.0.1", 18710)],
     "cluster_name": "docker",
 }).connect() as client:
 
@@ -53,7 +58,7 @@ from aerospike_py import AsyncClient
 
 async def main():
     async with AsyncClient({
-        "hosts": [("127.0.0.1", 3000)],
+        "hosts": [("127.0.0.1", 18710)],
         "cluster_name": "docker",
     }) as client:
         await client.connect()

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -157,7 +157,7 @@ Used by: `aerospike_py.client(config)`, `AsyncClient(config)`
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `hosts` | `list[tuple[str, int]]` | *required* | Seed nodes |
-| `cluster_name` | `str` | | Expected cluster name |
+| `cluster_name` | `str \| None` | | Expected cluster name. `None` is treated the same as omitting the field. |
 | `auth_mode` | `int` | `AUTH_INTERNAL` | `AUTH_INTERNAL`, `AUTH_EXTERNAL`, `AUTH_PKI` |
 | `user` | `str` | | Authentication username |
 | `password` | `str` | | Authentication password |
@@ -421,7 +421,7 @@ Used by: `admin_create_role()`, `admin_grant_privileges()`, `admin_revoke_privil
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `code` | `int` | Privilege code (`PRIV_READ`, `PRIV_WRITE`, etc.) |
+| `code` | `int \| str` | Privilege code constant (`PRIV_READ`, `PRIV_WRITE`, etc.) or canonical name (`"read"`, `"read-write"`, etc.) |
 | `ns` | `str` | Namespace scope (empty = global) |
 | `set` | `str` | Set scope (empty = namespace-wide) |
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -16,6 +16,11 @@ pip install aerospike-py
 
 **Requirements:** Python 3.10+ (CPython)
 
+From a source checkout, start the local Aerospike CE container with
+`make run-aerospike-ce`; it listens on `127.0.0.1:18710`. If you start
+Aerospike manually on the default service port, use `3000` in the examples
+below instead.
+
 ## Quick Start
 
 <Tabs>
@@ -26,7 +31,7 @@ import aerospike_py as aerospike
 from aerospike_py import Record
 
 with aerospike.client({
-    "hosts": [("127.0.0.1", 3000)],
+    "hosts": [("127.0.0.1", 18710)],
 }).connect() as client:
     key: tuple[str, str, str] = ("test", "demo", "user1")
 
@@ -54,7 +59,7 @@ import aerospike_py as aerospike
 from aerospike_py import AsyncClient, Record
 
 async def main() -> None:
-    async with AsyncClient({"hosts": [("127.0.0.1", 3000)]}) as client:
+    async with AsyncClient({"hosts": [("127.0.0.1", 18710)]}) as client:
         await client.connect()
         key: tuple[str, str, str] = ("test", "demo", "user1")
 

--- a/docs/docs/guides/config/client-config.md
+++ b/docs/docs/guides/config/client-config.md
@@ -16,7 +16,7 @@ import aerospike_py as aerospike
 from aerospike_py.types import ClientConfig
 
 config: ClientConfig = {
-    "hosts": [("127.0.0.1", 3000)],
+    "hosts": [("127.0.0.1", 18710)],
     "cluster_name": "docker",
 }
 client = aerospike.client(config).connect()
@@ -27,7 +27,7 @@ client = aerospike.client(config).connect()
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `hosts` | `list[tuple[str, int]]` | *required* | Seed node addresses |
-| `cluster_name` | `str` | `""` | Expected cluster name |
+| `cluster_name` | `str \| None` | `""` | Expected cluster name. `None` is treated the same as omitting the field. |
 | `auth_mode` | `int` | `AUTH_INTERNAL` | Auth mode |
 | `user` / `password` | `str` | `""` | Credentials |
 | `timeout` | `int` | `1000` | Connection timeout (ms) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/KimSoungRyoul/aerospike-py"
-Documentation = "https://kimsoungryoul.github.io/aerospike-py/"
-Repository = "https://github.com/KimSoungRyoul/aerospike-py"
-Issues = "https://github.com/KimSoungRyoul/aerospike-py/issues"
-Changelog = "https://github.com/KimSoungRyoul/aerospike-py/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/aerospike-ce-ecosystem/aerospike-py"
+Documentation = "https://aerospike-ce-ecosystem.github.io/aerospike-py/"
+Repository = "https://github.com/aerospike-ce-ecosystem/aerospike-py"
+Issues = "https://github.com/aerospike-ce-ecosystem/aerospike-py/issues"
+Changelog = "https://github.com/aerospike-ce-ecosystem/aerospike-py/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 numpy = ["numpy>=2.0"]

--- a/src/aerospike_py/types.py
+++ b/src/aerospike_py/types.py
@@ -285,7 +285,7 @@ class WriteMeta(TypedDict, total=False):
 
 class ClientConfig(TypedDict, total=False):
     hosts: list[tuple[str, int]]
-    cluster_name: str
+    cluster_name: str | None
     auth_mode: int
     user: str
     password: str


### PR DESCRIPTION
## Summary
- Update source-checkout examples to use the local compose port 18710 and document the manual 3000 override path.
- Align public `ClientConfig.cluster_name` typing/docs with runtime behavior accepting `None`.
- Move package project URLs from the old personal repo/docs locations to the aerospike-ce-ecosystem org.

## Testing
- `python3 -m py_compile src/aerospike_py/types.py`
- targeted `rg` checks for `cluster_name`, privilege code docs, org URLs, `18710`, and `AEROSPIKE_PORT=3000`
- `git diff --check`