### PR TITLE
fix: require HLL and map_put_items 'val' to prevent silent Nil substitution

### DIFF
--- a/rust/src/operations.rs
+++ b/rust/src/operations.rs
@@ -44,6 +44,24 @@ fn require_bitwise_value(val: Option<Value>, op_name: &str) -> PyResult<Value> {
     val.ok_or_else(|| pyo3::exceptions::PyValueError::new_err(format!("{op_name} requires 'val'")))
 }
 
+/// Require a `val` for an HLL or map op-dispatch arm.
+///
+/// Same failure mode as the bitwise variant: a missing `val` used to default
+/// to `Value::Nil`, which downstream helpers like `values_from_list` happily
+/// coerce into an empty list. For `hll_add` that silently means "add zero
+/// values" (the HLL bin is created on first use but no elements register);
+/// for `hll_get_union` / `_union_count` / `_intersect_count` / `_similarity`
+/// / `_set_union` it means "compare against zero HLL bins", quietly producing
+/// a 0/1.0 result that the caller cannot distinguish from an empty input. For
+/// `map_put_items` it bypassed the `Value::HashMap` arm and fell through to
+/// the ambiguous "map_put_items requires a dict value" error even though the
+/// real bug was a missing `val` key. All the corresponding Python facade
+/// helpers already require their values/items as positional arguments, so this
+/// only fires for callers who construct op dicts directly.
+fn require_hll_value(val: Option<Value>, op_name: &str) -> PyResult<Value> {
+    val.ok_or_else(|| pyo3::exceptions::PyValueError::new_err(format!("{op_name} requires 'val'")))
+}
+
 fn get_index(dict: &Bound<'_, PyDict>) -> PyResult<i64> {
     dict.get_item("index")?
         .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("Operation requires 'index'"))?
@@ -647,7 +665,12 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             OP_MAP_PUT_ITEMS => {
                 let name = require_bin(&bin_name, "map_put_items")?;
                 let policy = parse_map_policy(dict)?;
-                let v = val.unwrap_or(Value::Nil);
+                // Reject a missing `val` explicitly. The old fallback to
+                // `Value::Nil` here landed in the catch-all arm below and
+                // produced the misleading "map_put_items requires a dict
+                // value" error, even though the real bug was a missing
+                // top-level `val` key.
+                let v = require_hll_value(val, "map_put_items")?;
                 // Convert Value::HashMap to HashMap
                 match v {
                     Value::HashMap(map) => map_ops::put_items(&policy, &name, map),
@@ -847,7 +870,10 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             OP_HLL_ADD => {
                 let name = require_bin(&bin_name, "hll_add")?;
                 let policy = parse_hll_policy(dict)?;
-                let v = val.unwrap_or(Value::Nil);
+                // Reject missing `val` rather than defaulting to `Value::Nil`,
+                // which `values_from_list` coerces to an empty list — silently
+                // turning `hll_add` into a no-op that still creates the bin.
+                let v = require_hll_value(val, "hll_add")?;
                 let list = values_from_list(&v);
                 let index_bit_count: i64 = dict
                     .get_item("index_bit_count")?
@@ -873,22 +899,25 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             }
             OP_HLL_GET_UNION => {
                 let name = require_bin(&bin_name, "hll_get_union")?;
-                let v = val.unwrap_or(Value::Nil);
+                // Missing `val` would degrade to "union with zero HLL bins"
+                // and return the bin contents unchanged — see require_hll_value
+                // for the full rationale.
+                let v = require_hll_value(val, "hll_get_union")?;
                 hll_ops::get_union(&name, values_from_list(&v))
             }
             OP_HLL_GET_UNION_COUNT => {
                 let name = require_bin(&bin_name, "hll_get_union_count")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "hll_get_union_count")?;
                 hll_ops::get_union_count(&name, values_from_list(&v))
             }
             OP_HLL_GET_INTERSECT_COUNT => {
                 let name = require_bin(&bin_name, "hll_get_intersect_count")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "hll_get_intersect_count")?;
                 hll_ops::get_intersect_count(&name, values_from_list(&v))
             }
             OP_HLL_GET_SIMILARITY => {
                 let name = require_bin(&bin_name, "hll_get_similarity")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "hll_get_similarity")?;
                 hll_ops::get_similarity(&name, values_from_list(&v))
             }
             OP_HLL_DESCRIBE => {
@@ -910,7 +939,10 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             OP_HLL_SET_UNION => {
                 let name = require_bin(&bin_name, "hll_set_union")?;
                 let policy = parse_hll_policy(dict)?;
-                let v = val.unwrap_or(Value::Nil);
+                // Missing `val` would replace the bin with the union of zero
+                // HLL bins (i.e. silently clear it). Force the caller to
+                // supply the list explicitly.
+                let v = require_hll_value(val, "hll_set_union")?;
                 hll_ops::set_union(&policy, &name, values_from_list(&v))
             }
 
@@ -1486,5 +1518,152 @@ mod tests {
     fn bit_and_missing_val_raises_value_error() {
         assert_bit_op_missing_val_errors(super::OP_BIT_AND, "bit_and");
         assert_bit_op_with_val_succeeds(super::OP_BIT_AND);
+    }
+
+    // ── HLL ops: missing `val` must error, not silently become Nil ────────
+    //
+    // Regression for the bug where the OP_HLL_ADD / OP_HLL_GET_UNION /
+    // OP_HLL_GET_UNION_COUNT / OP_HLL_GET_INTERSECT_COUNT /
+    // OP_HLL_GET_SIMILARITY / OP_HLL_SET_UNION arms defaulted a missing
+    // `val` key to `Value::Nil`. Downstream `values_from_list` coerces Nil
+    // to an empty list, so `hll_add` silently registered zero elements
+    // (while still creating the bin) and the get_* ops compared against
+    // zero HLL bins — producing a 0/1.0 result the caller could not
+    // distinguish from a genuinely empty input. The fix raises
+    // ValueError("<op> requires 'val'") so a caller building op dicts
+    // directly gets a clear failure instead.
+
+    /// Build a single HLL-op dict with the given op code, optionally setting
+    /// `val` to a list of byte payloads (each payload represents an HLL bin
+    /// value or, for `hll_add`, an item to register).
+    fn build_hll_op_dict<'py>(
+        py: Python<'py>,
+        op_code: i32,
+        with_val: Option<Vec<&[u8]>>,
+    ) -> Bound<'py, PyDict> {
+        let dict = PyDict::new(py);
+        dict.set_item("op", op_code).unwrap();
+        dict.set_item("bin", "mybin").unwrap();
+        if let Some(items) = with_val {
+            let list = PyList::new(py, items).unwrap();
+            dict.set_item("val", list).unwrap();
+        }
+        dict
+    }
+
+    fn assert_hll_op_missing_val_errors(op_code: i32, op_name: &str) {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = build_hll_op_dict(py, op_code, None);
+            let ops = PyList::new(py, [dict]).unwrap();
+            let err = super::py_ops_to_rust(&ops)
+                .expect_err("missing 'val' must raise ValueError, not silently become Nil");
+            assert!(err.is_instance_of::<PyValueError>(py));
+            let msg = err.to_string();
+            assert!(
+                msg.contains(op_name) && msg.contains("val"),
+                "error message should mention '{op_name}' and 'val', got: {msg}"
+            );
+        });
+    }
+
+    fn assert_hll_op_with_val_succeeds(op_code: i32) {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = build_hll_op_dict(py, op_code, Some(vec![b"\x00\x01"]));
+            let ops = PyList::new(py, [dict]).unwrap();
+            let converted =
+                super::py_ops_to_rust(&ops).expect("HLL op with explicit val must succeed");
+            assert_eq!(converted.len(), 1);
+        });
+    }
+
+    #[test]
+    fn hll_add_missing_val_raises_value_error() {
+        assert_hll_op_missing_val_errors(super::OP_HLL_ADD, "hll_add");
+        assert_hll_op_with_val_succeeds(super::OP_HLL_ADD);
+    }
+
+    #[test]
+    fn hll_get_union_missing_val_raises_value_error() {
+        assert_hll_op_missing_val_errors(super::OP_HLL_GET_UNION, "hll_get_union");
+        assert_hll_op_with_val_succeeds(super::OP_HLL_GET_UNION);
+    }
+
+    #[test]
+    fn hll_get_union_count_missing_val_raises_value_error() {
+        assert_hll_op_missing_val_errors(super::OP_HLL_GET_UNION_COUNT, "hll_get_union_count");
+        assert_hll_op_with_val_succeeds(super::OP_HLL_GET_UNION_COUNT);
+    }
+
+    #[test]
+    fn hll_get_intersect_count_missing_val_raises_value_error() {
+        assert_hll_op_missing_val_errors(
+            super::OP_HLL_GET_INTERSECT_COUNT,
+            "hll_get_intersect_count",
+        );
+        assert_hll_op_with_val_succeeds(super::OP_HLL_GET_INTERSECT_COUNT);
+    }
+
+    #[test]
+    fn hll_get_similarity_missing_val_raises_value_error() {
+        assert_hll_op_missing_val_errors(super::OP_HLL_GET_SIMILARITY, "hll_get_similarity");
+        assert_hll_op_with_val_succeeds(super::OP_HLL_GET_SIMILARITY);
+    }
+
+    #[test]
+    fn hll_set_union_missing_val_raises_value_error() {
+        assert_hll_op_missing_val_errors(super::OP_HLL_SET_UNION, "hll_set_union");
+        assert_hll_op_with_val_succeeds(super::OP_HLL_SET_UNION);
+    }
+
+    // ── map_put_items: missing `val` must error with a clear message ──────
+    //
+    // Regression for the bug where omitting `val` from a `map_put_items`
+    // op dict landed in the `Value::Nil` catch-all arm and produced the
+    // misleading "map_put_items requires a dict value" error, even though
+    // the real bug was a missing top-level `val` key. The fix raises
+    // ValueError("map_put_items requires 'val'") before the type check, so
+    // the error always names the actual missing key.
+
+    #[test]
+    fn map_put_items_missing_val_raises_value_error_with_val_in_message() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("op", super::OP_MAP_PUT_ITEMS).unwrap();
+            dict.set_item("bin", "mybin").unwrap();
+            // intentionally omit "val"
+            let ops = PyList::new(py, [dict]).unwrap();
+
+            let err = super::py_ops_to_rust(&ops)
+                .expect_err("map_put_items without 'val' must raise ValueError");
+            assert!(err.is_instance_of::<PyValueError>(py));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("map_put_items") && msg.contains("val"),
+                "error message should mention 'map_put_items' and 'val' (not just \
+                 'requires a dict value'), got: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn map_put_items_with_dict_val_succeeds() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("op", super::OP_MAP_PUT_ITEMS).unwrap();
+            dict.set_item("bin", "mybin").unwrap();
+            let items = PyDict::new(py);
+            items.set_item("a", 1i64).unwrap();
+            items.set_item("b", 2i64).unwrap();
+            dict.set_item("val", items).unwrap();
+            let ops = PyList::new(py, [dict]).unwrap();
+
+            let converted = super::py_ops_to_rust(&ops)
+                .expect("map_put_items with explicit dict val must succeed");
+            assert_eq!(converted.len(), 1);
+        });
     }
 }

--- a/tests/unit/test_hll_operations.py
+++ b/tests/unit/test_hll_operations.py
@@ -165,6 +165,51 @@ class TestHLLOperations:
         op = hll_set_union("mybin", [b"\x00"])
         assert "hll_policy" not in op
 
+    def test_hll_ops_facade_always_emits_val(self):
+        """Regression: hll_add / hll_get_union / hll_get_union_count /
+        hll_get_intersect_count / hll_get_similarity / hll_set_union op dicts
+        must always include `val`.
+
+        At the Rust dispatch layer (operations.rs OP_HLL_{ADD,GET_UNION,
+        GET_UNION_COUNT,GET_INTERSECT_COUNT,GET_SIMILARITY,SET_UNION} arms), a
+        missing `val` raises ValueError rather than silently defaulting to
+        `Value::Nil` (which `values_from_list` would coerce into an empty list,
+        producing a no-op `hll_add` or "compared against zero HLL bins" result
+        the caller could not distinguish from a genuinely empty input). The
+        Python facade signatures already require `values` as a positional
+        argument; this test asserts both that the emitted op carries the value
+        through and that the facade has no default that would let a caller omit
+        it.
+        """
+        emitting = [
+            (hll_add, ("mybin", ["a", "b"]), 3002),
+            (hll_get_union, ("mybin", [b"\x00"]), 3004),
+            (hll_get_union_count, ("mybin", [b"\x00"]), 3005),
+            (hll_get_intersect_count, ("mybin", [b"\x00"]), 3006),
+            (hll_get_similarity, ("mybin", [b"\x00"]), 3007),
+            (hll_set_union, ("mybin", [b"\x00"]), 3010),
+        ]
+        for func, args, expected_op in emitting:
+            op = func(*args)
+            assert op["op"] == expected_op
+            assert "val" in op, f"{func.__name__} must emit 'val' in op dict"
+            assert op["val"] == args[-1]
+
+        # The facade has no default that would let a caller produce a
+        # value-less op dict for any of these ops.
+        with pytest.raises(TypeError):
+            hll_add("mybin")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            hll_get_union("mybin")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            hll_get_union_count("mybin")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            hll_get_intersect_count("mybin")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            hll_get_similarity("mybin")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            hll_set_union("mybin")  # type: ignore[call-arg]
+
 
 class TestHLLModuleAccess:
     """Test that the module is accessible from the package."""

--- a/tests/unit/test_list_map_ops.py
+++ b/tests/unit/test_list_map_ops.py
@@ -364,6 +364,26 @@ class TestMapOperations:
         assert op["rank"] == expected_rank
         assert "count" not in op
 
+    def test_map_put_items_facade_always_emits_val(self):
+        """Regression: `map_put_items` op dict must always include `val`.
+
+        At the Rust dispatch layer (operations.rs OP_MAP_PUT_ITEMS arm), a
+        missing `val` raises ValueError("map_put_items requires 'val'") rather
+        than falling through to the catch-all `Value::Nil` arm and producing
+        the misleading "map_put_items requires a dict value" error. The Python
+        facade signature already requires `items`, but assert the emitted op
+        carries it through so direct dict callers and facade callers agree.
+        """
+        op = map_put_items("mybin", {"a": 1, "b": 2})
+        assert op["op"] == 2003
+        assert op["bin"] == "mybin"
+        assert "val" in op
+        assert op["val"] == {"a": 1, "b": 2}
+        # The facade has no default that would let a caller produce a
+        # map_put_items op without supplying items.
+        with pytest.raises(TypeError):
+            map_put_items("mybin")  # type: ignore[call-arg]
+
 
 class TestModuleAccess:
     """Test that modules are accessible from the package."""


### PR DESCRIPTION
## Summary

Extends the same guard pattern as #371 (bit ops) and #370 (`list_trim` count) to the **HLL CDT arms** and to `map_put_items`. Each was silently substituting a missing top-level `val` key with `Value::Nil` at the Rust op-dispatch layer, producing wrong-result operations that callers could not distinguish from valid empty input.

## What changed

`rust/src/operations.rs`:

* New `require_hll_value()` helper, mirroring `require_bitwise_value()` from #371.
* **HLL arms** (`OP_HLL_ADD`, `OP_HLL_GET_UNION`, `OP_HLL_GET_UNION_COUNT`, `OP_HLL_GET_INTERSECT_COUNT`, `OP_HLL_GET_SIMILARITY`, `OP_HLL_SET_UNION`): replaced `val.unwrap_or(Value::Nil)` with `require_hll_value(val, "<op>")?`.
* **`OP_MAP_PUT_ITEMS`**: replaced the silent `Value::Nil` fallback with the same require pattern, so the error names the actual missing key (`'val'`) instead of the misleading "map_put_items requires a dict value".

### Failure modes the old code allowed

| Op | Old behavior on missing `val` |
|----|--------------------------------|
| `hll_add` | `values_from_list(Nil)` → empty list → registered zero elements but still created the bin |
| `hll_get_union` / `_union_count` / `_intersect_count` / `_similarity` | Compared bin against zero HLL bins → 0 / 1.0 result indistinguishable from empty input |
| `hll_set_union` | Replaced bin with union of zero HLL bins → silently cleared it |
| `map_put_items` | Fell through to catch-all arm → misleading error message hiding the real missing-key bug |

After this PR all seven arms raise `ValueError("<op> requires 'val'")` with the op name in the message.

### Scope

PATCH-class. The Python facade helpers (`aerospike_py.hll_operations.*`, `aerospike_py.map_operations.map_put_items`) already require these values as positional arguments, so the new error only fires for callers building op dicts directly. No public-API or wire-protocol change.

## Tests

**Rust** (`rust/src/operations.rs` test module, +8 tests):
* `hll_add_missing_val_raises_value_error`
* `hll_get_union_missing_val_raises_value_error`
* `hll_get_union_count_missing_val_raises_value_error`
* `hll_get_intersect_count_missing_val_raises_value_error`
* `hll_get_similarity_missing_val_raises_value_error`
* `hll_set_union_missing_val_raises_value_error`
* `map_put_items_missing_val_raises_value_error_with_val_in_message`
* `map_put_items_with_dict_val_succeeds`

Each HLL test exercises both the missing-val (ValueError + op name in msg) and explicit-val (success) paths via `py_ops_to_rust()`, mirroring the bit-op test fixture from #371.

**Python** (regression tests):
* `tests/unit/test_hll_operations.py`: `test_hll_ops_facade_always_emits_val` covers all six HLL helpers — asserts `'val'` is emitted in the op dict and that the facade rejects calls without `values` (`TypeError`).
* `tests/unit/test_list_map_ops.py`: `test_map_put_items_facade_always_emits_val` mirrors the `list_trim` and bit-ops facade tests for `map_put_items`.

## Verification

| Command | Result |
|---------|--------|
| `cargo fmt --check` | PASS |
| `cargo clippy -- -D warnings` | PASS |
| `cargo test --lib operations` | PASS (26 tests, including 8 new) |
| `uv run pytest tests/unit/` | PASS (911 passed, 8 skipped) |
| `uv run ruff check` | PASS |
| `uv run ruff format --check` | PASS (162 files) |

## Diff stats

```
rust/src/operations.rs            | 193 ++++++++++++++++++++++++++++++++++++--
tests/unit/test_hll_operations.py |  45 +++++++++
tests/unit/test_list_map_ops.py   |  20 ++++
3 files changed, 251 insertions(+), 7 deletions(-)
```

Production-code change is ~60 LOC in `operations.rs`; the rest is tests.

## Related

* #371 — bit-ops silent `Nil` substitution (this PR follows the same pattern)
* #370 — `list_trim` silent `count=0` truncation
