### PR TITLE
test: align feasibility test config with env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "hypothesis>=6.0",
     "pre-commit>=4.5.1",
 ]
-test = ["pytest", "pytest-asyncio", "numpy>=2.0", "pytest-cov>=5.0"]
+test = ["pytest", "pytest-asyncio", "numpy>=2.0", "pytest-cov>=5.0", "hypothesis>=6.0"]
 test-integration = [{include-group = "test"}, "fastapi", "httpx", "prometheus-client"]
 test-fastapi = ["pytest", "pytest-asyncio", "fastapi", "httpx"]
 test-gunicorn = ["pytest", "pytest-asyncio", "gunicorn", "httpx"]

--- a/tests/feasibility/conftest.py
+++ b/tests/feasibility/conftest.py
@@ -1,11 +1,15 @@
 """Shared fixtures for feasibility tests (requires Aerospike server)."""
 
+import os
 import socket
 
 import pytest
 
 
-def _server_available(host: str = "127.0.0.1", port: int = 18710) -> bool:
+def _server_available(host: str | None = None, port: int | None = None) -> bool:
+    host = host or os.environ.get("AEROSPIKE_HOST", "127.0.0.1")
+    port = port if port is not None else int(os.environ.get("AEROSPIKE_PORT", "18710"))
+
     try:
         s = socket.socket()
         s.settimeout(1)

--- a/tests/feasibility/test_gunicorn.py
+++ b/tests/feasibility/test_gunicorn.py
@@ -23,7 +23,15 @@ import os
 
 import aerospike_py
 
-CONFIG = {{"hosts": [("127.0.0.1", int(os.environ.get("AEROSPIKE_PORT", "18710")))], "cluster_name": "docker"}}
+CONFIG = {
+    "hosts": [
+        (
+            os.environ.get("AEROSPIKE_HOST", "127.0.0.1"),
+            int(os.environ.get("AEROSPIKE_PORT", "18710")),
+        )
+    ],
+    "cluster_name": os.environ.get("AEROSPIKE_CLUSTER_NAME", "docker"),
+}
 NS = "test"
 SET_NAME = "feasibility_gunicorn"
 

--- a/tests/unit/test_feasibility_config.py
+++ b/tests/unit/test_feasibility_config.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from tests.feasibility import conftest as feasibility_conftest
+
+
+def test_server_available_uses_aerospike_env(monkeypatch):
+    connected_to = []
+
+    class FakeSocket:
+        def settimeout(self, timeout):
+            pass
+
+        def connect(self, address):
+            connected_to.append(address)
+
+        def close(self):
+            pass
+
+    monkeypatch.setenv("AEROSPIKE_HOST", "aerospike-ci")
+    monkeypatch.setenv("AEROSPIKE_PORT", "3000")
+    monkeypatch.setattr(feasibility_conftest.socket, "socket", FakeSocket)
+
+    assert feasibility_conftest._server_available()
+    assert connected_to == [("aerospike-ci", 3000)]
+
+
+def test_gunicorn_wsgi_app_uses_aerospike_env():
+    test_file = Path(__file__).parents[1] / "feasibility" / "test_gunicorn.py"
+    source = test_file.read_text()
+
+    assert 'os.environ.get("AEROSPIKE_HOST", "127.0.0.1")' in source
+    assert 'os.environ.get("AEROSPIKE_PORT", "18710")' in source

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,7 @@ dev = [
     { name = "ruff" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
@@ -76,6 +77,7 @@ test-all = [
     { name = "fastapi" },
     { name = "gunicorn" },
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "prometheus-client" },
@@ -103,6 +105,7 @@ test-gunicorn = [
 test-integration = [
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "prometheus-client" },
@@ -131,6 +134,7 @@ dev = [
     { name = "ruff" },
 ]
 test = [
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -140,6 +144,7 @@ test-all = [
     { name = "fastapi" },
     { name = "gunicorn" },
     { name = "httpx" },
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "prometheus-client" },
     { name = "pytest" },
@@ -166,6 +171,7 @@ test-gunicorn = [
 test-integration = [
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "prometheus-client" },
     { name = "pytest" },


### PR DESCRIPTION
## Summary
- make feasibility Aerospike availability checks honor AEROSPIKE_HOST and AEROSPIKE_PORT
- align the Gunicorn feasibility app with the same environment-driven connection config
- include hypothesis in the test dependency group used by unit/property tests

## Testing
- uv lock --check
- PYTHONDONTWRITEBYTECODE=1 uv run --group test pytest -p no:cacheprovider tests/unit/test_feasibility_config.py tests/unit/test_property_based.py -q -rs
- PYTHONDONTWRITEBYTECODE=1 uv run --group test pytest -p no:cacheprovider tests/unit/ -q -rs