### PR TITLE
fix: connect() cancellation wedge, complete result_code table, batch error mapping

### DIFF
--- a/rust/src/async_client.rs
+++ b/rust/src/async_client.rs
@@ -17,6 +17,53 @@ const CONNECTING: u8 = 1;
 const CONNECTED: u8 = 2;
 const CLOSING: u8 = 3;
 
+/// RAII guard that reverts a stuck `CONNECTING` state back to `DISCONNECTED`.
+///
+/// `connect()` transitions the state machine to `CONNECTING` synchronously,
+/// then drives `AsClient::new()` inside the returned Python awaitable. If that
+/// awaitable is dropped before completing — e.g. the coroutine is garbage
+/// collected, cancelled, or wrapped in an `asyncio.wait_for()` that times out —
+/// the success/failure arms that move the state to `CONNECTED`/`DISCONNECTED`
+/// never run. Without this guard the client stays `CONNECTING` forever:
+/// `connect()` and `close()` both refuse to proceed and the client is wedged
+/// with no recovery path.
+///
+/// The guard's `Drop` only ever performs the `CONNECTING -> DISCONNECTED`
+/// transition (via CAS), so it can never clobber a state that the connect
+/// future already advanced. On the normal success/failure paths the future
+/// calls `disarm()` before storing the terminal state.
+struct ConnectStateGuard {
+    state: Arc<AtomicU8>,
+    armed: bool,
+}
+
+impl ConnectStateGuard {
+    fn new(state: Arc<AtomicU8>) -> Self {
+        Self { state, armed: true }
+    }
+
+    /// Disarm the guard once the connect future has reached a terminal arm
+    /// and will itself store the final state.
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ConnectStateGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            // Only revert if still CONNECTING; never overwrite a state the
+            // connect future may have already advanced.
+            let _ = self.state.compare_exchange(
+                CONNECTING,
+                DISCONNECTED,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
+        }
+    }
+}
+
 /// Outcome of preparing a close transition — see [`PyAsyncClient::prepare_close`].
 ///
 /// Computed synchronously while holding `&mut self` so the subsequent async
@@ -144,6 +191,11 @@ impl PyAsyncClient {
         let hosts_str = parsed.connection_string;
         info!("Async connecting to Aerospike cluster: {}", hosts_str);
         future_into_py(py, async move {
+            // Armed guard: if this future is dropped/cancelled before the
+            // match below runs, Drop reverts CONNECTING -> DISCONNECTED so the
+            // client is not permanently wedged.
+            let mut guard = ConnectStateGuard::new(state.clone());
+
             let result = AsClient::new(
                 &client_policy,
                 &hosts_str as &(dyn aerospike_core::ToHosts + Send + Sync),
@@ -153,11 +205,15 @@ impl PyAsyncClient {
             match result {
                 Ok(client) => {
                     inner.store(Some(Arc::new(client)));
+                    // We own the terminal transition now; disarm the guard so
+                    // its Drop cannot revert CONNECTED back to DISCONNECTED.
+                    guard.disarm();
                     state.store(CONNECTED, Ordering::SeqCst);
                     Ok(())
                 }
                 Err(e) => {
                     // Revert to Disconnected so retry is possible.
+                    guard.disarm();
                     state.store(DISCONNECTED, Ordering::SeqCst);
                     Err(as_to_pyerr(e))
                 }
@@ -1466,5 +1522,59 @@ impl PyAsyncClient {
         future_into_py(py, async move {
             client_ops::do_index_create(&client, args).await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connect_guard_reverts_stuck_connecting_on_drop() {
+        // Simulates a connect() awaitable that is dropped (cancelled / GC'd)
+        // before reaching its terminal arm: the guard's Drop must revert
+        // CONNECTING -> DISCONNECTED so the client is not wedged.
+        let state = Arc::new(AtomicU8::new(CONNECTING));
+        {
+            let _guard = ConnectStateGuard::new(state.clone());
+            assert_eq!(state.load(Ordering::SeqCst), CONNECTING);
+        }
+        assert_eq!(
+            state.load(Ordering::SeqCst),
+            DISCONNECTED,
+            "dropping an armed guard must revert CONNECTING to DISCONNECTED"
+        );
+    }
+
+    #[test]
+    fn connect_guard_disarm_preserves_connected_state() {
+        // On the success path the future disarms the guard and stores
+        // CONNECTED; the guard's Drop must not revert that.
+        let state = Arc::new(AtomicU8::new(CONNECTING));
+        {
+            let mut guard = ConnectStateGuard::new(state.clone());
+            guard.disarm();
+            state.store(CONNECTED, Ordering::SeqCst);
+        }
+        assert_eq!(
+            state.load(Ordering::SeqCst),
+            CONNECTED,
+            "a disarmed guard must not revert a CONNECTED state"
+        );
+    }
+
+    #[test]
+    fn connect_guard_never_clobbers_non_connecting_state() {
+        // If the state has already advanced past CONNECTING (e.g. a racing
+        // transition), an armed guard's CAS must be a no-op.
+        for terminal in [DISCONNECTED, CONNECTED, CLOSING] {
+            let state = Arc::new(AtomicU8::new(terminal));
+            drop(ConnectStateGuard::new(state.clone()));
+            assert_eq!(
+                state.load(Ordering::SeqCst),
+                terminal,
+                "armed guard must only act on CONNECTING, not state {terminal}"
+            );
+        }
     }
 }

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -182,7 +182,12 @@ pyo3::create_exception!(
 
 /// Map an `aerospike_core::ResultCode` to its integer wire-protocol value.
 ///
-/// Unknown variants are passed through; truly unrecognized variants return `-1`.
+/// Every variant is mapped explicitly to the wire code defined in the server's
+/// `proto.h` (mirroring `ResultCode::from_u8` in aerospike-core), so that
+/// `BatchRecord.result` and error messages always carry the real server code.
+/// `Unknown(code)` carries the raw byte through. The match is exhaustive — a
+/// new aerospike-core variant fails the build instead of silently collapsing
+/// to a meaningless `-1`.
 pub(crate) fn result_code_to_int(rc: &ResultCode) -> i32 {
     match rc {
         ResultCode::Ok => 0,
@@ -218,18 +223,117 @@ pub(crate) fn result_code_to_int(rc: &ResultCode) -> i32 {
         ResultCode::QueryEnd => 50,
         ResultCode::SecurityNotSupported => 51,
         ResultCode::SecurityNotEnabled => 52,
+        ResultCode::SecuritySchemeNotSupported => 53,
+        ResultCode::InvalidCommand => 54,
+        ResultCode::InvalidField => 55,
+        ResultCode::IllegalState => 56,
         ResultCode::InvalidUser => 60,
+        ResultCode::UserAlreadyExists => 61,
+        ResultCode::InvalidPassword => 62,
+        ResultCode::ExpiredPassword => 63,
+        ResultCode::ForbiddenPassword => 64,
+        ResultCode::InvalidCredential => 65,
+        ResultCode::ExpiredSession => 66,
+        ResultCode::InvalidRole => 70,
+        ResultCode::RoleAlreadyExists => 71,
+        ResultCode::InvalidPrivilege => 72,
+        ResultCode::InvalidAllowlist => 73,
+        ResultCode::QuotasNotEnabled => 74,
+        ResultCode::InvalidQuota => 75,
         ResultCode::NotAuthenticated => 80,
         ResultCode::RoleViolation => 81,
+        ResultCode::NotAllowlisted => 82,
+        ResultCode::QuotaExceeded => 83,
         ResultCode::UdfBadResponse => 100,
         ResultCode::BatchDisabled => 150,
+        ResultCode::BatchMaxRequestsExceeded => 151,
+        ResultCode::BatchQueuesFull => 152,
+        ResultCode::InvalidGeojson => 160,
         ResultCode::IndexFound => 200,
         ResultCode::IndexNotFound => 201,
+        ResultCode::IndexOom => 202,
+        ResultCode::IndexNotReadable => 203,
+        ResultCode::IndexGeneric => 204,
+        ResultCode::IndexNameMaxLen => 205,
+        ResultCode::IndexMaxCount => 206,
         ResultCode::QueryAborted => 210,
+        ResultCode::QueryQueueFull => 211,
         ResultCode::QueryTimeout => 212,
-        ResultCode::InvalidGeojson => 160,
+        ResultCode::QueryGeneric => 213,
+        ResultCode::QueryNetioErr => 214,
+        ResultCode::QueryDuplicate => 215,
         ResultCode::Unknown(code) => *code as i32,
-        _ => -1,
+    }
+}
+
+/// Map a server `ResultCode` (plus a pre-rendered message) to the most
+/// specific Python exception subclass.
+///
+/// Shared by every `aerospike_core::Error` variant that carries a
+/// `ResultCode` — `ServerError`, `BatchError`, and `BatchLastError` — so a
+/// batch failure surfaces the same exception type as the equivalent
+/// single-record failure (e.g. a batch server timeout becomes
+/// `AerospikeTimeoutError`, not a generic `ClientError`).
+fn result_code_to_pyerr(rc: &ResultCode, msg: String) -> PyErr {
+    match rc {
+        // Record-level: specific subclasses
+        ResultCode::KeyNotFoundError => RecordNotFound::new_err(msg),
+        ResultCode::KeyExistsError => RecordExistsError::new_err(msg),
+        ResultCode::GenerationError => RecordGenerationError::new_err(msg),
+        ResultCode::RecordTooBig => RecordTooBig::new_err(msg),
+        ResultCode::BinNameTooLong => BinNameError::new_err(msg),
+        ResultCode::BinExistsError => BinExistsError::new_err(msg),
+        ResultCode::BinNotFound => BinNotFound::new_err(msg),
+        ResultCode::BinTypeError => BinTypeError::new_err(msg),
+        ResultCode::FilteredOut => FilteredOut::new_err(msg),
+        ResultCode::ElementNotFound | ResultCode::ElementExists => RecordError::new_err(msg),
+        // Server-side timeout: a server timeout result code must surface
+        // as AerospikeTimeoutError so callers (and HTTP layers mapping
+        // AerospikeTimeoutError -> 504) handle it like a client timeout
+        // instead of an opaque 500-class ServerError.
+        ResultCode::Timeout | ResultCode::QueryTimeout => AerospikeTimeoutError::new_err(msg),
+        // Index
+        ResultCode::IndexFound => IndexFoundError::new_err(msg),
+        ResultCode::IndexNotFound => IndexNotFound::new_err(msg),
+        // Query
+        ResultCode::QueryAborted | ResultCode::ScanAbort => QueryAbortedError::new_err(msg),
+        // UDF
+        ResultCode::UdfBadResponse => UDFError::new_err(msg),
+        // Admin / Security — every security/auth/quota result code
+        // routes to AdminError so callers catching auth failures do
+        // not silently miss password/session/role/quota errors.
+        ResultCode::InvalidUser
+        | ResultCode::NotAuthenticated
+        | ResultCode::RoleViolation
+        | ResultCode::SecurityNotSupported
+        | ResultCode::SecurityNotEnabled
+        | ResultCode::SecuritySchemeNotSupported
+        | ResultCode::InvalidCommand
+        | ResultCode::InvalidField
+        | ResultCode::IllegalState
+        | ResultCode::UserAlreadyExists
+        | ResultCode::InvalidPassword
+        | ResultCode::ExpiredPassword
+        | ResultCode::ForbiddenPassword
+        | ResultCode::InvalidCredential
+        | ResultCode::ExpiredSession
+        | ResultCode::InvalidRole
+        | ResultCode::RoleAlreadyExists
+        | ResultCode::InvalidPrivilege
+        | ResultCode::InvalidAllowlist
+        | ResultCode::QuotasNotEnabled
+        | ResultCode::InvalidQuota
+        | ResultCode::NotAllowlisted
+        | ResultCode::QuotaExceeded => AdminError::new_err(msg),
+        // Default server error
+        _ => {
+            log::warn!(
+                "Unmapped ResultCode encountered in aerospike-py. \
+                 This may indicate aerospike-py needs updating for this server error code. \
+                 Error: {msg}"
+            );
+            ServerError::new_err(msg)
+        }
     }
 }
 
@@ -250,50 +354,18 @@ pub fn as_to_pyerr(err: AsError) -> PyErr {
             let code = result_code_to_int(rc);
             let doubt_suffix = if *in_doubt { " [in_doubt]" } else { "" };
             let msg = format!("AEROSPIKE_ERR ({code}): {err}{doubt_suffix}");
-            match rc {
-                // Record-level: specific subclasses
-                ResultCode::KeyNotFoundError => RecordNotFound::new_err(msg),
-                ResultCode::KeyExistsError => RecordExistsError::new_err(msg),
-                ResultCode::GenerationError => RecordGenerationError::new_err(msg),
-                ResultCode::RecordTooBig => RecordTooBig::new_err(msg),
-                ResultCode::BinNameTooLong => BinNameError::new_err(msg),
-                ResultCode::BinExistsError => BinExistsError::new_err(msg),
-                ResultCode::BinNotFound => BinNotFound::new_err(msg),
-                ResultCode::BinTypeError => BinTypeError::new_err(msg),
-                ResultCode::FilteredOut => FilteredOut::new_err(msg),
-                ResultCode::ElementNotFound | ResultCode::ElementExists => {
-                    RecordError::new_err(msg)
-                }
-                // Server-side timeout: a server timeout result code must surface
-                // as AerospikeTimeoutError so callers (and HTTP layers mapping
-                // AerospikeTimeoutError -> 504) handle it like a client timeout
-                // instead of an opaque 500-class ServerError.
-                ResultCode::Timeout | ResultCode::QueryTimeout => {
-                    AerospikeTimeoutError::new_err(msg)
-                }
-                // Index
-                ResultCode::IndexFound => IndexFoundError::new_err(msg),
-                ResultCode::IndexNotFound => IndexNotFound::new_err(msg),
-                // Query
-                ResultCode::QueryAborted | ResultCode::ScanAbort => QueryAbortedError::new_err(msg),
-                // UDF
-                ResultCode::UdfBadResponse => UDFError::new_err(msg),
-                // Admin / Security
-                ResultCode::InvalidUser
-                | ResultCode::NotAuthenticated
-                | ResultCode::RoleViolation
-                | ResultCode::SecurityNotSupported
-                | ResultCode::SecurityNotEnabled => AdminError::new_err(msg),
-                // Default server error
-                _ => {
-                    log::warn!(
-                        "Unmapped ResultCode encountered in aerospike-py. \
-                         This may indicate aerospike-py needs updating for this server error code. \
-                         Error: {msg}"
-                    );
-                    ServerError::new_err(msg)
-                }
-            }
+            result_code_to_pyerr(rc, msg)
+        }
+        // Batch errors carry a real server ResultCode. Route them through the
+        // same mapping as ServerError so a batch KeyNotFoundError / Timeout /
+        // auth failure raises the precise exception type instead of falling
+        // through to a generic ClientError plus a spurious bug-report log.
+        AsError::BatchError(idx, rc, in_doubt, _msg)
+        | AsError::BatchLastError(idx, rc, in_doubt, _msg) => {
+            let code = result_code_to_int(rc);
+            let doubt_suffix = if *in_doubt { " [in_doubt]" } else { "" };
+            let msg = format!("AEROSPIKE_ERR ({code}) [batch_index={idx}]: {err}{doubt_suffix}");
+            result_code_to_pyerr(rc, msg)
         }
         AsError::InvalidNode(msg) => ClusterError::new_err(format!("Invalid node: {msg}")),
         AsError::NoMoreConnections => ClusterError::new_err("No more connections available"),
@@ -402,6 +474,84 @@ mod tests {
     }
 
     #[test]
+    fn test_result_code_to_int_previously_unmapped_codes() {
+        // These variants previously collapsed to the meaningless `-1` catch-all,
+        // so BatchRecord.result and error messages lost the real wire code.
+        // Each must now carry its proto.h wire value.
+        assert_eq!(
+            result_code_to_int(&ResultCode::BatchMaxRequestsExceeded),
+            151
+        );
+        assert_eq!(result_code_to_int(&ResultCode::BatchQueuesFull), 152);
+        assert_eq!(result_code_to_int(&ResultCode::IndexOom), 202);
+        assert_eq!(result_code_to_int(&ResultCode::IndexNotReadable), 203);
+        assert_eq!(result_code_to_int(&ResultCode::IndexGeneric), 204);
+        assert_eq!(result_code_to_int(&ResultCode::IndexNameMaxLen), 205);
+        assert_eq!(result_code_to_int(&ResultCode::IndexMaxCount), 206);
+        assert_eq!(result_code_to_int(&ResultCode::QueryQueueFull), 211);
+        assert_eq!(result_code_to_int(&ResultCode::QueryGeneric), 213);
+        assert_eq!(result_code_to_int(&ResultCode::QueryNetioErr), 214);
+        assert_eq!(result_code_to_int(&ResultCode::QueryDuplicate), 215);
+        assert_eq!(result_code_to_int(&ResultCode::ExpiredSession), 66);
+        assert_eq!(result_code_to_int(&ResultCode::InvalidPassword), 62);
+        assert_eq!(result_code_to_int(&ResultCode::QuotaExceeded), 83);
+        assert_eq!(result_code_to_int(&ResultCode::UserAlreadyExists), 61);
+        assert_eq!(result_code_to_int(&ResultCode::IllegalState), 56);
+    }
+
+    #[test]
+    fn test_result_code_to_int_no_longer_returns_minus_one() {
+        // The `-1` catch-all is gone. Every named variant must map to its real
+        // non-negative wire code; only an `Unknown` byte can still be passed
+        // through verbatim. Spot-check a representative variant from each range.
+        for rc in [
+            ResultCode::Ok,
+            ResultCode::ServerError,
+            ResultCode::Timeout,
+            ResultCode::ElementExists,
+            ResultCode::XDRKeyBusy,
+            ResultCode::QueryEnd,
+            ResultCode::IllegalState,
+            ResultCode::ExpiredSession,
+            ResultCode::QuotaExceeded,
+            ResultCode::UdfBadResponse,
+            ResultCode::BatchQueuesFull,
+            ResultCode::InvalidGeojson,
+            ResultCode::IndexMaxCount,
+            ResultCode::QueryDuplicate,
+        ] {
+            assert!(
+                result_code_to_int(&rc) >= 0,
+                "result_code_to_int must not return -1 for {rc:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_security_result_codes_map_to_admin_error() {
+        // Password/session/role/quota security codes must surface as AdminError
+        // so callers catching auth failures do not silently miss them.
+        Python::initialize();
+        Python::attach(|py| {
+            for rc in [
+                ResultCode::InvalidPassword,
+                ResultCode::ExpiredSession,
+                ResultCode::InvalidCredential,
+                ResultCode::UserAlreadyExists,
+                ResultCode::InvalidRole,
+                ResultCode::QuotaExceeded,
+                ResultCode::NotAllowlisted,
+            ] {
+                let err = as_to_pyerr(AsError::ServerError(rc, false, String::new()));
+                assert!(
+                    err.is_instance_of::<AdminError>(py),
+                    "security result code {rc:?} must map to AdminError"
+                );
+            }
+        });
+    }
+
+    #[test]
     fn test_server_timeout_maps_to_timeout_error() {
         // A server-side Timeout result code must surface as AerospikeTimeoutError,
         // not the generic ServerError it previously fell through to.
@@ -431,6 +581,72 @@ mod tests {
             assert!(
                 err.is_instance_of::<AerospikeTimeoutError>(py),
                 "QueryTimeout result code must map to AerospikeTimeoutError"
+            );
+        });
+    }
+
+    #[test]
+    fn test_batch_error_maps_by_result_code() {
+        // BatchError / BatchLastError carry a real server ResultCode and must
+        // map to the same precise exception type as ServerError, instead of
+        // collapsing to a generic ClientError.
+        Python::initialize();
+        Python::attach(|py| {
+            let not_found = as_to_pyerr(AsError::BatchError(
+                3,
+                ResultCode::KeyNotFoundError,
+                false,
+                "node".into(),
+            ));
+            assert!(
+                not_found.is_instance_of::<RecordNotFound>(py),
+                "batch KeyNotFoundError must map to RecordNotFound"
+            );
+
+            let timeout = as_to_pyerr(AsError::BatchLastError(
+                0,
+                ResultCode::Timeout,
+                true,
+                "node".into(),
+            ));
+            assert!(
+                timeout.is_instance_of::<AerospikeTimeoutError>(py),
+                "batch Timeout must map to AerospikeTimeoutError"
+            );
+
+            let big = as_to_pyerr(AsError::BatchError(
+                7,
+                ResultCode::RecordTooBig,
+                false,
+                "node".into(),
+            ));
+            assert!(
+                big.is_instance_of::<RecordTooBig>(py),
+                "batch RecordTooBig must map to RecordTooBig"
+            );
+        });
+    }
+
+    #[test]
+    fn test_batch_error_message_includes_index_and_in_doubt() {
+        // The rendered message must surface the batch index and the in_doubt
+        // flag so callers can retry/diagnose the failed sub-request.
+        Python::initialize();
+        Python::attach(|py| {
+            let err = as_to_pyerr(AsError::BatchLastError(
+                5,
+                ResultCode::ServerError,
+                true,
+                "node".into(),
+            ));
+            let text = err.value(py).to_string();
+            assert!(
+                text.contains("batch_index=5"),
+                "batch error message must include the batch index: {text}"
+            );
+            assert!(
+                text.contains("in_doubt"),
+                "in_doubt batch error message must be flagged: {text}"
             );
         });
     }

--- a/tests/unit/test_client_lifecycle.py
+++ b/tests/unit/test_client_lifecycle.py
@@ -4,7 +4,10 @@ Covers:
 - Double-connect error for both Client and AsyncClient
 - Close on disconnected client is idempotent
 - Operations on closed client raise ClientError
+- AsyncClient.connect() cancellation does not wedge the state machine
 """
+
+import asyncio
 
 import pytest
 
@@ -76,5 +79,47 @@ class TestAsyncClientLifecycle:
     async def test_is_connected_false_after_close(self):
         """is_connected() should return False after close()."""
         c = aerospike_py.AsyncClient(DUMMY_CONFIG)
+        await c.close()
+        assert c.is_connected() is False
+
+    async def test_cancelled_connect_does_not_wedge_state(self):
+        """A cancelled connect() must revert to Disconnected, not stay stuck.
+
+        Previously, cancelling an in-flight ``connect()`` (e.g. via
+        ``asyncio.wait_for`` timeout) left the client permanently in the
+        ``CONNECTING`` state: both ``connect()`` and ``close()`` then refused
+        to proceed and the client could never be recovered. The native
+        connect future now reverts ``CONNECTING -> DISCONNECTED`` on drop.
+        """
+        c = aerospike_py.AsyncClient(DUMMY_CONFIG)
+
+        # Drive connect() to a dead port and cancel it almost immediately so
+        # the underlying future is dropped while still mid-connect.
+        with pytest.raises((asyncio.TimeoutError, aerospike_py.AerospikeError)):
+            await asyncio.wait_for(c.connect(), timeout=0.001)
+
+        # Give the cancelled future a chance to be dropped and run its guard.
+        await asyncio.sleep(0.05)
+
+        # The client must not be wedged: close() must succeed (idempotent or
+        # real), and a fresh connect() must be allowed to run again rather
+        # than failing with "client is already connecting".
+        await c.close()  # must not raise "client is currently connecting"
+        with pytest.raises(aerospike_py.AerospikeError) as excinfo:
+            await c.connect()
+        assert "already connecting" not in str(excinfo.value), (
+            "connect() after a cancelled connect must not see a wedged CONNECTING state"
+        )
+
+    async def test_close_after_cancelled_connect_is_not_blocked(self):
+        """close() must recover a client whose connect() was cancelled."""
+        c = aerospike_py.AsyncClient(DUMMY_CONFIG)
+        task = asyncio.ensure_future(c.connect())
+        await asyncio.sleep(0)  # let the connect future start
+        task.cancel()
+        with pytest.raises((asyncio.CancelledError, aerospike_py.AerospikeError)):
+            await task
+        await asyncio.sleep(0.05)
+        # close() must not raise "client is currently connecting".
         await c.close()
         assert c.is_connected() is False


### PR DESCRIPTION
Three genuine correctness fixes in the PyO3 error/lifecycle layer, found while
auditing `origin/main`. Two are the findings explicitly deferred from #368
(the `connect()` state-machine wedge and the incomplete `result_code_to_int`
table); the third (batch error mapping) was found during the same audit.

## Issue 1 — `AsyncClient.connect()` cancellation permanently wedges the client

**Problem.** Cancelling an in-flight `AsyncClient.connect()` — via
`asyncio.wait_for` timeout, task cancellation, or a GC'd coroutine — leaves the
client permanently in the `CONNECTING` state. `connect()` then errors with
"client is already connecting" and `close()` errors with "client is currently
connecting": the client cannot be recovered.

**Root cause.** `connect()` transitions the state machine to `CONNECTING`
synchronously, then drives `AsClient::new()` inside the returned Python
awaitable. The `match` arms that move state to `CONNECTED`/`DISCONNECTED` only
run if that awaitable is polled to completion. If it is dropped first, the
state stays `CONNECTING` with no recovery path. (The sync `Client` is immune —
its `connect()` runs start-to-finish without a cancellation point.)

**Fix.** Add `ConnectStateGuard`, an RAII guard whose `Drop` reverts
`CONNECTING -> DISCONNECTED` via a CAS (so it can never clobber a state the
future already advanced). The success/failure arms call `disarm()` before
storing their terminal state. When the connect future is dropped mid-flight,
the guard runs and unsticks the state machine.

**Test.** Rust unit tests for the guard (revert-on-drop, disarm preserves
`CONNECTED`, never clobbers a non-`CONNECTING` state) plus Python regression
tests in `test_client_lifecycle.py` that cancel an in-flight `connect()` and
assert `close()` and a subsequent `connect()` are not blocked.

## Issue 2 — `result_code_to_int` collapses ~18 server codes to `-1`

**Problem.** `BatchRecord.result` and error messages report a meaningless `-1`
for ~18 server result codes — including batch-relevant ones like
`BatchMaxRequestsExceeded` (151) and `BatchQueuesFull` (152), plus `IndexOom`
(202), `QuotaExceeded` (83), `ExpiredSession` (66), and others.

**Root cause.** `result_code_to_int` mapped ~40 of aerospike-core's 60+
`ResultCode` variants and routed the rest through a `_ => -1` catch-all.

**Fix.** Map every variant explicitly to its proto.h wire code (mirroring
`ResultCode::from_u8`) and remove the `-1` catch-all, so a future
aerospike-core variant fails the build instead of silently degrading. Also
extend the `as_to_pyerr` Admin/Security arm — previously only 5 codes — to
route every auth/password/session/role/quota code to `AdminError` instead of
the generic `ServerError` fallback, so callers catching auth failures do not
miss them.

**Test.** Rust unit tests for the previously unmapped wire codes and for the
security-code -> `AdminError` mapping.

## Issue 3 — batch errors bypass `ResultCode`-based exception mapping

**Problem.** A batch sub-request failing with a server timeout does not become
`AerospikeTimeoutError`, and a batch `KeyNotFoundError` does not become
`RecordNotFound` — both surface as a generic `ClientError`. Worse, every batch
error is falsely logged as an "Unmapped aerospike_core::Error variant" bug
report.

**Root cause.** `as_to_pyerr` handled `ServerError` (which carries a
`ResultCode`) but not `BatchError` / `BatchLastError`, which also carry a real
server `ResultCode` and `in_doubt` flag. They fell into the catch-all arm.

**Fix.** Extract the shared `ResultCode -> PyErr` mapping into
`result_code_to_pyerr` and route `ServerError`, `BatchError`, and
`BatchLastError` through it, so a batch failure raises the same precise
exception type as the equivalent single-record failure. Batch error messages
now also include the failing `batch_index` and the `in_doubt` flag.

**Test.** Rust unit tests asserting batch errors map to the precise exception
type (`RecordNotFound`, `AerospikeTimeoutError`, `RecordTooBig`) and that the
message carries the index and `in_doubt`.

## Verification

All run locally on this branch:

- `cargo build --manifest-path rust/Cargo.toml` — succeeds
- `cargo test --manifest-path rust/Cargo.toml` — **196 passed**, 0 failed (188 baseline + 8 new)
- `cargo clippy --manifest-path rust/Cargo.toml --all-targets` — **0 warnings**
- `cargo fmt --manifest-path rust/Cargo.toml --check` — clean
- `uv run maturin develop --release` — builds the extension
- `uv run python -m pytest tests/unit -q` — **907 passed**, 8 skipped (server-required)
- `ruff check` / `ruff format --check` on the modified test file — clean

## Scope

3 files changed (`rust/src/errors.rs`, `rust/src/async_client.rs`,
`tests/unit/test_client_lifecycle.py`). Production-code changes are modest; the
bulk of the line count is added test coverage. No version keys touched, no
public API renamed, no exported symbols removed — all changes are internal
correctness fixes. The `result_code_to_int` and `as_to_pyerr` changes only
make previously-degraded mappings more precise; no existing mapping changed
direction in a breaking way.