### PR TITLE
fix(observability): register TRACE level name and harden Python helpers

### DIFF
--- a/src/aerospike_py/_bug_report.py
+++ b/src/aerospike_py/_bug_report.py
@@ -21,6 +21,15 @@ def _shell_escape(s: str) -> str:
     return s.replace("'", "'\\''")
 
 
+def _sanitize_for_title(s: str) -> str:
+    """Collapse all whitespace (incl. newlines) into single spaces.
+
+    Mirrors the Rust-side ``sanitize_for_title`` so the gh issue title stays
+    on a single line.
+    """
+    return " ".join(s.split())
+
+
 def log_unexpected_error(context: str, exc: BaseException) -> None:
     """Log an unexpected error with a gh issue create command.
 
@@ -33,7 +42,7 @@ def log_unexpected_error(context: str, exc: BaseException) -> None:
     exc_msg = str(exc)
     tb_str = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)).strip()
 
-    title = f"Unexpected error: {exc_type}: {exc_msg[:80]}"
+    title = _sanitize_for_title(f"Unexpected error: {exc_type}: {exc_msg}")[:80]
     body = (
         f"aerospike-py version: {__version__}\n"
         f"Python: {sys.version}\n"

--- a/src/aerospike_py/_observability.py
+++ b/src/aerospike_py/_observability.py
@@ -23,6 +23,11 @@ from aerospike_py._aerospike import shutdown_tracing as _shutdown_tracing
 
 logger = logging.getLogger("aerospike_py")
 
+# Register the numeric TRACE level (5) so TRACE-level records render as
+# "TRACE" instead of the default "Level 5".
+_TRACE_LEVEL = 5
+logging.addLevelName(_TRACE_LEVEL, "TRACE")
+
 
 _LEVEL_MAP: dict[int, int] = {
     -1: logging.CRITICAL + 1,  # OFF
@@ -30,7 +35,7 @@ _LEVEL_MAP: dict[int, int] = {
     1: logging.WARNING,
     2: logging.INFO,
     3: logging.DEBUG,
-    4: 5,  # TRACE
+    4: _TRACE_LEVEL,  # TRACE
 }
 """Map aerospike LOG_LEVEL_* constants to Python logging levels."""
 
@@ -52,8 +57,18 @@ def set_log_level(level: int) -> None:
 
         aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)
         ```
+
+    Raises:
+        ValueError: If ``level`` is not one of the ``LOG_LEVEL_*`` constants.
     """
-    py_level = _LEVEL_MAP.get(level, level)
+    if level not in _LEVEL_MAP:
+        raise ValueError(
+            f"Invalid log level: {level!r}. Expected one of the LOG_LEVEL_* "
+            "constants: LOG_LEVEL_OFF (-1), LOG_LEVEL_ERROR (0), "
+            "LOG_LEVEL_WARN (1), LOG_LEVEL_INFO (2), LOG_LEVEL_DEBUG (3), "
+            "LOG_LEVEL_TRACE (4)."
+        )
+    py_level = _LEVEL_MAP[level]
     logging.getLogger("aerospike_py").setLevel(py_level)
     logging.getLogger("_aerospike").setLevel(py_level)
     logging.getLogger("aerospike_core").setLevel(py_level)

--- a/src/aerospike_py/list_operations.py
+++ b/src/aerospike_py/list_operations.py
@@ -79,22 +79,24 @@ _OP_LIST_SET_ORDER = 1031
 
 def list_append(bin: str, val: Any, policy: Optional[ListPolicy] = None) -> Operation:
     """Append a value to a list bin."""
-    return _build_op(_OP_LIST_APPEND, bin, val=val, list_policy=policy or _UNSET)
+    return _build_op(_OP_LIST_APPEND, bin, val=val, list_policy=policy if policy is not None else _UNSET)
 
 
 def list_append_items(bin: str, values: list[Any], policy: Optional[ListPolicy] = None) -> Operation:
     """Append multiple values to a list bin."""
-    return _build_op(_OP_LIST_APPEND_ITEMS, bin, val=values, list_policy=policy or _UNSET)
+    return _build_op(_OP_LIST_APPEND_ITEMS, bin, val=values, list_policy=policy if policy is not None else _UNSET)
 
 
 def list_insert(bin: str, index: int, val: Any, policy: Optional[ListPolicy] = None) -> Operation:
     """Insert a value at the given index."""
-    return _build_op(_OP_LIST_INSERT, bin, index=index, val=val, list_policy=policy or _UNSET)
+    return _build_op(_OP_LIST_INSERT, bin, index=index, val=val, list_policy=policy if policy is not None else _UNSET)
 
 
 def list_insert_items(bin: str, index: int, values: list[Any], policy: Optional[ListPolicy] = None) -> Operation:
     """Insert multiple values at the given index."""
-    return _build_op(_OP_LIST_INSERT_ITEMS, bin, index=index, val=values, list_policy=policy or _UNSET)
+    return _build_op(
+        _OP_LIST_INSERT_ITEMS, bin, index=index, val=values, list_policy=policy if policy is not None else _UNSET
+    )
 
 
 def list_pop(bin: str, index: int) -> Operation:
@@ -243,7 +245,9 @@ def list_remove_by_rank_range(bin: str, rank: int, return_type: int, count: Opti
 
 def list_increment(bin: str, index: int, val: int, policy: Optional[ListPolicy] = None) -> Operation:
     """Increment the value at the given index."""
-    return _build_op(_OP_LIST_INCREMENT, bin, index=index, val=val, list_policy=policy or _UNSET)
+    return _build_op(
+        _OP_LIST_INCREMENT, bin, index=index, val=val, list_policy=policy if policy is not None else _UNSET
+    )
 
 
 def list_sort(bin: str, sort_flags: int = 0) -> Operation:

--- a/src/aerospike_py/map_operations.py
+++ b/src/aerospike_py/map_operations.py
@@ -76,22 +76,22 @@ def map_set_order(bin: str, map_order: int) -> Operation:
 
 def map_put(bin: str, key: Any, val: Any, policy: Optional[MapPolicy] = None) -> Operation:
     """Put a key/value pair into a map bin."""
-    return _build_op(_OP_MAP_PUT, bin, map_key=key, val=val, map_policy=policy or _UNSET)
+    return _build_op(_OP_MAP_PUT, bin, map_key=key, val=val, map_policy=policy if policy is not None else _UNSET)
 
 
 def map_put_items(bin: str, items: dict[str, Any], policy: Optional[MapPolicy] = None) -> Operation:
     """Put multiple key/value pairs into a map bin."""
-    return _build_op(_OP_MAP_PUT_ITEMS, bin, val=items, map_policy=policy or _UNSET)
+    return _build_op(_OP_MAP_PUT_ITEMS, bin, val=items, map_policy=policy if policy is not None else _UNSET)
 
 
 def map_increment(bin: str, key: Any, incr: Any, policy: Optional[MapPolicy] = None) -> Operation:
     """Increment a value in a map by key."""
-    return _build_op(_OP_MAP_INCREMENT, bin, map_key=key, val=incr, map_policy=policy or _UNSET)
+    return _build_op(_OP_MAP_INCREMENT, bin, map_key=key, val=incr, map_policy=policy if policy is not None else _UNSET)
 
 
 def map_decrement(bin: str, key: Any, decr: Any, policy: Optional[MapPolicy] = None) -> Operation:
     """Decrement a value in a map by key."""
-    return _build_op(_OP_MAP_DECREMENT, bin, map_key=key, val=decr, map_policy=policy or _UNSET)
+    return _build_op(_OP_MAP_DECREMENT, bin, map_key=key, val=decr, map_policy=policy if policy is not None else _UNSET)
 
 
 def map_clear(bin: str) -> Operation:

--- a/tests/unit/test_bug_report.py
+++ b/tests/unit/test_bug_report.py
@@ -52,6 +52,39 @@ class TestLogUnexpectedError:
         assert "This error may be a bug in aerospike-py" in msg
 
 
+class TestTitleSingleLine:
+    """The gh-issue title must be a single line (no embedded newlines)."""
+
+    def _title_from_log(self, caplog):
+        # The logged message embeds: --title '<title>' --body '<body>'.
+        # Extract the single-quoted title argument.
+        import re
+
+        msg = caplog.records[0].message
+        m = re.search(r"--title '(.*?)' --body", msg, re.DOTALL)
+        assert m is not None, msg
+        return m.group(1)
+
+    def test_multiline_message_is_collapsed(self, caplog):
+        exc = ValueError("line one\nline two\r\nline three")
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"):
+            log_unexpected_error("Client.get", exc)
+
+        title = self._title_from_log(caplog)
+        assert "\n" not in title
+        assert "\r" not in title
+        assert "line one line two line three" in title
+
+    def test_title_truncated_to_80_chars(self, caplog):
+        exc = ValueError("x" * 200)
+        with caplog.at_level(logging.ERROR, logger="aerospike_py"):
+            log_unexpected_error("Client.get", exc)
+
+        title = self._title_from_log(caplog)
+        assert len(title) <= 80
+        assert "\n" not in title
+
+
 class TestCatchUnexpectedSync:
     """Tests for catch_unexpected decorator with sync functions."""
 

--- a/tests/unit/test_list_map_ops.py
+++ b/tests/unit/test_list_map_ops.py
@@ -454,6 +454,56 @@ class TestListMapByValueFacadeRequiresVal:
             func("mybin", return_type=0)  # type: ignore[call-arg]
 
 
+class TestEmptyPolicyPreserved:
+    """Regression: an empty ``{}`` policy must be forwarded, not dropped.
+
+    The facade uses ``policy if policy is not None else _UNSET`` so that an
+    explicit empty-dict policy is treated as a real (default-valued) policy
+    rather than being elided like ``None``. The earlier ``policy or _UNSET``
+    form wrongly treated ``{}`` as unset because empty dicts are falsy.
+    """
+
+    @pytest.mark.parametrize(
+        "func,args,expected_op",
+        [
+            (list_append, ("mybin", 42), 1001),
+            (list_append_items, ("mybin", [1, 2]), 1002),
+            (list_insert, ("mybin", 0, "x"), 1003),
+            (list_increment, ("mybin", 0, 5), 1029),
+        ],
+        ids=["list_append", "list_append_items", "list_insert", "list_increment"],
+    )
+    def test_list_empty_policy_preserved(self, func, args, expected_op):
+        op = func(*args, policy={})
+        assert op["op"] == expected_op
+        assert "list_policy" in op
+        assert op["list_policy"] == {}
+
+    @pytest.mark.parametrize(
+        "func,args,expected_op",
+        [
+            (map_put, ("mybin", "k", "v"), 2002),
+            (map_put_items, ("mybin", {"a": 1}), 2003),
+            (map_increment, ("mybin", "c", 5), 2004),
+            (map_decrement, ("mybin", "c", 3), 2005),
+        ],
+        ids=["map_put", "map_put_items", "map_increment", "map_decrement"],
+    )
+    def test_map_empty_policy_preserved(self, func, args, expected_op):
+        op = func(*args, policy={})
+        assert op["op"] == expected_op
+        assert "map_policy" in op
+        assert op["map_policy"] == {}
+
+    def test_list_none_policy_omitted(self):
+        op = list_append("mybin", 42, policy=None)
+        assert "list_policy" not in op
+
+    def test_map_none_policy_omitted(self):
+        op = map_put("mybin", "k", "v", policy=None)
+        assert "map_policy" not in op
+
+
 class TestModuleAccess:
     """Test that modules are accessible from the package."""
 

--- a/tests/unit/test_observability_log_level.py
+++ b/tests/unit/test_observability_log_level.py
@@ -1,0 +1,60 @@
+"""Unit tests for set_log_level validation and TRACE level registration."""
+
+import logging
+
+import pytest
+
+import aerospike_py
+
+
+class TestTraceLevelRegistered:
+    def test_trace_level_name_registered(self):
+        """Numeric level 5 must render as 'TRACE', not 'Level 5'."""
+        assert logging.getLevelName(5) == "TRACE"
+
+    def test_trace_record_formats_as_trace(self):
+        record = logging.LogRecord(
+            name="aerospike_py",
+            level=5,
+            pathname=__file__,
+            lineno=1,
+            msg="trace message",
+            args=(),
+            exc_info=None,
+        )
+        assert record.levelname == "TRACE"
+
+
+class TestSetLogLevelValid:
+    @pytest.mark.parametrize(
+        "level,expected",
+        [
+            (aerospike_py.LOG_LEVEL_OFF, logging.CRITICAL + 1),
+            (aerospike_py.LOG_LEVEL_ERROR, logging.ERROR),
+            (aerospike_py.LOG_LEVEL_WARN, logging.WARNING),
+            (aerospike_py.LOG_LEVEL_INFO, logging.INFO),
+            (aerospike_py.LOG_LEVEL_DEBUG, logging.DEBUG),
+            (aerospike_py.LOG_LEVEL_TRACE, 5),
+        ],
+    )
+    def test_valid_levels_applied(self, level, expected):
+        try:
+            aerospike_py.set_log_level(level)
+            assert logging.getLogger("aerospike_py").level == expected
+        finally:
+            # Reset to a sane default so other tests are unaffected.
+            logging.getLogger("aerospike_py").setLevel(logging.WARNING)
+
+
+class TestSetLogLevelInvalid:
+    @pytest.mark.parametrize("bad_level", [5, 99, -2, 100])
+    def test_invalid_level_raises_value_error(self, bad_level):
+        with pytest.raises(ValueError, match="LOG_LEVEL"):
+            aerospike_py.set_log_level(bad_level)
+
+    def test_invalid_level_does_not_change_logger(self):
+        logging.getLogger("aerospike_py").setLevel(logging.INFO)
+        with pytest.raises(ValueError):
+            aerospike_py.set_log_level(42)
+        assert logging.getLogger("aerospike_py").level == logging.INFO
+        logging.getLogger("aerospike_py").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary

Three small, **Python-only**, low-risk robustness/consistency fixes found by a code analysis sweep against `main`. No native (Rust) rebuild required, no public API renames, no exported-symbol removal — MINOR/PATCH level.

### 1. Observability — TRACE level name + input validation (`_observability.py`)
- Register the numeric TRACE level (`5`) via `logging.addLevelName(5, "TRACE")` at import, so TRACE-level records render as `TRACE` instead of the default `Level 5`.
- `set_log_level` previously did `_LEVEL_MAP.get(level, level)`, silently forwarding any out-of-range int straight to `Logger.setLevel`. It now validates `level` against the `LOG_LEVEL_*` constants and raises a clear `ValueError` on unknown input.
- ⚠️ **Minor behavior change**: input that was previously silently (mis)accepted now raises `ValueError`. The documented contract is the `LOG_LEVEL_*` constants, so this surfaces caller mistakes rather than degrading silently. Flagging for reviewer awareness.

### 2. CDT list/map operations — empty-policy handling (`list_operations.py`, `map_operations.py`)
- Replaced `policy or _UNSET` with `policy if policy is not None else _UNSET` so an empty `{}` `ListPolicy`/`MapPolicy` is no longer mistaken for "unset". This matches the already-correct `hll_operations.py` / `bit_operations.py` helpers.

### 3. Bug-report title sanitization (`_bug_report.py`)
- The suggested `gh issue create` title is now collapsed to a single line before truncating to 80 chars (mirrors the Rust-side `sanitize_for_title`), preventing embedded newlines from breaking the suggested command.

## Tests
- New `tests/unit/test_observability_log_level.py` (TRACE name registered, valid levels applied, invalid levels raise without mutating the logger).
- Extended `tests/unit/test_bug_report.py` (multiline message collapsed, title ≤ 80 chars).
- Extended `tests/unit/test_list_map_ops.py` (empty-policy handling).

## Verification
- `uv run ruff check src tests` ✅
- `uv run ruff format --check src tests` ✅
- `uv run pytest tests/unit/...` ✅ 90 passed

🤖 Automated improvement sweep (analysis → fix → verify).