### PR TITLE
fix: reject non-int list_increment, propagate batch keys() errors, accept uint64 ints

### DIFF
--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -291,22 +291,11 @@ impl PyBatchReadHandle {
     }
 
     /// Extract just the user keys without converting record data.
+    ///
+    /// Conversion errors are propagated (not silently dropped) so the returned
+    /// list length always matches the records that carry a `user_key`.
     fn keys<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
-        use crate::types::value::value_to_py;
-        let keys: Vec<Bound<'py, PyAny>> = self
-            .inner
-            .iter()
-            .filter_map(|br| {
-                br.key.user_key.as_ref().map(|uk| match uk {
-                    aerospike_core::Value::String(s) => {
-                        s.into_pyobject(py).map(|o| o.into_any()).ok()
-                    }
-                    aerospike_core::Value::Int(i) => i.into_pyobject(py).map(|o| o.into_any()).ok(),
-                    v => value_to_py(py, v).ok().map(|o| o.into_bound(py)),
-                })
-            })
-            .flatten()
-            .collect();
+        let keys = collect_user_keys(py, &self.inner)?;
         PyList::new(py, &keys)
     }
 }
@@ -400,6 +389,29 @@ pub fn batch_to_dict_py<'py>(
     Ok(dict)
 }
 
+/// Convert each `BatchRecord`'s `user_key` to a Python object.
+///
+/// Records without a `user_key` (digest-only) are skipped. Conversion errors
+/// are `?`-propagated rather than silently dropped, so the returned `Vec`
+/// length always matches the number of records that carry a `user_key`.
+pub fn collect_user_keys<'py>(
+    py: Python<'py>,
+    results: &[BatchRecord],
+) -> PyResult<Vec<Bound<'py, PyAny>>> {
+    use crate::types::value::value_to_py;
+    results
+        .iter()
+        .filter_map(|br| br.key.user_key.as_ref())
+        .map(|uk| -> PyResult<Bound<'py, PyAny>> {
+            match uk {
+                aerospike_core::Value::String(s) => Ok(s.into_pyobject(py)?.into_any()),
+                aerospike_core::Value::Int(i) => Ok(i.into_pyobject(py)?.into_any()),
+                v => Ok(value_to_py(py, v)?.into_bound(py)),
+            }
+        })
+        .collect()
+}
+
 /// Convert `BatchRecord`s into a Python [`PyBatchRecords`] with **lazy bin conversion**.
 ///
 /// Only key and result_code are converted eagerly (lightweight).
@@ -443,4 +455,60 @@ pub fn batch_to_batch_records_py(
     }
 
     Ok(PyBatchRecords { batch_records })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aerospike_core::Value;
+
+    /// Build a minimal `BatchRecord` with the given `user_key`.
+    ///
+    /// `BatchRecord::new` is `pub(crate)` in `aerospike_core`, so we construct
+    /// a layout-compatible mirror and transmute — the same pattern used by the
+    /// `client_ops` unit tests. Size + alignment are guarded at compile time.
+    fn make_batch_record(user_key: Value) -> BatchRecord {
+        #[repr(C)]
+        struct BatchRecordMirror {
+            key: aerospike_core::Key,
+            record: Option<Record>,
+            result_code: Option<ResultCode>,
+            in_doubt: bool,
+            has_write: bool,
+        }
+
+        static_assertions::assert_eq_size!(BatchRecordMirror, BatchRecord);
+        static_assertions::assert_eq_align!(BatchRecordMirror, BatchRecord);
+
+        let mirror = BatchRecordMirror {
+            key: aerospike_core::Key::new("test", "demo", user_key).unwrap(),
+            record: None,
+            result_code: Some(ResultCode::Ok),
+            in_doubt: false,
+            has_write: false,
+        };
+        // SAFETY: `BatchRecordMirror` mirrors `BatchRecord`'s field types and
+        // order exactly; size + alignment are asserted above. Test-only.
+        unsafe { std::mem::transmute(mirror) }
+    }
+
+    /// `collect_user_keys` returns every key for a normal batch, preserving
+    /// order and length (round-trip) — no keys are silently dropped.
+    #[test]
+    fn collect_user_keys_returns_all_keys() {
+        Python::initialize();
+        Python::attach(|py| {
+            let records = vec![
+                make_batch_record(Value::from("k0".to_string())),
+                make_batch_record(Value::from("k1".to_string())),
+                make_batch_record(Value::Int(42)),
+            ];
+            let keys = collect_user_keys(py, &records).expect("conversion should succeed");
+            assert_eq!(keys.len(), records.len(), "no key may be dropped");
+
+            assert_eq!(keys[0].extract::<String>().unwrap(), "k0");
+            assert_eq!(keys[1].extract::<String>().unwrap(), "k1");
+            assert_eq!(keys[2].extract::<i64>().unwrap(), 42);
+        });
+    }
 }

--- a/rust/src/operations.rs
+++ b/rust/src/operations.rs
@@ -293,9 +293,6 @@ fn values_from_list(val: &Value) -> Vec<Value> {
     }
 }
 
-/// Parse an operation flag value that should be a small integer (i32).
-///
-/// Missing/None values default to `0`.
 /// Resolve the `val` of a `list_increment` op to the i64 increment amount.
 ///
 /// Mirrors the bit-op (`OP_BIT_ADD`/`OP_BIT_SUBTRACT`) handling: a missing or
@@ -311,6 +308,9 @@ fn parse_increment_value(val: &Option<Value>) -> PyResult<i64> {
     }
 }
 
+/// Parse an operation flag value that should be a small integer (i32).
+///
+/// Missing/None values default to `0`.
 fn parse_i32_flag(val: &Option<Value>, op_name: &str, field_name: &str) -> PyResult<i32> {
     match val {
         None | Some(Value::Nil) => Ok(0),

--- a/rust/src/operations.rs
+++ b/rust/src/operations.rs
@@ -296,6 +296,21 @@ fn values_from_list(val: &Value) -> Vec<Value> {
 /// Parse an operation flag value that should be a small integer (i32).
 ///
 /// Missing/None values default to `0`.
+/// Resolve the `val` of a `list_increment` op to the i64 increment amount.
+///
+/// Mirrors the bit-op (`OP_BIT_ADD`/`OP_BIT_SUBTRACT`) handling: a missing or
+/// `Nil` `val` defaults to `+1`; an integer `val` is used as-is; any other type
+/// is a type error rather than being silently collapsed to `1`.
+fn parse_increment_value(val: &Option<Value>) -> PyResult<i64> {
+    match val {
+        None | Some(Value::Nil) => Ok(1),
+        Some(Value::Int(i)) => Ok(*i),
+        Some(other) => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "list_increment requires an integer value, got {other:?}"
+        ))),
+    }
+}
+
 fn parse_i32_flag(val: &Option<Value>, op_name: &str, field_name: &str) -> PyResult<i32> {
     match val {
         None | Some(Value::Nil) => Ok(0),
@@ -556,10 +571,7 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
                 let name = require_bin(&bin_name, "list_increment")?;
                 let policy = parse_list_policy(dict)?;
                 let index = get_index(dict)?;
-                let v: i64 = match &val {
-                    Some(Value::Int(i)) => *i,
-                    _ => 1,
-                };
+                let v: i64 = parse_increment_value(&val)?;
                 list_ops::increment(&policy, &name, index, v)
             }
             OP_LIST_SORT => {
@@ -1053,7 +1065,7 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
 
 #[cfg(test)]
 mod tests {
-    use super::parse_i32_flag;
+    use super::{parse_i32_flag, parse_increment_value};
     use aerospike_core::Value;
     use pyo3::{exceptions::PyTypeError, exceptions::PyValueError, PyErr, Python};
 
@@ -1098,5 +1110,45 @@ mod tests {
         Python::attach(|py| {
             assert!(err.is_instance_of::<PyTypeError>(py));
         });
+    }
+
+    #[test]
+    fn parse_increment_value_defaults_to_one_for_missing_or_nil() {
+        assert_eq!(
+            parse_increment_value(&None).expect("None should default to +1"),
+            1
+        );
+        assert_eq!(
+            parse_increment_value(&Some(Value::Nil)).expect("Nil should default to +1"),
+            1
+        );
+    }
+
+    #[test]
+    fn parse_increment_value_uses_int_as_is() {
+        assert_eq!(
+            parse_increment_value(&Some(Value::Int(5))).expect("int should be used as-is"),
+            5
+        );
+        assert_eq!(
+            parse_increment_value(&Some(Value::Int(-3))).expect("negative int should be used"),
+            -3
+        );
+    }
+
+    #[test]
+    fn parse_increment_value_rejects_non_int() {
+        Python::initialize();
+        for bad in [
+            Value::String("1".to_string()),
+            Value::Float(aerospike_core::FloatValue::from(1.5_f64)),
+            Value::Bool(true),
+        ] {
+            let err: PyErr = parse_increment_value(&Some(bad))
+                .expect_err("non-int value should raise instead of defaulting to +1");
+            Python::attach(|py| {
+                assert!(err.is_instance_of::<PyValueError>(py));
+            });
+        }
     }
 }

--- a/rust/src/types/value.rs
+++ b/rust/src/types/value.rs
@@ -31,8 +31,16 @@ fn py_to_value_inner(obj: &Bound<'_, PyAny>, depth: usize) -> PyResult<Value> {
         return Ok(Value::Bool(b.is_true()));
     }
     if let Ok(i) = obj.cast::<PyInt>() {
-        let val: i64 = i.extract()?;
-        return Ok(Value::Int(val));
+        // Aerospike's integer particle is a 64-bit two's-complement value.
+        // Accept Python ints in [2^63, 2^64-1] (e.g. large unsigned values written
+        // by the official C client) by bit-reinterpreting them as i64.
+        match i.extract::<i64>() {
+            Ok(val) => return Ok(Value::Int(val)),
+            Err(i64_err) => match i.extract::<u64>() {
+                Ok(u) => return Ok(Value::Int(u as i64)),
+                Err(_) => return Err(i64_err),
+            },
+        }
     }
     if let Ok(f) = obj.cast::<PyFloat>() {
         let val: f64 = f.extract()?;
@@ -113,5 +121,60 @@ pub fn value_to_py(py: Python<'_>, val: &Value) -> PyResult<Py<PyAny>> {
         Value::HLL(b) => Ok(PyBytes::new(py, b).into_any().unbind()),
         Value::Infinity => Ok(py.None()),
         Value::Wildcard => Ok(py.None()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `i64`-range ints convert as-is.
+    #[test]
+    fn py_to_value_accepts_i64_range_ints() {
+        Python::initialize();
+        Python::attach(|py| {
+            for n in [0_i64, 1, -1, i64::MAX, i64::MIN] {
+                let obj = n.into_pyobject(py).expect("int");
+                match py_to_value(&obj.into_any()).expect("i64 should convert") {
+                    Value::Int(v) => assert_eq!(v, n),
+                    other => panic!("expected Value::Int, got {other:?}"),
+                }
+            }
+        });
+    }
+
+    /// Python ints in `[2^63, 2^64-1]` (e.g. large unsigned values from the
+    /// official C client) are bit-reinterpreted into the i64 integer particle
+    /// instead of being rejected with OverflowError.
+    #[test]
+    fn py_to_value_accepts_uint64_range_ints() {
+        Python::initialize();
+        Python::attach(|py| {
+            for u in [1_u64 << 63, u64::MAX, (1_u64 << 63) + 12345] {
+                let obj = u.into_pyobject(py).expect("uint");
+                match py_to_value(&obj.into_any()).expect("u64 should convert") {
+                    Value::Int(v) => assert_eq!(v as u64, u, "bit-reinterpretation round-trip"),
+                    other => panic!("expected Value::Int, got {other:?}"),
+                }
+            }
+        });
+    }
+
+    /// Ints that fit neither i64 nor u64 still propagate the original error.
+    #[test]
+    fn py_to_value_rejects_ints_beyond_uint64() {
+        Python::initialize();
+        Python::attach(|py| {
+            // Build `2**64` (one past the u64 ceiling) as a Python int.
+            let max_u64 = u64::MAX.into_pyobject(py).expect("u64::MAX");
+            let one = 1_u64.into_pyobject(py).expect("one");
+            let huge = max_u64
+                .add(one)
+                .expect("u64::MAX + 1 is a valid Python big int");
+            assert!(
+                py_to_value(&huge).is_err(),
+                "values beyond u64 range must still raise"
+            );
+        });
     }
 }


### PR DESCRIPTION
Follow-up to the **2026-05 code audit (#362)**. Three focused correctness fixes in the Rust/PyO3 core. All changes are additive and **non-breaking** — no public API, exception class, or NamedTuple was renamed or removed, and no `version:` fields were touched.

## Fix 1 [P1] — `list_increment` silently ignores non-integer `val`

**Problem:** the `OP_LIST_INCREMENT` arm in `rust/src/operations.rs` collapsed any non-`Int` `val` (float, string, bool, etc.) to `1`:

```rust
let v: i64 = match &val {
    Some(Value::Int(i)) => *i,
    _ => 1,
};
```

A caller passing a wrong-typed increment got a silent +1 and a success result instead of an error.

**Fix:** extracted the logic into `parse_increment_value`, mirroring the existing bit-op handling (`OP_BIT_ADD` / `OP_BIT_SUBTRACT`) in the same file:
- `None` / `Some(Value::Nil)` → default `+1`
- `Some(Value::Int(i))` → use `i`
- anything else → `PyValueError("list_increment requires an integer value, got ...")`

## Fix 2 [P2] — `BatchReadHandle.keys()` silently drops keys whose conversion fails

**Problem:** `keys()` in `rust/src/batch_types.rs` used `.ok()` + `.flatten()`, so a conversion `Err` was silently discarded. The returned list length could then be shorter than the batch, with no error surfaced.

**Fix:** extracted the per-key conversion into `collect_user_keys`, which collects into a `PyResult<Vec<_>>` and `?`-propagates any conversion error — mirroring how `batch_to_dict_py` in the same file handles conversion errors. Per-variant handling (String / Int / `value_to_py` fallback) is preserved; digest-only records (no `user_key`) are still skipped.

## Fix 3 [P2] — Python ints in `[2^63, 2^64-1]` wrongly rejected with `OverflowError`

**Problem:** in `py_to_value` (`rust/src/types/value.rs`), a `PyInt` was extracted only as `i64`. Aerospike's integer particle is a 64-bit two's-complement value, so large unsigned values written by the official C client could not be supplied from Python.

**Fix:** when `extract::<i64>()` fails, fall back to `extract::<u64>()`; on success store `Value::Int(u as i64)` (bit-reinterpret). The original error is propagated **only** when both `i64` and `u64` extraction fail. Additive and non-breaking.

## Tests

Server-free Rust `#[cfg(test)]` unit tests added for all three fixes:
- `parse_increment_value`: defaults to +1 for missing/Nil, uses int as-is, rejects string/float/bool.
- `collect_user_keys`: round-trips all keys for a normal batch (length + order preserved).
- `py_to_value`: i64-range ints, uint64-range ints (`2^63`, `u64::MAX`) round-trip; values beyond `u64` still raise.

## Verification

- `cargo build` (OpenTelemetry is always-on in this crate — no separate feature flag, per CLAUDE.md) — passes.
- `cargo test` — 169 passed, 0 failed (includes the 7 new tests).
- `cargo clippy --all-targets` — clean, no warnings.
- `pytest tests/unit/` — 886 passed, 8 skipped (skips need a running Aerospike server).
- Integration tests requiring a live server were not run in this environment; CI covers the full matrix.