### PR TITLE
docs(stub): clarify batch_apply does not accept retry parameter

### DIFF
--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -1020,6 +1020,15 @@ class Client:
                 "test_udf", "add", args=[1, 1],
             )
             ```
+
+        Note:
+            ``batch_apply`` does **not** accept a ``retry`` parameter
+            (unlike :meth:`batch_write`, which accepts ``retry: int = 0``).
+            Passing ``retry=`` to this method raises ``TypeError``.
+            UDF batches are not idempotent in the general case, so retries
+            must be driven by the caller. For per-record control over the
+            UDF call shape and policy fields, use ``(key, meta)`` tuples
+            with a ``BatchUDFMeta`` payload in ``keys``.
         """
         ...
 
@@ -2012,6 +2021,13 @@ class AsyncClient:
         See :meth:`Client.batch_apply` for full description. Per-record
         ``BatchUDFMeta`` overrides may change the UDF call shape
         (``module``/``function``/``args``) or policy fields per record.
+
+        Note:
+            ``batch_apply`` does **not** accept a ``retry`` parameter
+            (unlike :meth:`batch_write`, which accepts ``retry: int = 0``).
+            Passing ``retry=`` raises ``TypeError``. UDF batches are not
+            idempotent in the general case, so retries must be driven by
+            the caller.
         """
         ...
 


### PR DESCRIPTION
## Summary

The type stub signatures for `Client.batch_apply` and `AsyncClient.batch_apply` were already correct (they did not list a `retry` parameter), but the docstrings did not call this out. Users coming from `batch_write` — which does accept `retry` — would assume `batch_apply` has the same surface and be confused by the resulting `TypeError`.

## Changes

- `src/aerospike_py/__init__.pyi` (+16 / -0) — added a `Note:` block to both `Client.batch_apply` and `AsyncClient.batch_apply` docstrings explaining that `retry` is not accepted, that passing it raises `TypeError`, and pointing to the per-record `BatchUDFMeta` override as the actual escape hatch users have.

## Rust cross-check (no code changed)

- `rust/src/client.rs:1344` — `#[pyo3(signature = (keys, module, function, args=None, policy=None))]` — confirms no `retry` param.
- `rust/src/async_client.rs:979` — same.
- For comparison `batch_write` (client.rs:1207, async_client.rs:860) does take `retry=0`; `batch_operate` also does NOT take `retry`, so the doc note compares only to `batch_write` (the lookalike that confuses users).

## Verification

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 105 files already formatted (idempotent)
- [x] `uv run pyright src/` — 0 errors / 0 warnings
- [x] `uv run pytest tests/unit/test_batch_apply_types.py tests/unit/test_docstring_examples.py -k batch_apply` — 12 passed
- [x] Pre-commit hooks — all green