### PR TITLE
fix: surface RustPanicError on poisoned BatchRecord.record mutex

### DIFF
--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -75,12 +75,23 @@ pub struct PyBatchRecord {
 impl PyBatchRecord {
     /// Lazily convert the record to Python `(key, meta, bins)` tuple.
     /// Returns `None` if the record was not found.
+    ///
+    /// A poisoned `record_cell` mutex means a previous lazy conversion
+    /// panicked mid-flight (e.g. a legacy language-specific blob particle
+    /// type that `aerospike-core` cannot decode — see issue #280). Rather
+    /// than silently recovering and re-running the same conversion that
+    /// already crashed, surface a clear [`RustPanicError`] so callers know
+    /// this batch record's data is unrecoverable.
     #[getter]
     fn record(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        self.record_cell
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .to_python(py)
+        let mut guard = self.record_cell.lock().map_err(|_| {
+            crate::errors::RustPanicError::new_err(
+                "BatchRecord.record conversion previously panicked; this batch \
+                 record's data is unrecoverable (likely a legacy blob particle \
+                 type aerospike-core cannot decode — see issue #280)",
+            )
+        })?;
+        guard.to_python(py)
     }
 }
 
@@ -490,6 +501,45 @@ mod tests {
         // SAFETY: `BatchRecordMirror` mirrors `BatchRecord`'s field types and
         // order exactly; size + alignment are asserted above. Test-only.
         unsafe { std::mem::transmute(mirror) }
+    }
+
+    /// A poisoned `record_cell` mutex (left behind by a panic during a
+    /// previous lazy conversion) must surface as a `RustPanicError` rather
+    /// than being silently recovered. Without the fix the getter calls
+    /// `unwrap_or_else(|e| e.into_inner())` and returns `Ok(...)`.
+    #[test]
+    fn record_getter_rejects_poisoned_cell() {
+        Python::initialize();
+        Python::attach(|py| {
+            let br = Py::new(
+                py,
+                PyBatchRecord {
+                    key: py.None(),
+                    result: 0,
+                    record_cell: Mutex::new(LazyRecordCell::None),
+                    in_doubt: false,
+                },
+            )
+            .expect("construct PyBatchRecord");
+
+            // Poison the mutex by panicking while holding the lock.
+            let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let cell = br.borrow(py);
+                let _g = cell.record_cell.lock().unwrap();
+                panic!("synthetic conversion panic");
+            }))
+            .is_err();
+            assert!(poisoned, "panic must unwind to poison the mutex");
+
+            let cell = br.borrow(py);
+            let err = cell
+                .record(py)
+                .expect_err("poisoned cell must surface an error");
+            assert!(
+                err.is_instance_of::<crate::errors::RustPanicError>(py),
+                "poisoned record_cell must raise RustPanicError"
+            );
+        });
     }
 
     /// `collect_user_keys` returns every key for a normal batch, preserving


### PR DESCRIPTION
## Summary

Scoped code-quality follow-up. Of three reviewed candidates, **one** was confirmed and fixed; the other two were rejected after verification (see below).

## Fix implemented — poisoned-mutex silent recovery in `BatchRecord.record`

`rust/src/batch_types.rs` — the `record` getter previously did:

```rust
self.record_cell.lock().unwrap_or_else(|e| e.into_inner()).to_python(py)
```

This silently recovers from a **poisoned** `record_cell` mutex. A `Mutex` is poisoned only when a thread panics while holding the lock. The lock here is held exclusively by `LazyRecordCell::to_python`, which calls `record_to_py_with_key` — a record-particle decoder. The project's own panic-safety design (`rust/src/panic_safety.rs`, issue #280) documents that particle decoding **can panic** on legacy language-specific blob particle types (`PYTHON_BLOB`, `JAVA_BLOB`, …) that `aerospike-core 2.0.0` cannot decode.

So a poisoned `record_cell` is a reachable state meaning "a previous lazy conversion of this batch record crashed". Silently recovering hid the crash and re-ran the same conversion that panics again. The getter now detects the poisoned lock and raises **`RustPanicError`** — the project's canonical exception for native panics (a `ClientError` subclass), already exported as a public exception — telling callers the batch record's data is unrecoverable.

### Evidence / verification

- New Rust unit test `record_getter_rejects_poisoned_cell`: constructs a `PyBatchRecord`, poisons the `record_cell` mutex via a panic-while-locked, and asserts `record()` raises `RustPanicError`. **Confirmed it FAILS against the old getter** (old code returns `Ok(...)`) **and PASSES with the fix.**
- `cargo build`, `cargo test` — 173 tests passed.
- `cargo clippy --all-targets` — clean, no warnings.
- `cargo fmt --check` — clean.
- `maturin develop` build succeeds; `pytest tests/unit` — 886 passed, 8 skipped (server-dependent). No Python files were modified.

PATCH-level `fix:` — no public API/constant/exception/NamedTuple renamed.

## Candidates rejected after verification

**Candidate A — `POLICY_EXISTS_UPDATE` vs `parse_record_exists_action` — SKIPPED (not a bug).**
`constants.rs` defines both `POLICY_EXISTS_UPDATE = 1` and `POLICY_EXISTS_UPDATE_ONLY = 1` (the report's premise — that constants run `0..=4` distinctly — does not match the actual file). The parser `parse_record_exists_action` correctly mirrors the `aerospike-core` `RecordExistsAction` enum (`Update=0, UpdateOnly=1, Replace=2, ReplaceOnly=3, CreateOnly=4`). Git history shows PR #360 ("correctness and consistency fixes from project-wide review", merged 3 days ago) **explicitly** included `docs(constants): correct POLICY_EXISTS_* values to match the code` and updated `docs/docs/api/constants.md` to document `POLICY_EXISTS_UPDATE` as "Alias of `POLICY_EXISTS_UPDATE_ONLY`". This is a deliberate, recently-reviewed, documented design choice — not an unambiguous code bug. Changing the constant value would revert that decision and alter documented public-constant behavior, which needs maintainer approval. Skipped per the conservative scope.

**Candidate B — `TTL_CLIENT_DEFAULT = -3` rejected by `parse_ttl` — SKIPPED (no valid mapping).**
The `aerospike-core` `Expiration` enum has only four variants: `Seconds`, `NamespaceDefault`, `Never`, `DontUpdate`. There is **no "client default"** concept in the Rust core. Mapping `-3` in `parse_ttl` would require inventing behavior the underlying library does not support. Per the task's own guidance, this is a guess and was skipped.

The reported `policy["gen"]` and `touch()` vs `policy["ttl"]` changes were explicitly out of scope and not touched.