### PR TITLE
fix: require list/map BY_VALUE ops to specify 'val' to prevent silent Nil substitution

### DIFF
--- a/rust/src/operations.rs
+++ b/rust/src/operations.rs
@@ -847,7 +847,7 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             }
             OP_MAP_GET_BY_VALUE_LIST => {
                 let name = require_bin(&bin_name, "map_get_by_value_list")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "map_get_by_value_list")?;
                 let rt = int_to_map_return_type(get_return_type(dict)?);
                 map_ops::get_by_value_list(&name, values_from_list(&v), rt)
             }
@@ -1831,5 +1831,14 @@ mod tests {
             "map_remove_by_value_list",
         );
         assert_by_value_list_op_with_val_succeeds(super::OP_MAP_REMOVE_BY_VALUE_LIST);
+    }
+
+    #[test]
+    fn map_get_by_value_list_missing_val_raises_value_error() {
+        assert_by_value_list_op_missing_val_errors(
+            super::OP_MAP_GET_BY_VALUE_LIST,
+            "map_get_by_value_list",
+        );
+        assert_by_value_list_op_with_val_succeeds(super::OP_MAP_GET_BY_VALUE_LIST);
     }
 }

--- a/rust/src/operations.rs
+++ b/rust/src/operations.rs
@@ -44,20 +44,24 @@ fn require_bitwise_value(val: Option<Value>, op_name: &str) -> PyResult<Value> {
     val.ok_or_else(|| pyo3::exceptions::PyValueError::new_err(format!("{op_name} requires 'val'")))
 }
 
-/// Require a `val` for an HLL or map op-dispatch arm.
+/// Require a `val` for an HLL, list-by-value, or map-by-value op-dispatch arm.
 ///
 /// Same failure mode as the bitwise variant: a missing `val` used to default
 /// to `Value::Nil`, which downstream helpers like `values_from_list` happily
-/// coerce into an empty list. For `hll_add` that silently means "add zero
-/// values" (the HLL bin is created on first use but no elements register);
-/// for `hll_get_union` / `_union_count` / `_intersect_count` / `_similarity`
-/// / `_set_union` it means "compare against zero HLL bins", quietly producing
-/// a 0/1.0 result that the caller cannot distinguish from an empty input. For
-/// `map_put_items` it bypassed the `Value::HashMap` arm and fell through to
-/// the ambiguous "map_put_items requires a dict value" error even though the
-/// real bug was a missing `val` key. All the corresponding Python facade
-/// helpers already require their values/items as positional arguments, so this
-/// only fires for callers who construct op dicts directly.
+/// coerce into a single-element `[Nil]` list. For `hll_add` that silently
+/// means "add zero values" (the HLL bin is created on first use but no
+/// elements register); for `hll_get_union` / `_union_count` / `_intersect_count`
+/// / `_similarity` / `_set_union` it means "compare against zero HLL bins",
+/// quietly producing a 0/1.0 result that the caller cannot distinguish from
+/// an empty input. For `map_put_items` it bypassed the `Value::HashMap` arm
+/// and fell through to the ambiguous "map_put_items requires a dict value"
+/// error even though the real bug was a missing `val` key. For
+/// `list_get_by_value` / `list_remove_by_value` / `map_get_by_value` /
+/// `map_remove_by_value` (and their `_list` variants), the dispatch happily
+/// queries the bin for `Nil` matches, silently returning an empty result
+/// instead of the records the caller actually expected. All the corresponding
+/// Python facade helpers already require their values/items as positional
+/// arguments, so this only fires for callers who construct op dicts directly.
 fn require_hll_value(val: Option<Value>, op_name: &str) -> PyResult<Value> {
     val.ok_or_else(|| pyo3::exceptions::PyValueError::new_err(format!("{op_name} requires 'val'")))
 }
@@ -522,7 +526,7 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             }
             OP_LIST_GET_BY_VALUE => {
                 let name = require_bin(&bin_name, "list_get_by_value")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "list_get_by_value")?;
                 let rt = int_to_list_return_type(get_return_type(dict)?);
                 list_ops::get_by_value(&name, v, rt)
             }
@@ -558,7 +562,7 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             }
             OP_LIST_GET_BY_VALUE_LIST => {
                 let name = require_bin(&bin_name, "list_get_by_value_list")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "list_get_by_value_list")?;
                 let rt = int_to_list_return_type(get_return_type(dict)?);
                 list_ops::get_by_value_list(&name, values_from_list(&v), rt)
             }
@@ -571,13 +575,13 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             }
             OP_LIST_REMOVE_BY_VALUE => {
                 let name = require_bin(&bin_name, "list_remove_by_value")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "list_remove_by_value")?;
                 let rt = int_to_list_return_type(get_return_type(dict)?);
                 list_ops::remove_by_value(&name, v, rt)
             }
             OP_LIST_REMOVE_BY_VALUE_LIST => {
                 let name = require_bin(&bin_name, "list_remove_by_value_list")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "list_remove_by_value_list")?;
                 let rt = int_to_list_return_type(get_return_type(dict)?);
                 list_ops::remove_by_value_list(&name, values_from_list(&v), rt)
             }
@@ -720,13 +724,13 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             }
             OP_MAP_REMOVE_BY_VALUE => {
                 let name = require_bin(&bin_name, "map_remove_by_value")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "map_remove_by_value")?;
                 let rt = int_to_map_return_type(get_return_type(dict)?);
                 map_ops::remove_by_value(&name, v, rt)
             }
             OP_MAP_REMOVE_BY_VALUE_LIST => {
                 let name = require_bin(&bin_name, "map_remove_by_value_list")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "map_remove_by_value_list")?;
                 let rt = int_to_map_return_type(get_return_type(dict)?);
                 map_ops::remove_by_value_list(&name, values_from_list(&v), rt)
             }
@@ -790,7 +794,7 @@ pub fn py_ops_to_rust(ops_list: &Bound<'_, PyList>) -> PyResult<Vec<Operation>> 
             }
             OP_MAP_GET_BY_VALUE => {
                 let name = require_bin(&bin_name, "map_get_by_value")?;
-                let v = val.unwrap_or(Value::Nil);
+                let v = require_hll_value(val, "map_get_by_value")?;
                 let rt = int_to_map_return_type(get_return_type(dict)?);
                 map_ops::get_by_value(&name, v, rt)
             }
@@ -1665,5 +1669,167 @@ mod tests {
                 .expect("map_put_items with explicit dict val must succeed");
             assert_eq!(converted.len(), 1);
         });
+    }
+
+    // ── list/map BY_VALUE ops: missing `val` must error, not silently Nil ──
+    //
+    // Regression for the bug where the OP_LIST_GET_BY_VALUE,
+    // OP_LIST_GET_BY_VALUE_LIST, OP_LIST_REMOVE_BY_VALUE,
+    // OP_LIST_REMOVE_BY_VALUE_LIST, OP_MAP_GET_BY_VALUE, OP_MAP_REMOVE_BY_VALUE
+    // and OP_MAP_REMOVE_BY_VALUE_LIST arms defaulted a missing `val` key to
+    // `Value::Nil`. For the singular-value variants the dispatch quietly
+    // queried the bin for `Nil` matches; for the `_list` variants
+    // `values_from_list(&Nil)` collapsed to `[Nil]`, so the op also matched
+    // against a single nonsense value. In both cases the call returned an
+    // empty result the caller could not distinguish from a genuinely missing
+    // record. The fix raises ValueError("<op> requires 'val'") instead, so
+    // callers building op dicts directly get a clear failure.
+    //
+    // The `*_BY_VALUE_RANGE` and `*_BY_KEY_RANGE` arms are intentionally NOT
+    // covered here — distinguishing a missing key from `val=None` (unbounded
+    // begin) needs a separate `val` extractor and is deferred.
+
+    /// Build a single list/map BY_VALUE op dict with the given op code,
+    /// optionally setting `val` to an arbitrary Python int. The `return_type`
+    /// key is always set so the arm's `get_return_type` call succeeds.
+    fn build_by_value_op_dict<'py>(
+        py: Python<'py>,
+        op_code: i32,
+        with_val: Option<i64>,
+    ) -> Bound<'py, PyDict> {
+        let dict = PyDict::new(py);
+        dict.set_item("op", op_code).unwrap();
+        dict.set_item("bin", "mybin").unwrap();
+        dict.set_item("return_type", 0i32).unwrap();
+        if let Some(v) = with_val {
+            dict.set_item("val", v).unwrap();
+        }
+        dict
+    }
+
+    /// Build a single list/map BY_VALUE_LIST op dict, optionally setting `val`
+    /// to a Python list of ints.
+    fn build_by_value_list_op_dict<'py>(
+        py: Python<'py>,
+        op_code: i32,
+        with_val: Option<Vec<i64>>,
+    ) -> Bound<'py, PyDict> {
+        let dict = PyDict::new(py);
+        dict.set_item("op", op_code).unwrap();
+        dict.set_item("bin", "mybin").unwrap();
+        dict.set_item("return_type", 0i32).unwrap();
+        if let Some(items) = with_val {
+            let list = PyList::new(py, items).unwrap();
+            dict.set_item("val", list).unwrap();
+        }
+        dict
+    }
+
+    fn assert_by_value_op_missing_val_errors(op_code: i32, op_name: &str) {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = build_by_value_op_dict(py, op_code, None);
+            let ops = PyList::new(py, [dict]).unwrap();
+            let err = super::py_ops_to_rust(&ops)
+                .expect_err("missing 'val' must raise ValueError, not silently become Nil");
+            assert!(err.is_instance_of::<PyValueError>(py));
+            let msg = err.to_string();
+            assert!(
+                msg.contains(op_name) && msg.contains("val"),
+                "error message should mention '{op_name}' and 'val', got: {msg}"
+            );
+        });
+    }
+
+    fn assert_by_value_op_with_val_succeeds(op_code: i32) {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = build_by_value_op_dict(py, op_code, Some(42));
+            let ops = PyList::new(py, [dict]).unwrap();
+            let converted =
+                super::py_ops_to_rust(&ops).expect("BY_VALUE op with explicit val must succeed");
+            assert_eq!(converted.len(), 1);
+        });
+    }
+
+    fn assert_by_value_list_op_missing_val_errors(op_code: i32, op_name: &str) {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = build_by_value_list_op_dict(py, op_code, None);
+            let ops = PyList::new(py, [dict]).unwrap();
+            let err = super::py_ops_to_rust(&ops)
+                .expect_err("missing 'val' must raise ValueError, not silently become Nil");
+            assert!(err.is_instance_of::<PyValueError>(py));
+            let msg = err.to_string();
+            assert!(
+                msg.contains(op_name) && msg.contains("val"),
+                "error message should mention '{op_name}' and 'val', got: {msg}"
+            );
+        });
+    }
+
+    fn assert_by_value_list_op_with_val_succeeds(op_code: i32) {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = build_by_value_list_op_dict(py, op_code, Some(vec![1, 2, 3]));
+            let ops = PyList::new(py, [dict]).unwrap();
+            let converted = super::py_ops_to_rust(&ops)
+                .expect("BY_VALUE_LIST op with explicit val must succeed");
+            assert_eq!(converted.len(), 1);
+        });
+    }
+
+    #[test]
+    fn list_get_by_value_missing_val_raises_value_error() {
+        assert_by_value_op_missing_val_errors(super::OP_LIST_GET_BY_VALUE, "list_get_by_value");
+        assert_by_value_op_with_val_succeeds(super::OP_LIST_GET_BY_VALUE);
+    }
+
+    #[test]
+    fn list_get_by_value_list_missing_val_raises_value_error() {
+        assert_by_value_list_op_missing_val_errors(
+            super::OP_LIST_GET_BY_VALUE_LIST,
+            "list_get_by_value_list",
+        );
+        assert_by_value_list_op_with_val_succeeds(super::OP_LIST_GET_BY_VALUE_LIST);
+    }
+
+    #[test]
+    fn list_remove_by_value_missing_val_raises_value_error() {
+        assert_by_value_op_missing_val_errors(
+            super::OP_LIST_REMOVE_BY_VALUE,
+            "list_remove_by_value",
+        );
+        assert_by_value_op_with_val_succeeds(super::OP_LIST_REMOVE_BY_VALUE);
+    }
+
+    #[test]
+    fn list_remove_by_value_list_missing_val_raises_value_error() {
+        assert_by_value_list_op_missing_val_errors(
+            super::OP_LIST_REMOVE_BY_VALUE_LIST,
+            "list_remove_by_value_list",
+        );
+        assert_by_value_list_op_with_val_succeeds(super::OP_LIST_REMOVE_BY_VALUE_LIST);
+    }
+
+    #[test]
+    fn map_get_by_value_missing_val_raises_value_error() {
+        assert_by_value_op_missing_val_errors(super::OP_MAP_GET_BY_VALUE, "map_get_by_value");
+        assert_by_value_op_with_val_succeeds(super::OP_MAP_GET_BY_VALUE);
+    }
+
+    #[test]
+    fn map_remove_by_value_missing_val_raises_value_error() {
+        assert_by_value_op_missing_val_errors(super::OP_MAP_REMOVE_BY_VALUE, "map_remove_by_value");
+        assert_by_value_op_with_val_succeeds(super::OP_MAP_REMOVE_BY_VALUE);
+    }
+
+    #[test]
+    fn map_remove_by_value_list_missing_val_raises_value_error() {
+        assert_by_value_list_op_missing_val_errors(
+            super::OP_MAP_REMOVE_BY_VALUE_LIST,
+            "map_remove_by_value_list",
+        );
+        assert_by_value_list_op_with_val_succeeds(super::OP_MAP_REMOVE_BY_VALUE_LIST);
     }
 }

--- a/tests/unit/test_list_map_ops.py
+++ b/tests/unit/test_list_map_ops.py
@@ -37,6 +37,7 @@ from aerospike_py.map_operations import (
     map_get_by_rank,
     map_get_by_rank_range,
     map_get_by_value,
+    map_get_by_value_list,
     map_increment,
     map_put,
     map_put_items,
@@ -434,11 +435,13 @@ class TestListMapByValueFacadeRequiresVal:
             (list_get_by_value_list, 1020, [1, 2, 3]),
             (list_remove_by_value_list, 1023, [1, 2, 3]),
             (map_remove_by_value_list, 2011, [1, 2, 3]),
+            (map_get_by_value_list, 2027, [1, 2, 3]),
         ],
         ids=[
             "list_get_by_value_list",
             "list_remove_by_value_list",
             "map_remove_by_value_list",
+            "map_get_by_value_list",
         ],
     )
     def test_by_value_list_facade_emits_val(self, func, expected_op, sample_values):

--- a/tests/unit/test_list_map_ops.py
+++ b/tests/unit/test_list_map_ops.py
@@ -11,6 +11,8 @@ from aerospike_py.list_operations import (
     list_get_by_index,
     list_get_by_rank,
     list_get_by_rank_range,
+    list_get_by_value,
+    list_get_by_value_list,
     list_get_range,
     list_increment,
     list_insert,
@@ -19,6 +21,8 @@ from aerospike_py.list_operations import (
     list_remove,
     list_remove_by_rank,
     list_remove_by_rank_range,
+    list_remove_by_value,
+    list_remove_by_value_list,
     list_remove_range,
     list_set,
     list_size,
@@ -39,6 +43,8 @@ from aerospike_py.map_operations import (
     map_remove_by_key,
     map_remove_by_rank,
     map_remove_by_rank_range,
+    map_remove_by_value,
+    map_remove_by_value_list,
     map_size,
 )
 
@@ -383,6 +389,66 @@ class TestMapOperations:
         # map_put_items op without supplying items.
         with pytest.raises(TypeError):
             map_put_items("mybin")  # type: ignore[call-arg]
+
+
+class TestListMapByValueFacadeRequiresVal:
+    """Regression: facade helpers for list/map BY_VALUE ops always emit `val`.
+
+    At the Rust dispatch layer (operations.rs) the OP_LIST_GET_BY_VALUE,
+    OP_LIST_GET_BY_VALUE_LIST, OP_LIST_REMOVE_BY_VALUE,
+    OP_LIST_REMOVE_BY_VALUE_LIST, OP_MAP_GET_BY_VALUE, OP_MAP_REMOVE_BY_VALUE,
+    and OP_MAP_REMOVE_BY_VALUE_LIST arms now raise ValueError("<op> requires
+    'val'") for a missing `val` key instead of silently substituting
+    `Value::Nil`. These tests assert the facade always supplies `val` and
+    rejects a missing positional value (TypeError), so callers using the
+    facade never hit the dispatch-level error in normal use.
+    """
+
+    @pytest.mark.parametrize(
+        "func,expected_op,sample_val",
+        [
+            (list_get_by_value, 1015, 42),
+            (list_remove_by_value, 1022, 42),
+            (map_get_by_value, 2020, 42),
+            (map_remove_by_value, 2010, 42),
+        ],
+        ids=[
+            "list_get_by_value",
+            "list_remove_by_value",
+            "map_get_by_value",
+            "map_remove_by_value",
+        ],
+    )
+    def test_by_value_facade_emits_val(self, func, expected_op, sample_val):
+        op = func("mybin", sample_val, return_type=0)
+        assert op["op"] == expected_op
+        assert op["bin"] == "mybin"
+        assert "val" in op
+        assert op["val"] == sample_val
+        with pytest.raises(TypeError):
+            func("mybin", return_type=0)  # type: ignore[call-arg]
+
+    @pytest.mark.parametrize(
+        "func,expected_op,sample_values",
+        [
+            (list_get_by_value_list, 1020, [1, 2, 3]),
+            (list_remove_by_value_list, 1023, [1, 2, 3]),
+            (map_remove_by_value_list, 2011, [1, 2, 3]),
+        ],
+        ids=[
+            "list_get_by_value_list",
+            "list_remove_by_value_list",
+            "map_remove_by_value_list",
+        ],
+    )
+    def test_by_value_list_facade_emits_val(self, func, expected_op, sample_values):
+        op = func("mybin", sample_values, return_type=0)
+        assert op["op"] == expected_op
+        assert op["bin"] == "mybin"
+        assert "val" in op
+        assert op["val"] == sample_values
+        with pytest.raises(TypeError):
+            func("mybin", return_type=0)  # type: ignore[call-arg]
 
 
 class TestModuleAccess:


### PR DESCRIPTION
## Summary

Extends the guard pattern from PR #371 (bit ops) and PR #372 (HLL ops + `map_put_items`) to the list/map `BY_VALUE` single- and `_list`-arity arms in `rust/src/operations.rs`. A missing `val` key in the op dict used to default to `Value::Nil` and silently return an empty result instead of the matching records — the caller couldn't tell whether their data was actually absent or whether they forgot to include `val`.

## The Bug

Each affected arm currently does:

```rust
let v = val.unwrap_or(Value::Nil);
```

For the singular-value variants (`OP_LIST_GET_BY_VALUE`, `OP_LIST_REMOVE_BY_VALUE`, `OP_MAP_GET_BY_VALUE`, `OP_MAP_REMOVE_BY_VALUE`) the dispatch quietly queried the bin for `Nil` matches.

For the `_list` variants (`OP_LIST_GET_BY_VALUE_LIST`, `OP_LIST_REMOVE_BY_VALUE_LIST`, `OP_MAP_REMOVE_BY_VALUE_LIST`), `values_from_list(&Nil)` collapses to `[Nil]`, so the op matched against a single nonsense value.

In both cases the call returned an empty result indistinguishable from a genuinely missing record.

## The Fix

All seven arms now route through the existing `require_hll_value()` helper (introduced in #372 — it's generic, just requires `Some(value)`), raising `ValueError("<op> requires 'val'")` instead. The helper's doc comment is updated to reflect the new callers.

Affected arms:
- `OP_LIST_GET_BY_VALUE`
- `OP_LIST_GET_BY_VALUE_LIST`
- `OP_LIST_REMOVE_BY_VALUE`
- `OP_LIST_REMOVE_BY_VALUE_LIST`
- `OP_MAP_GET_BY_VALUE`
- `OP_MAP_REMOVE_BY_VALUE`
- `OP_MAP_REMOVE_BY_VALUE_LIST`

The Python facade helpers in `aerospike_py.list_operations` and `aerospike_py.map_operations` already require these values as positional arguments, so this only fires for callers who construct op dicts directly.

## Deferred to a Follow-up

The original task scope included the range arms:
- `OP_LIST_GET_BY_VALUE_RANGE`, `OP_LIST_REMOVE_BY_VALUE_RANGE`
- `OP_MAP_GET_BY_VALUE_RANGE`, `OP_MAP_REMOVE_BY_VALUE_RANGE`
- `OP_MAP_GET_BY_KEY_RANGE`, `OP_MAP_REMOVE_BY_KEY_RANGE`

These intentionally allow `Value::Nil` to mean an open-ended begin/end bound (matched against `Value::Infinity` on the other end via `get_val_end`). Requiring the `val` dict key to be **present** while still allowing its value to be Python `None` needs a different extractor than the current one at line 393 of `operations.rs`, which collapses a missing key and `val=None` to the same `Option::None`. Out of scope for this PR; tracked for a follow-up that introduces a `get_val_present()`-style helper.

## Tests

- **7 new Rust unit tests** in `rust/src/operations.rs` covering missing-val errors and explicit-val success paths for each affected arm (mirrors the helpers introduced in #371 / #372).
- **Python facade regression tests** in `tests/unit/test_list_map_ops.py` asserting the list/map BY_VALUE helpers always emit `val` and reject missing positional args (`TypeError`).

## Verification

```
cargo test --manifest-path rust/Cargo.toml --lib       # 218 passed
uv run pytest tests/unit/test_list_map_ops.py -x -q    # 51 passed
uv run ruff check .                                    # All checks passed
uv run ruff format --check .                           # 162 files already formatted
cargo fmt --manifest-path rust/Cargo.toml --check      # clean
cargo clippy --manifest-path rust/Cargo.toml --lib --tests   # clean
```

## Impact

- No public-API or wire-protocol change.
- PATCH-class fix.
- Related: #371, #372.