### PR TITLE
fix: numpy sub-array data loss, batch mutex poisoning, and Rust test coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,12 @@ jobs:
       - name: Run pre-commit
         run: uvx pre-commit run --all-files
 
+      # Mirrors the cargo-clippy pre-commit hook's manifest path / features so
+      # the Rust #[cfg(test)] suites actually execute in CI (previously they
+      # never ran — only pre-commit, clippy, and Python tox did).
+      - name: Run Rust unit tests
+        run: cargo test --manifest-path rust/Cargo.toml --features otel
+
   build:
     name: Build & Unit Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ test-compat: build run-aerospike-ce ## Run compatibility tests (vs official C cl
 test-all: build run-aerospike-ce ## Run all tests
 	uvx --with tox-uv tox -e all
 
+.PHONY: test-rust
+test-rust: ## Run Rust unit tests (cargo test, no server needed)
+	cargo test --manifest-path rust/Cargo.toml --features otel
+
 .PHONY: test-matrix
 test-matrix: build ## Run unit tests across all Python versions
 	uvx --with tox-uv tox

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -77,7 +77,10 @@ impl PyBatchRecord {
     /// Returns `None` if the record was not found.
     #[getter]
     fn record(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        self.record_cell.lock().unwrap().to_python(py)
+        self.record_cell
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .to_python(py)
     }
 }
 

--- a/rust/src/numpy_support.rs
+++ b/rust/src/numpy_support.rs
@@ -673,6 +673,23 @@ unsafe fn read_value_from_buffer(row_ptr: *const u8, field: &FieldInfo) -> PyRes
     }
     // SAFETY: caller guarantees row_ptr + field.offset is valid and within bounds
     let src = unsafe { row_ptr.add(field.offset) };
+
+    // Sub-array numeric field (e.g. ('vec','(4,)f8')): the field spans
+    // `itemsize` bytes across multiple base elements. A scalar read would
+    // capture only `base_itemsize` bytes and silently drop the rest, so
+    // read all `itemsize` bytes into a Blob — mirroring the write path,
+    // which routes such fields through `write_bytes_to_buffer`.
+    if matches!(
+        field.kind,
+        DtypeKind::Int | DtypeKind::Uint | DtypeKind::Float
+    ) && field.itemsize > field.base_itemsize
+    {
+        let mut buf = vec![0u8; field.itemsize];
+        // SAFETY: src points to at least field.itemsize bytes of readable memory
+        unsafe { ptr::copy_nonoverlapping(src, buf.as_mut_ptr(), field.itemsize) };
+        return Ok(Value::Blob(buf));
+    }
+
     match field.kind {
         DtypeKind::Int => {
             let v = match field.base_itemsize {
@@ -1657,5 +1674,95 @@ def make_reverse_slice():
             _ => original.clone(),
         };
         assert_eq!(result, Value::Blob(b"exact".to_vec()));
+    }
+
+    /// Regression test for the sub-array data-loss bug: a structured-dtype
+    /// field that is a numeric sub-array (e.g. ('vec','(4,)f8') →
+    /// kind=Float, base_itemsize=8, itemsize=32) must round-trip ALL
+    /// `itemsize` bytes through write → read. Before the fix, the read path
+    /// matched only on `base_itemsize` and returned a single scalar,
+    /// silently dropping all but the first base element.
+    #[test]
+    fn test_subarray_float_write_read_roundtrip() {
+        // 4-element f64 sub-array: base_itemsize=8, itemsize=32.
+        let field = FieldInfo {
+            name: "vec".to_string(),
+            offset: 0,
+            itemsize: 32,
+            base_itemsize: 8,
+            kind: DtypeKind::Float,
+        };
+        let mut buf = [0u8; 32];
+
+        // Source payload: 4 distinct f64 values laid out contiguously.
+        let values = [1.5_f64, -2.25, 3.125, 4.0e10];
+        let mut payload = Vec::with_capacity(32);
+        for v in values {
+            payload.extend_from_slice(&v.to_le_bytes());
+        }
+
+        unsafe {
+            // WRITE path: a Blob whose len equals itemsize routes through
+            // write_bytes_to_buffer for sub-array numeric fields.
+            write_value_to_buffer(buf.as_mut_ptr(), &field, &Value::Blob(payload.clone()))
+                .expect("sub-array blob write should succeed");
+
+            // READ path: must return all 32 bytes, not a single 8-byte scalar.
+            let read = read_value_from_buffer(buf.as_ptr(), &field)
+                .expect("sub-array read should succeed");
+
+            match read {
+                Value::Blob(bytes) => {
+                    assert_eq!(
+                        bytes.len(),
+                        32,
+                        "sub-array read must preserve all {} bytes, not just base_itemsize",
+                        field.itemsize
+                    );
+                    assert_eq!(bytes, payload, "sub-array bytes must round-trip exactly");
+                }
+                other => panic!("expected Value::Blob for sub-array field, got {other:?}"),
+            }
+        }
+    }
+
+    /// Same round-trip guarantee for an integer sub-array.
+    #[test]
+    fn test_subarray_int_write_read_roundtrip() {
+        // 3-element i32 sub-array: base_itemsize=4, itemsize=12.
+        let field = FieldInfo {
+            name: "ids".to_string(),
+            offset: 0,
+            itemsize: 12,
+            base_itemsize: 4,
+            kind: DtypeKind::Int,
+        };
+        let mut buf = [0u8; 12];
+
+        let values = [10_i32, -20, 30];
+        let mut payload = Vec::with_capacity(12);
+        for v in values {
+            payload.extend_from_slice(&v.to_le_bytes());
+        }
+
+        unsafe {
+            write_value_to_buffer(buf.as_mut_ptr(), &field, &Value::Blob(payload.clone()))
+                .expect("sub-array int blob write should succeed");
+
+            let read = read_value_from_buffer(buf.as_ptr(), &field)
+                .expect("sub-array int read should succeed");
+
+            match read {
+                Value::Blob(bytes) => {
+                    assert_eq!(
+                        bytes.len(),
+                        12,
+                        "int sub-array read must preserve all bytes"
+                    );
+                    assert_eq!(bytes, payload);
+                }
+                other => panic!("expected Value::Blob for int sub-array field, got {other:?}"),
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes three findings from the May 2026 code audit of the Rust/PyO3 layer. Diffs are minimal and scoped strictly to the affected files plus tests.

## Fix 1 — `batch_read` into a numpy sub-array dtype dropped all but the first element (P1, data loss)

**Problem:** In `rust/src/numpy_support.rs`, `read_value_from_buffer` matched only on `base_itemsize`. For a structured-dtype field that is a numeric sub-array (e.g. `('vec','(4,)f8')` → `kind=Float`, `base_itemsize=8`, `itemsize=32`), it decoded a single scalar — reading 8 of 32 bytes and silently discarding the rest. The write path (`write_value_to_buffer`) already handled sub-arrays correctly by routing `Blob` values through `write_bytes_to_buffer` when `itemsize > base_itemsize`, so reads and writes were asymmetric.

**Fix:** When `field.itemsize > field.base_itemsize` for numeric kinds (`Int`/`Uint`/`Float`), read all `itemsize` bytes into a `Value::Blob`, mirroring the write path. Added two `#[cfg(test)]` round-trip tests (float and int sub-arrays) asserting every byte survives write → read.

## Fix 2 — `PyBatchRecord.record` getter panicked on a poisoned mutex (P2, robustness)

**Problem:** `rust/src/batch_types.rs:80` called `self.record_cell.lock().unwrap()`. A first-access panic during particle decoding (#280) poisons the mutex, after which every subsequent access on the batch aborts uncatchably.

**Fix:** Use `unwrap_or_else(|e| e.into_inner())` to recover the inner guard, consistent with the existing pattern in `rust/src/tracing.rs` and `rust/src/metrics.rs`.

## Fix 3 — Rust unit tests never ran in CI or `make` (P1, CI gap)

**Problem:** No `cargo test` invocation existed anywhere — CI ran only pre-commit, clippy, and Python tox. The substantial Rust `#[cfg(test)]` suites (162 tests) never executed.

**Fix:**
- Added a "Run Rust unit tests" step to the CI `lint` job in `.github/workflows/ci.yaml`, mirroring the cargo-clippy pre-commit hook's manifest path / features (`--manifest-path rust/Cargo.toml --features otel`).
- Added a `test-rust` target to the `Makefile` running `cargo test` against the Rust crate.

## Verification

All run against `rust/Cargo.toml` with `--features otel`:

| Command | Result |
|---------|--------|
| `cargo check --manifest-path rust/Cargo.toml --features otel` | clean |
| `cargo test --manifest-path rust/Cargo.toml --features otel` | 162 passed, 0 failed (incl. 2 new sub-array round-trip tests) |
| `cargo clippy --manifest-path rust/Cargo.toml --features otel --all-targets -- -D warnings` | clean, no new warnings |
| `cargo fmt --all --manifest-path rust/Cargo.toml -- --check` | clean |
| `make test-rust` | passes |

No `version` fields were touched.