### PR TITLE
fix(stubs,docs): correct deprecated exception alias base classes and fix NameError in exceptions doc

### DIFF
--- a/docs/docs/api/exceptions.md
+++ b/docs/docs/api/exceptions.md
@@ -85,6 +85,7 @@ Exception
 ## Examples
 
 ```python
+import aerospike_py as aerospike
 from aerospike_py.exception import (
     RecordNotFound,
     RecordExistsError,

--- a/src/aerospike_py/exception.pyi
+++ b/src/aerospike_py/exception.pyi
@@ -51,7 +51,7 @@ class ClusterError(AerospikeError):
 class AerospikeTimeoutError(AerospikeError):
     """Raised when an operation exceeds its timeout threshold."""
 
-class TimeoutError(AerospikeError):
+class TimeoutError(AerospikeTimeoutError):
     """Deprecated: use ``AerospikeTimeoutError`` instead.
 
     Accessing this name emits a ``DeprecationWarning``.
@@ -110,7 +110,7 @@ class FilteredOut(RecordError):
 class AerospikeIndexError(ServerError):
     """Base exception for secondary index errors."""
 
-class IndexError(ServerError):
+class IndexError(AerospikeIndexError):
     """Deprecated: use ``AerospikeIndexError`` instead.
 
     Accessing this name emits a ``DeprecationWarning``.


### PR DESCRIPTION
## Summary

- Fix `TimeoutError` stub to subclass `AerospikeTimeoutError` (not bare `AerospikeError`) so that type checkers correctly narrow `isinstance(x, AerospikeTimeoutError)` matches on `TimeoutError`. At runtime these are the same class object (see `rust/src/errors.rs:315` — `m.add("TimeoutError", py.get_type::<AerospikeTimeoutError>())`).
- Fix `IndexError` stub to subclass `AerospikeIndexError` (not bare `ServerError`) for the same reason (see `rust/src/errors.rs:334`).
- Add `import aerospike_py as aerospike` to the Examples code block in `docs/docs/api/exceptions.md` so the snippet that uses `aerospike.POLICY_GEN_EQ` and `aerospike.POLICY_EXISTS_CREATE_ONLY` is self-contained and does not raise `NameError`.
- No version bump (auto-release handles that from Conventional Commits).

## Test plan

- [x] `uvx ruff check src/aerospike_py/exception.pyi` — clean
- [x] `uvx ruff format --check src/aerospike_py/exception.pyi` — clean
- [x] Verified stub edits match the runtime class identity in `rust/src/errors.rs` (`TimeoutError` ↔ `AerospikeTimeoutError`, `IndexError` ↔ `AerospikeIndexError`).
- [x] Confirmed only one code block in `docs/docs/api/exceptions.md` references `aerospike.POLICY_*` and that block now imports `aerospike_py as aerospike`.