### PR TITLE
fix(test): handle batch_read partial-not-found in feasibility FastAPI fixture

### DIFF
--- a/tests/feasibility/test_fastapi.py
+++ b/tests/feasibility/test_fastapi.py
@@ -150,15 +150,29 @@ def _create_app() -> FastAPI:
         keys = [_key(k["ns"], k["set"], k["key"]) for k in body["keys"]]
         bins = body.get("bins")
         results = await app.state.client.batch_read(keys, bins=bins)
+        # ``batch_read`` returns a ``LazyBatchRecords`` Mapping view that
+        # EXCLUDES not-found records (see rust/src/batch_types.rs:282-307
+        # and examples/sample-fastapi/app/routers/batch.py). Iterate the
+        # input keys so the response preserves order and length even when
+        # some keys are missing.
         sanitized = []
-        for user_key, bins_data in results.items():
-            sanitized.append(
-                {
-                    "key": user_key,
-                    "meta": None,
-                    "bins": bins_data,
-                }
-            )
+        for ns, set_name, user_key in keys:
+            if user_key in results:
+                sanitized.append(
+                    {
+                        "key": [ns, set_name, user_key],
+                        "meta": None,
+                        "bins": results[user_key],
+                    }
+                )
+            else:
+                sanitized.append(
+                    {
+                        "key": [ns, set_name, user_key],
+                        "meta": None,
+                        "bins": None,
+                    }
+                )
         return {"batch_records": sanitized}
 
     @app.post("/batch/operate")


### PR DESCRIPTION
## Summary

`tests/feasibility/test_fastapi.py::TestFastAPIBatch::test_batch_read_partial_not_found` was failing on `main` because the inline `/batch/read` endpoint in the test fixture iterated `results.items()` (the `LazyBatchRecords` Mapping view), which by documented design excludes not-found records.

## Bug reproduction

The test posts two keys to `/batch/read`:
- `batch-r-exists` (pre-seeded)
- `batch-r-missing` (does not exist)

It expects the response to contain **two** records, with the missing key surfaced as `{"bins": null}`. Instead, the response contained only one record (the existing key), and `records[1]["bins"] is None` raised `IndexError`.

## Root cause

`LazyBatchRecords` exposes a Mapping protocol in `rust/src/batch_types.rs:282-307`. Its `__len__` and `__getitem__` deliberately filter to successful reads only:

> Records without a `user_key` (digest-only) or with a failed result are not present in the dict view — use `batch_records[i]` for raw index-based access...

So `results.items()` silently drops not-found keys. The previous handler used that view directly, losing positional information.

## Patch shape

Rewrite the handler to iterate the **input keys** in order and check membership against the dict view, exactly matching the canonical sample at `examples/sample-fastapi/app/routers/batch.py:30-39`:

```python
results = await app.state.client.batch_read(keys, bins=bins)
sanitized = []
for ns, set_name, user_key in keys:
    if user_key in results:
        sanitized.append({"key": [ns, set_name, user_key], "meta": None, "bins": results[user_key]})
    else:
        sanitized.append({"key": [ns, set_name, user_key], "meta": None, "bins": None})
return {"batch_records": sanitized}
```

Response now preserves input length and order; missing keys carry `bins=None`.

## Scope

- Only `tests/feasibility/test_fastapi.py` is modified.
- No changes to `rust/src/batch_types.rs`, `src/aerospike_py/`, or the sample app.
- No version edits, no public API change.

## Test plan

- [x] `uvx ruff check tests/feasibility/test_fastapi.py` — passes
- [x] `uvx ruff format --check tests/feasibility/test_fastapi.py` — passes
- [ ] CI: `tox -e feasibility` runs `TestFastAPIBatch::test_batch_read` (all-found case, expected unchanged) and `::test_batch_read_partial_not_found` (the fixed case)
- [ ] CI: `tox -e all` — full suite

Local verification was ruff-only — Aerospike CE was not reachable on `127.0.0.1:18710` from this environment, so the live FastAPI feasibility run will exercise on CI.