### PR TITLE
fix: honor Aerospike env in feasibility tests

### DIFF
--- a/tests/feasibility/conftest.py
+++ b/tests/feasibility/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for feasibility tests (requires Aerospike server)."""
 
+import os
 import socket
 
 import pytest
@@ -16,7 +17,15 @@ def _server_available(host: str = "127.0.0.1", port: int = 18710) -> bool:
         return False
 
 
+def _server_endpoint() -> tuple[str, int]:
+    return (
+        os.environ.get("AEROSPIKE_HOST", "127.0.0.1"),
+        int(os.environ.get("AEROSPIKE_PORT", "18710")),
+    )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def require_aerospike():
-    if not _server_available():
-        pytest.skip("Aerospike server not available")
+    host, port = _server_endpoint()
+    if not _server_available(host, port):
+        pytest.skip(f"Aerospike server not available at {host}:{port}")

--- a/tests/unit/test_feasibility_config.py
+++ b/tests/unit/test_feasibility_config.py
@@ -1,0 +1,8 @@
+from tests.feasibility import conftest as feasibility_conftest
+
+
+def test_feasibility_server_endpoint_uses_aerospike_env(monkeypatch):
+    monkeypatch.setenv("AEROSPIKE_HOST", "aerospike-ci")
+    monkeypatch.setenv("AEROSPIKE_PORT", "3000")
+
+    assert feasibility_conftest._server_endpoint() == ("aerospike-ci", 3000)


### PR DESCRIPTION
## Summary
- Make feasibility test availability checks read AEROSPIKE_HOST and AEROSPIKE_PORT.
- Add a unit test covering CI's port override path.

## Testing
- uv run pytest tests/unit/test_feasibility_config.py tests/unit/test_import.py::test_exception_aliases -q
- uv run ruff check tests/feasibility/conftest.py tests/unit/test_feasibility_config.py