### PR TITLE
refactor(rust): remove latent cast().unwrap() in batch_remove/apply

### DIFF
--- a/rust/src/client_common.rs
+++ b/rust/src/client_common.rs
@@ -576,8 +576,10 @@ pub fn prepare_batch_remove_args(
         //   - Key      ::= (str, str, user_key[, digest])  — len in {3, 4}, [0]=str
         //   - (K,meta) ::= (tuple, dict)                    — len == 2, [0]=tuple, [1]=dict
         // The `tuple.len() == 2 && [0] is tuple && [1] is dict` test is precise
-        // because a Key is never length-2 (always >= 3).
-        let is_key_meta_pair = if let Ok(tuple) = item.cast::<PyTuple>() {
+        // because a Key is never length-2 (always >= 3). We bind the downcast
+        // result here so the (Key, meta) branch never needs a second cast +
+        // `unwrap()` — any future refactor stays panic-free by construction.
+        let key_meta_tuple = item.cast::<PyTuple>().ok().filter(|tuple| {
             tuple.len() == 2
                 && tuple
                     .get_item(0)
@@ -587,12 +589,9 @@ pub fn prepare_batch_remove_args(
                     .get_item(1)
                     .map(|x| x.is_instance_of::<PyDict>())
                     .unwrap_or(false)
-        } else {
-            false
-        };
+        });
 
-        if is_key_meta_pair {
-            let tuple = item.cast::<PyTuple>().unwrap();
+        if let Some(tuple) = key_meta_tuple {
             let key_obj = tuple.get_item(0)?;
             let meta_obj = tuple.get_item(1)?;
             let meta_dict = meta_obj
@@ -697,8 +696,9 @@ pub fn prepare_batch_apply_args(
     for item in keys.iter() {
         // Disambiguate Key vs (Key, meta): same rule as prepare_batch_remove_args.
         // A bare Key tuple is len >= 3; the (Key, meta) pair is exactly len 2 with
-        // [0] = tuple (Key) and [1] = dict (meta).
-        let is_key_meta_pair = if let Ok(tuple) = item.cast::<PyTuple>() {
+        // [0] = tuple (Key) and [1] = dict (meta). Bind the downcast result so
+        // the (Key, meta) branch never needs a second cast + `unwrap()`.
+        let key_meta_tuple = item.cast::<PyTuple>().ok().filter(|tuple| {
             tuple.len() == 2
                 && tuple
                     .get_item(0)
@@ -708,12 +708,9 @@ pub fn prepare_batch_apply_args(
                     .get_item(1)
                     .map(|x| x.is_instance_of::<PyDict>())
                     .unwrap_or(false)
-        } else {
-            false
-        };
+        });
 
-        if is_key_meta_pair {
-            let tuple = item.cast::<PyTuple>().unwrap();
+        if let Some(tuple) = key_meta_tuple {
             let key_obj = tuple.get_item(0)?;
             let meta_obj = tuple.get_item(1)?;
             let meta_dict = meta_obj


### PR DESCRIPTION
## Summary

In `rust/src/client_common.rs`, both `prepare_batch_remove_args` (line ~595) and `prepare_batch_apply_args` (line ~716) used a `cast::<PyTuple>().unwrap()` inside the `(Key, meta)` branch after an earlier `is_key_meta_pair` check that performed a separate cast on the same `Bound<PyAny>`.

This PR restructures the predicate to bind the downcast result directly via `cast::<PyTuple>().ok().filter(...)`, and rewrites the dispatch as `if let Some(tuple) = key_meta_tuple { ... } else { ... }` so the (Key, meta) branch reuses the already-cast `Bound<PyTuple>` rather than re-casting and unwrapping.

## What I verified

- **Is the original `unwrap()` actually exploitable from Python?** **No.** The `unwrap()` is only reached when the prior `if let Ok(tuple) = item.cast::<PyTuple>() { ... }` branch succeeded on the **same** `Bound<PyAny>`. `Bound<PyAny>::cast::<T>()` is a pure runtime type check, and Python object types are stable across synchronous calls, so the second cast on the same binding cannot fail. No Python-level input shape reaches the unwrap path.
- **Why change anything then?** It is a latent refactor hazard. Any future tweak to the `is_key_meta_pair` predicate (e.g. accepting `Sequence`/`Mapping`, or making the (Key, meta) branch also accept non-tuple keys) could silently desynchronize the two casts and turn the unwrap into a real panic on malformed Python input. Reusing the already-bound `Bound<PyTuple>` removes that class of bug by construction with zero behavior change.
- Both call sites updated identically, comment refreshed to explain the binding pattern.

## Test results

- `cargo fmt --all` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `uv run pytest tests/unit/ -x -q` -> **921 passed, 8 skipped** (skips are pre-existing, require live Aerospike server)
- Integration tests not run (require Aerospike server)

## Diff size

11 insertions, 14 deletions in one file. No public API change, no version bump.