### PR TITLE
fix(policy): accept TTL_CLIENT_DEFAULT (-3) sentinel in parse_ttl

### DIFF
--- a/rust/src/policy/write_policy.rs
+++ b/rust/src/policy/write_policy.rs
@@ -17,19 +17,24 @@ pub static DEFAULT_WRITE_POLICY: LazyLock<WritePolicy> = LazyLock::new(WritePoli
 
 /// Convert a TTL integer value to an [`Expiration`] enum.
 ///
-/// Special values: `0` = namespace default, `-1` = never expire, `-2` = don't update.
+/// Special values: `0` = namespace default, `-1` = never expire, `-2` = don't update,
+/// `-3` = client default (degrades to namespace default).
 pub(crate) fn parse_ttl(ttl_val: i64) -> PyResult<Expiration> {
     match ttl_val {
         0 => Ok(Expiration::NamespaceDefault),
         -1 => Ok(Expiration::Never),
         -2 => Ok(Expiration::DontUpdate),
+        // TTL_CLIENT_DEFAULT (-3) degrades to the namespace default: aerospike-py
+        // exposes no client-level default-TTL config and aerospike-core's Expiration
+        // enum has no ClientDefault variant, so there is nothing else to fall back to.
+        -3 => Ok(Expiration::NamespaceDefault),
         t if t > 0 && t <= u32::MAX as i64 => Ok(Expiration::Seconds(t as u32)),
         t if t > u32::MAX as i64 => Err(crate::errors::InvalidArgError::new_err(format!(
             "ttl out of range: {t} (max: {})",
             u32::MAX
         ))),
         t => Err(crate::errors::InvalidArgError::new_err(format!(
-            "ttl out of range: {t} (only 0, -1, -2, or positive seconds are valid)"
+            "ttl out of range: {t} (only 0, -1, -2, -3, or positive seconds are valid)"
         ))),
     }
 }
@@ -150,6 +155,14 @@ mod tests {
             let p = parse_write_policy(Some(&d), None).unwrap();
             assert_eq!(p.base_policy.sleep_between_retries, 250);
         });
+    }
+
+    #[test]
+    fn parse_ttl_accepts_client_default_sentinel() {
+        assert!(matches!(
+            parse_ttl(-3).expect("TTL_CLIENT_DEFAULT should parse"),
+            Expiration::NamespaceDefault
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`client.put(..., meta={"ttl": aerospike_py.TTL_CLIENT_DEFAULT})` raised `InvalidArgError`, even though `TTL_CLIENT_DEFAULT` is an officially exported, documented sentinel. The same failure hit `batch_write` / `batch_apply` via the shared TTL helper.

## Root cause (contract self-contradiction)

Three places declare `-3` a valid TTL value:

- `rust/src/constants.rs` exports `TTL_CLIENT_DEFAULT = -3`
- `src/aerospike_py/__init__.pyi` declares `TTL = Literal[0, -1, -2, -3]` (and `TTL_CLIENT_DEFAULT: Literal[-3]`)
- docs list `-3 | Use client default`

But `parse_ttl` in `rust/src/policy/write_policy.rs` had match arms only for `0`, `-1`, `-2`, and positive seconds. `-3` fell through to the catch-all error arm and was rejected. `batch_policy.rs` reuses `parse_ttl`, so batch write/apply TTL handling was affected identically.

## Fix

`parse_ttl` now maps `-3 => Ok(Expiration::NamespaceDefault)`. aerospike-py exposes no client-level default-TTL config and aerospike-core's `Expiration` enum has no `ClientDefault` variant, so "client default" degrades to the namespace default — the only meaningful fallback. The catch-all error message was updated to list `-3` among the valid sentinels. ~4 LOC change; no version field touched (Conventional Commits `fix:` → PATCH).

## Test

Added `parse_ttl_accepts_client_default_sentinel` next to the existing `parse_ttl` unit tests:

```rust
assert!(matches!(
    parse_ttl(-3).expect("TTL_CLIENT_DEFAULT should parse"),
    Expiration::NamespaceDefault
));
```

No existing tests modified. The `.pyi` already lists `-3`, so no stub change was needed; the Python layer passes `meta["ttl"]` straight through with no interception, so no Python-side change is required.

## Verification (run locally from the worktree)

| Command | Result |
|---------|--------|
| `cargo fmt --manifest-path rust/Cargo.toml --all` | PASS (no diff) |
| `cargo build --manifest-path rust/Cargo.toml` | PASS |
| `cargo test --manifest-path rust/Cargo.toml parse_ttl` | PASS — 4 passed, 0 failed (incl. new test) |
| `cargo clippy --manifest-path rust/Cargo.toml --all-targets -- -D warnings` | PASS (no warnings) |

Plain build sufficed; no feature flags needed.