### PR TITLE
docs(stub): document IndexFoundError in AsyncClient index_*_create

### DIFF
--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -2074,6 +2074,9 @@ class AsyncClient:
             index_name: Name for the new index.
             policy: Optional [`AdminPolicy`](types.md#adminpolicy) dict.
 
+        Raises:
+            IndexFoundError: An index with that name already exists.
+
         Example:
             ```python
             await client.index_integer_create("test", "demo", "age", "age_idx")
@@ -2098,6 +2101,9 @@ class AsyncClient:
             index_name: Name for the new index.
             policy: Optional [`AdminPolicy`](types.md#adminpolicy) dict.
 
+        Raises:
+            IndexFoundError: An index with that name already exists.
+
         Example:
             ```python
             await client.index_string_create("test", "demo", "name", "name_idx")
@@ -2121,6 +2127,9 @@ class AsyncClient:
             bin_name: Bin to index (must contain GeoJSON values).
             index_name: Name for the new index.
             policy: Optional [`AdminPolicy`](types.md#adminpolicy) dict.
+
+        Raises:
+            IndexFoundError: An index with that name already exists.
 
         Example:
             ```python


### PR DESCRIPTION
## Summary

The three AsyncClient secondary-index create methods in `src/aerospike_py/__init__.pyi` were missing the `Raises: IndexFoundError` docstring section that their sync `Client` counterparts already document. Users hovering on either client should see the same exception expectations.

## Changes

`src/aerospike_py/__init__.pyi`:

- `AsyncClient.index_integer_create` — add `Raises: IndexFoundError`
- `AsyncClient.index_string_create` — add `Raises: IndexFoundError`
- `AsyncClient.index_geo2dsphere_create` — add `Raises: IndexFoundError`

Wording copied verbatim from the matching sync `Client.index_*_create` methods (~lines 1078, 1105, 1132).

## Test plan

- [x] `ruff format --check` clean
- [x] `ruff check` clean
- [x] symmetry check: 6 total `IndexFoundError: An index with that name already exists` occurrences (3 sync + 3 async)