### PR TITLE
fix: increment offset validation, server-timeout error mapping, bit_resize flag guard

### DIFF
--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -438,8 +438,9 @@ impl PyAsyncClient {
         meta: Option<&Bound<'_, PyDict>>,
         policy: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let client = self.get_client()?;
-        let limiter = self.limiter.clone();
+        // Validate arguments (key shape, numeric offset) before the connection
+        // check so a malformed call fails the same way whether or not the
+        // client is connected — mirroring `put`.
         let args = client_common::prepare_increment_args(
             py,
             key,
@@ -449,6 +450,8 @@ impl PyAsyncClient {
             policy,
             &self.connection_info,
         )?;
+        let client = self.get_client()?;
+        let limiter = self.limiter.clone();
         debug!(
             "async increment: ns={} set={} bin={}",
             args.key.namespace, args.key.set_name, bin

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -472,7 +472,9 @@ impl PyClient {
         meta: Option<&Bound<'_, PyDict>>,
         policy: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<()> {
-        let client = self.get_client()?;
+        // Validate arguments (key shape, numeric offset) before the connection
+        // check so a malformed call fails the same way whether or not the
+        // client is connected — mirroring `put`.
         let args = client_common::prepare_increment_args(
             py,
             key,
@@ -482,6 +484,7 @@ impl PyClient {
             policy,
             &self.connection_info,
         )?;
+        let client = self.get_client()?;
         debug!(
             "increment: ns={} set={} bin={}",
             args.key.namespace, args.key.set_name, bin

--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -353,7 +353,7 @@ pub fn prepare_increment_args(
 ) -> PyResult<SingleBinWriteArgs> {
     let rust_key = py_to_key(key)?;
     let write_policy = parse_write_policy(policy, meta)?;
-    let value = crate::types::value::py_to_value(offset)?;
+    let value = parse_increment_offset(offset)?;
     let bins = vec![Bin::new(bin.to_string(), value)];
 
     Ok(SingleBinWriteArgs {
@@ -362,6 +362,25 @@ pub fn prepare_increment_args(
         bins,
         otel: OtelContext::new(py, conn_info),
     })
+}
+
+/// Convert an `increment()` offset to a numeric [`Value`].
+///
+/// The documented signature is `offset: Union[int, float]`. Without this guard
+/// the offset went through the generic `py_to_value`, which silently accepts
+/// strings, lists, dicts, etc. — a non-numeric offset would then be shipped to
+/// the server, which fails the `add` operation with an opaque `BinTypeError`
+/// instead of a clear client-side error. A Python `bool` is also rejected:
+/// although `bool` is an `int` subclass, `increment(key, bin, True)` is far
+/// more likely a mistake than an intentional `+1`.
+fn parse_increment_offset(offset: &Bound<'_, PyAny>) -> PyResult<Value> {
+    let value = crate::types::value::py_to_value(offset)?;
+    match value {
+        Value::Int(_) | Value::Float(_) => Ok(value),
+        other => Err(pyo3::exceptions::PyTypeError::new_err(format!(
+            "increment offset must be an int or float, got {other:?}"
+        ))),
+    }
 }
 
 // ── remove_bin ───────────────────────────────────────────────────────────────
@@ -1110,10 +1129,55 @@ pub fn prepare_create_role_args(
 
 #[cfg(test)]
 mod tests {
-    use super::extract_cluster_name;
+    use super::{extract_cluster_name, parse_increment_offset};
+    use aerospike_core::Value;
     use pyo3::exceptions::PyTypeError;
     use pyo3::prelude::*;
-    use pyo3::types::PyDict;
+    use pyo3::types::{PyDict, PyList};
+
+    #[test]
+    fn parse_increment_offset_accepts_int_and_float() {
+        Python::initialize();
+        Python::attach(|py| {
+            let int_off = 5_i64.into_pyobject(py).unwrap().into_any();
+            assert!(matches!(
+                parse_increment_offset(&int_off).expect("int offset should parse"),
+                Value::Int(5)
+            ));
+
+            let neg_off = (-3_i64).into_pyobject(py).unwrap().into_any();
+            assert!(matches!(
+                parse_increment_offset(&neg_off).expect("negative int should parse"),
+                Value::Int(-3)
+            ));
+
+            let float_off = 0.5_f64.into_pyobject(py).unwrap().into_any();
+            assert!(matches!(
+                parse_increment_offset(&float_off).expect("float offset should parse"),
+                Value::Float(_)
+            ));
+        });
+    }
+
+    #[test]
+    fn parse_increment_offset_rejects_non_numeric() {
+        Python::initialize();
+        Python::attach(|py| {
+            // String, list, and bool offsets must all raise instead of being
+            // shipped to the server as a non-numeric `add` operand.
+            let str_off = pyo3::types::PyString::new(py, "1").into_any();
+            let err = parse_increment_offset(&str_off).expect_err("string offset must be rejected");
+            assert!(err.is_instance_of::<PyTypeError>(py));
+
+            let list_off = PyList::new(py, [1, 2, 3]).unwrap().into_any();
+            let err = parse_increment_offset(&list_off).expect_err("list offset must be rejected");
+            assert!(err.is_instance_of::<PyTypeError>(py));
+
+            let bool_off = true.into_pyobject(py).unwrap().to_owned().into_any();
+            let err = parse_increment_offset(&bool_off).expect_err("bool offset must be rejected");
+            assert!(err.is_instance_of::<PyTypeError>(py));
+        });
+    }
 
     #[test]
     fn extract_cluster_name_returns_empty_for_missing_key() {

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -226,6 +226,7 @@ pub(crate) fn result_code_to_int(rc: &ResultCode) -> i32 {
         ResultCode::IndexFound => 200,
         ResultCode::IndexNotFound => 201,
         ResultCode::QueryAborted => 210,
+        ResultCode::QueryTimeout => 212,
         ResultCode::InvalidGeojson => 160,
         ResultCode::Unknown(code) => *code as i32,
         _ => -1,
@@ -262,6 +263,13 @@ pub fn as_to_pyerr(err: AsError) -> PyErr {
                 ResultCode::FilteredOut => FilteredOut::new_err(msg),
                 ResultCode::ElementNotFound | ResultCode::ElementExists => {
                     RecordError::new_err(msg)
+                }
+                // Server-side timeout: a server timeout result code must surface
+                // as AerospikeTimeoutError so callers (and HTTP layers mapping
+                // AerospikeTimeoutError -> 504) handle it like a client timeout
+                // instead of an opaque 500-class ServerError.
+                ResultCode::Timeout | ResultCode::QueryTimeout => {
+                    AerospikeTimeoutError::new_err(msg)
                 }
                 // Index
                 ResultCode::IndexFound => IndexFoundError::new_err(msg),
@@ -385,5 +393,45 @@ mod tests {
     #[test]
     fn test_result_code_to_int_unknown() {
         assert_eq!(result_code_to_int(&ResultCode::Unknown(250)), 250);
+    }
+
+    #[test]
+    fn test_result_code_to_int_query_timeout() {
+        // QueryTimeout previously fell through to the catch-all `-1`.
+        assert_eq!(result_code_to_int(&ResultCode::QueryTimeout), 212);
+    }
+
+    #[test]
+    fn test_server_timeout_maps_to_timeout_error() {
+        // A server-side Timeout result code must surface as AerospikeTimeoutError,
+        // not the generic ServerError it previously fell through to.
+        Python::initialize();
+        Python::attach(|py| {
+            let err = as_to_pyerr(AsError::ServerError(
+                ResultCode::Timeout,
+                false,
+                String::new(),
+            ));
+            assert!(
+                err.is_instance_of::<AerospikeTimeoutError>(py),
+                "server Timeout result code must map to AerospikeTimeoutError"
+            );
+        });
+    }
+
+    #[test]
+    fn test_query_timeout_maps_to_timeout_error() {
+        Python::initialize();
+        Python::attach(|py| {
+            let err = as_to_pyerr(AsError::ServerError(
+                ResultCode::QueryTimeout,
+                false,
+                String::new(),
+            ));
+            assert!(
+                err.is_instance_of::<AerospikeTimeoutError>(py),
+                "QueryTimeout result code must map to AerospikeTimeoutError"
+            );
+        });
     }
 }

--- a/rust/src/operations.rs
+++ b/rust/src/operations.rs
@@ -268,12 +268,24 @@ fn get_resize_flags(dict: &Bound<'_, PyDict>) -> PyResult<Option<BitwiseResizeFl
         .get_item("resize_flags")?
         .map(|v| v.extract())
         .transpose()?;
-    Ok(flags.map(|f| match f {
-        1 => BitwiseResizeFlags::FromFront,
-        2 => BitwiseResizeFlags::GrowOnly,
-        4 => BitwiseResizeFlags::ShrinkOnly,
-        _ => BitwiseResizeFlags::Default,
-    }))
+    // `BitwiseResizeFlags` is a plain enum in aerospike-core — it cannot
+    // represent OR-composed flags. An unrecognized value (e.g. the composed
+    // `GROW_ONLY | FROM_FRONT` == 3) previously collapsed to `Default`,
+    // silently dropping every requested flag — a resize meant to grow-only
+    // could then shrink and truncate data. Reject it loudly instead.
+    flags
+        .map(|f| match f {
+            0 => Ok(BitwiseResizeFlags::Default),
+            1 => Ok(BitwiseResizeFlags::FromFront),
+            2 => Ok(BitwiseResizeFlags::GrowOnly),
+            4 => Ok(BitwiseResizeFlags::ShrinkOnly),
+            other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "bit_resize 'resize_flags' must be a single flag \
+                 (0=DEFAULT, 1=FROM_FRONT, 2=GROW_ONLY, 4=SHRINK_ONLY); \
+                 OR-composed values are not supported, got {other}"
+            ))),
+        })
+        .transpose()
 }
 
 fn get_scan_value(dict: &Bound<'_, PyDict>) -> PyResult<bool> {
@@ -1081,9 +1093,58 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_i32_flag, parse_increment_value};
+    use super::{get_resize_flags, parse_i32_flag, parse_increment_value};
+    use aerospike_core::operations::bitwise::BitwiseResizeFlags;
     use aerospike_core::Value;
+    use pyo3::types::PyDict;
     use pyo3::{exceptions::PyTypeError, exceptions::PyValueError, PyErr, Python};
+
+    #[test]
+    fn get_resize_flags_accepts_known_single_flags() {
+        Python::initialize();
+        Python::attach(|py| {
+            // Missing key -> None (no flags requested).
+            let empty = PyDict::new(py);
+            assert!(get_resize_flags(&empty)
+                .expect("missing resize_flags is fine")
+                .is_none());
+
+            for (raw, expected) in [
+                (0, BitwiseResizeFlags::Default),
+                (1, BitwiseResizeFlags::FromFront),
+                (2, BitwiseResizeFlags::GrowOnly),
+                (4, BitwiseResizeFlags::ShrinkOnly),
+            ] {
+                let d = PyDict::new(py);
+                d.set_item("resize_flags", raw).unwrap();
+                let got = get_resize_flags(&d)
+                    .expect("known flag should parse")
+                    .expect("flag is present");
+                // BitwiseResizeFlags is not PartialEq; compare via discriminant.
+                assert_eq!(
+                    std::mem::discriminant(&got),
+                    std::mem::discriminant(&expected),
+                    "resize_flags {raw} should map to the matching flag"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn get_resize_flags_rejects_composed_or_unknown_value() {
+        Python::initialize();
+        Python::attach(|py| {
+            // 3 == GROW_ONLY | FROM_FRONT — must fail loudly, not silently
+            // collapse to Default and risk truncating data on resize.
+            for bad in [3, 5, 6, 7, 99] {
+                let d = PyDict::new(py);
+                d.set_item("resize_flags", bad).unwrap();
+                let err = get_resize_flags(&d)
+                    .expect_err("composed/unknown resize flag must be rejected");
+                assert!(err.is_instance_of::<PyValueError>(py));
+            }
+        });
+    }
 
     #[test]
     fn parse_i32_flag_defaults_to_zero_for_missing_or_nil() {
@@ -1178,7 +1239,7 @@ mod tests {
     // representation of the produced `Operation`.
 
     use pyo3::prelude::*;
-    use pyo3::types::{PyDict, PyList};
+    use pyo3::types::PyList;
 
     /// Build a single-op `PyList` from `(op_code, extra fields)` and convert it.
     fn convert_one_op<'py>(

--- a/tests/unit/test_put_validation.py
+++ b/tests/unit/test_put_validation.py
@@ -4,6 +4,7 @@ Covers:
 - #118: put(key, None) should raise TypeError, not RecordNotFound
 - put(key, non_dict) should raise TypeError
 - key tuple shape validation (explicit digest length, tuple arity)
+- increment() offset must be numeric (int/float), not silently shipped
 """
 
 import pytest
@@ -73,3 +74,43 @@ def test_put_oversized_key_tuple_raises():
     key = ("test", "demo", "k1", b"\x00" * 20, "extra")
     with pytest.raises(ValueError, match="3 or 4 elements"):
         c.put(key, {"v": 1})
+
+
+@pytest.mark.parametrize(
+    "bad_offset,desc",
+    [
+        ("5", "string"),
+        ([1, 2], "list"),
+        ({"a": 1}, "dict"),
+        (b"\x01", "bytes"),
+        (True, "bool"),
+        (None, "None"),
+    ],
+    ids=["string", "list", "dict", "bytes", "bool", "None"],
+)
+def test_increment_non_numeric_offset_raises_type_error(bad_offset, desc):
+    """increment(key, bin, offset) must reject a non-numeric offset.
+
+    The documented signature is ``offset: Union[int, float]``. A non-numeric
+    offset was previously converted through the generic value path and shipped
+    to the server, which then failed the ``add`` op with an opaque
+    ``BinTypeError`` instead of a clear client-side error. A Python ``bool`` is
+    rejected too: ``increment(key, bin, True)`` is far more likely a mistake
+    than an intentional ``+1``.
+    """
+    c = _make_client()
+    with pytest.raises(TypeError):
+        c.increment(("test", "demo", "k1"), "counter", bad_offset)
+
+
+@pytest.mark.parametrize("good_offset", [1, -3, 0, 2**40, 0.5, -1.25])
+def test_increment_numeric_offset_passes_validation(good_offset):
+    """A numeric offset passes client-side validation.
+
+    No server is connected, so the call fails later with a client/cluster
+    error — but never with a TypeError about the offset type.
+    """
+    c = _make_client()
+    with pytest.raises(aerospike_py.AerospikeError) as exc_info:
+        c.increment(("test", "demo", "k1"), "counter", good_offset)
+    assert not isinstance(exc_info.value, TypeError)


### PR DESCRIPTION
## Summary

Three correctness fixes found in a review of `origin/main`. All are real behavior bugs (API-contract violation, incorrect error mapping, silent data-corruption footgun) — no stylistic changes. Each fix ships with Rust unit tests; fix 1 also adds Python unit tests. No version bumps, no breaking changes.

---

### 1. `increment()` accepted non-numeric offsets and shipped them to the server

**Problem.** `Client.increment` / `AsyncClient.increment` document `offset: Union[int, float]` (`__init__.pyi`), but `prepare_increment_args` (`rust/src/client_common.rs`) converted the offset through the generic `py_to_value`, which silently accepts strings, lists, dicts, bytes, and bool.

**Root cause.** The offset bypassed any numeric check. A non-numeric offset became e.g. `Value::String(...)` and was sent to the server, which failed the `add` op with an opaque `BinTypeError` instead of a clear client-side error.

**Fix.** New `parse_increment_offset` accepts only `Value::Int` / `Value::Float`, raising `TypeError` otherwise (a Python `bool` is rejected too — `increment(key, bin, True)` is almost certainly a mistake). Mirrors the recent `list_increment` fix (#363). Both `increment` methods are also reordered to validate arguments **before** the connection check, matching `put`, so a malformed call fails identically connected or not.

**Test.** Rust: `parse_increment_offset` accepts int/float, rejects string/list/bool. Python: `test_put_validation.py` covers numeric (`1, -3, 0, 2**40, 0.5, -1.25`) and non-numeric offsets.

### 2. Server-side timeout result codes mapped to `ServerError` instead of `AerospikeTimeoutError`

**Problem.** `as_to_pyerr` (`rust/src/errors.rs`) routed `ResultCode::Timeout` (code 9) and `ResultCode::QueryTimeout` (code 212) through the catch-all `_` arm to a generic `ServerError`.

**Root cause.** Only the client-side `AsError::Timeout` variant mapped to `AerospikeTimeoutError`; server-reported timeouts were never special-cased. Callers catching `AerospikeTimeoutError` — and FastAPI apps mapping `AerospikeTimeoutError` → 504 — silently missed every server-side timeout and treated it as a 500-class error.

**Fix.** Map both timeout result codes to `AerospikeTimeoutError`. Also add `QueryTimeout` to `result_code_to_int` so `BatchRecord.result` and error messages carry the real wire code `212` instead of the meaningless `-1`.

**Test.** Rust: `as_to_pyerr` yields `AerospikeTimeoutError` for `Timeout` and `QueryTimeout`; `result_code_to_int(QueryTimeout) == 212`.

### 3. `bit_resize` silently dropped composed/unknown `resize_flags`

**Problem.** `get_resize_flags` (`rust/src/operations.rs`) matched only the exact values `0/1/2/4` and collapsed everything else — including the composed `GROW_ONLY | FROM_FRONT` (`== 3`) — to `Default` via a `_` arm.

**Root cause.** `BitwiseResizeFlags` is a plain (non-bitflags) enum in `aerospike-core`, so a composed value cannot be represented and was silently discarded. A `bit_resize` issued with a composed flag therefore lost every requested flag — a resize meant to be grow-only could shrink the bitmap and truncate data, with no error.

**Fix.** Return a `ValueError` for any value outside `{0, 1, 2, 4}`, so the mistake fails loudly at operation-conversion time.

**Test.** Rust: each known single flag parses; composed/unknown values (`3, 5, 6, 7, 99`) are rejected.

---

## Verification

- `cargo build` — pass
- `cargo test` — pass (188 tests, +7 new)
- `cargo clippy --features otel --all-targets -- -D warnings` — pass (exact pre-commit command)
- `cargo fmt --check` — pass
- `ruff check .` — pass
- `ruff format --check .` — pass
- `maturin develop --release` + `pytest tests/unit/` — pass (905 tests, +12 new; 8 skipped need a server)

The full CI matrix (Python 3.10–3.14, integration/compat suites) will run on this PR.

## Notes (not implemented — out of scope / needs discussion)

- **`AsyncClient.connect()` can wedge the state machine.** `connect()` CAS-transitions `DISCONNECTED → CONNECTING` and only stores `CONNECTED`/`DISCONNECTED` inside the returned awaitable. If a caller creates the coroutine and never awaits it (or it is GC'd first), the client is stuck in `CONNECTING` forever — `prepare_close()` rejects `CONNECTING`, so it can never recover. A drop-guard that reverts the state would fix it; left out as a narrow misuse case worth a separate change.
- **`result_code_to_int` returns `-1` for many named `ResultCode` variants** (e.g. `BatchMaxRequestsExceeded`, `QuotaExceeded`, `IndexOom`). Completing the table is ~40 lines and better done as its own change.