### PR TITLE
fix: harden observability metrics-server restart + numpy batch error path

### DIFF
--- a/src/aerospike_py/_observability.py
+++ b/src/aerospike_py/_observability.py
@@ -51,15 +51,15 @@ def set_log_level(level: int) -> None:
             ``LOG_LEVEL_WARN`` (1), ``LOG_LEVEL_INFO`` (2),
             ``LOG_LEVEL_DEBUG`` (3), ``LOG_LEVEL_TRACE`` (4).
 
+    Raises:
+        ValueError: If ``level`` is not a valid ``LOG_LEVEL_*`` constant.
+
     Example:
         ```python
         import aerospike_py
 
         aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)
         ```
-
-    Raises:
-        ValueError: If ``level`` is not one of the ``LOG_LEVEL_*`` constants.
     """
     if level not in _LEVEL_MAP:
         raise ValueError(
@@ -231,6 +231,11 @@ def start_metrics_server(port: int = 9464) -> None:
                     )
             old_server = None
             old_thread = None
+            # The old server is fully torn down; publish a consistent
+            # "no server running" state so a failed re-bind below does not
+            # leave module globals pointing at the dead server.
+            _metrics_server = None
+            _metrics_server_thread = None
 
         # Bind the new port — if this raises OSError (port in use by another
         # process), the existing server on a different port remains untouched.

--- a/src/aerospike_py/numpy_batch.py
+++ b/src/aerospike_py/numpy_batch.py
@@ -154,7 +154,6 @@ def _batch_records_to_numpy(batch_records_obj, dtype, keys, *, strict=False):
                         try:
                             data[i][field] = val
                         except (ValueError, TypeError, OverflowError) as exc:
-                            pk = br.key[2] if br.key and len(br.key) >= 3 else i
                             raise type(exc)(
                                 f"Failed to assign value {val!r} to field '{field}' "
                                 f"(dtype={dtype[field]}) for record at index {i} (key={pk!r}): {exc}"

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,5 +1,6 @@
 """Unit tests for metrics module (no Aerospike server required)."""
 
+import logging
 import re
 import socket
 import threading
@@ -8,6 +9,7 @@ import urllib.request
 import pytest
 
 import aerospike_py
+from aerospike_py import _observability
 
 
 class TestGetMetrics:
@@ -211,3 +213,65 @@ class TestMetricsServerRestart:
         finally:
             occupied.close()
             aerospike_py.stop_metrics_server()
+
+    def test_same_port_rebind_failure_leaves_no_server(self, monkeypatch):
+        """If the same-port re-bind raises OSError after the old server is torn
+        down, the module globals must reflect a consistent 'no server running'
+        state (not a dangling reference to the dead server)."""
+        port = _find_free_port()
+        aerospike_py.start_metrics_server(port=port)
+        assert _observability._metrics_server is not None
+
+        # Force the re-bind to fail after the old server has been closed.
+        def _boom(*args, **kwargs):
+            raise OSError("simulated bind failure")
+
+        monkeypatch.setattr(_observability, "HTTPServer", _boom)
+
+        try:
+            with pytest.raises(OSError):
+                aerospike_py.start_metrics_server(port=port)
+
+            # Old server was torn down before the failed re-bind, so globals
+            # must not point at the dead server.
+            assert _observability._metrics_server is None
+            assert _observability._metrics_server_thread is None
+        finally:
+            monkeypatch.undo()
+            aerospike_py.stop_metrics_server()
+
+
+class TestSetLogLevel:
+    @pytest.fixture(autouse=True)
+    def _restore_level(self):
+        loggers = ["aerospike_py", "_aerospike", "aerospike_core", "aerospike"]
+        saved = {name: logging.getLogger(name).level for name in loggers}
+        yield
+        for name, level in saved.items():
+            logging.getLogger(name).setLevel(level)
+
+    def test_invalid_level_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid log level"):
+            aerospike_py.set_log_level(99)
+
+    def test_invalid_negative_level_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid log level"):
+            aerospike_py.set_log_level(-2)
+
+    @pytest.mark.parametrize(
+        "constant",
+        [
+            aerospike_py.LOG_LEVEL_OFF,
+            aerospike_py.LOG_LEVEL_ERROR,
+            aerospike_py.LOG_LEVEL_WARN,
+            aerospike_py.LOG_LEVEL_INFO,
+            aerospike_py.LOG_LEVEL_DEBUG,
+            aerospike_py.LOG_LEVEL_TRACE,
+        ],
+    )
+    def test_each_valid_constant_maps(self, constant):
+        # Each valid LOG_LEVEL_* constant should apply without raising and set
+        # the aerospike_py logger to the mapped Python level.
+        aerospike_py.set_log_level(constant)
+        expected = _observability._LEVEL_MAP[constant]
+        assert logging.getLogger("aerospike_py").level == expected

--- a/tests/unit/test_numpy_conversion.py
+++ b/tests/unit/test_numpy_conversion.py
@@ -733,6 +733,47 @@ class TestTypeConversionErrors:
         assert "bad_key" in msg
         assert "index 0" in msg
 
+    def test_strict_mode_error_message_includes_primary_key(self):
+        """In strict mode, a type-conversion failure must still report the
+        primary key computed for the record (the loop ``pk``, not a re-extracted
+        value)."""
+        dtype = np.dtype([("count", "i4")])
+        batch = _make_batch_records(
+            [
+                _make_batch_record(
+                    ("test", "demo", "strict_pk"),
+                    0,
+                    (None, {"gen": 1, "ttl": 0}, {"count": "not_a_number"}),
+                ),
+            ]
+        )
+        with pytest.raises((ValueError, TypeError)) as exc_info:
+            _batch_records_to_numpy(batch, dtype, [("test", "demo", "strict_pk")], strict=True)
+        msg = str(exc_info.value)
+        assert "strict_pk" in msg
+        assert "count" in msg
+
+    def test_error_message_uses_index_fallback_for_malformed_key(self):
+        """When the record key is malformed, the conversion-error message must
+        reference the same index-fallback primary key the loop computed."""
+        dtype = np.dtype([("count", "i4")])
+        batch = _make_batch_records(
+            [
+                _make_batch_record(
+                    None,  # malformed key → pk falls back to integer index 0
+                    0,
+                    (None, {"gen": 1, "ttl": 0}, {"count": "not_a_number"}),
+                ),
+            ]
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises((ValueError, TypeError)) as exc_info:
+                _batch_records_to_numpy(batch, dtype, [None])
+        msg = str(exc_info.value)
+        assert "key=0" in msg
+        assert "index 0" in msg
+
 
 # ── NumpyBatchRecords protocol method tests ────────────────────
 


### PR DESCRIPTION
## Summary

Three robustness fixes in the observability and numpy-batch code paths. No public API renames, no version edits (auto-release handles versions).

## Findings

### Finding 1 (P1) — `src/aerospike_py/_observability.py` `start_metrics_server` (~L195-234)
**Root cause:** On a same-port restart, the function shuts down and closes the old `HTTPServer` and then re-binds `HTTPServer(("", port), ...)`. If that bind raised `OSError` (port grabbed by another process in the meantime), the module globals `_metrics_server` / `_metrics_server_thread` still pointed at the dead, already-closed server — an inconsistent state where the client believes a server is running.
**Fix:** In the same-port teardown branch, set `_metrics_server = None` and `_metrics_server_thread = None` immediately after closing the old server (before the re-bind), so a failed re-bind leaves a clean "no server running" state.

### Finding 2 (P2) — `src/aerospike_py/_observability.py:56` `set_log_level`
**Root cause:** `py_level = _LEVEL_MAP.get(level, level)` silently forwarded an out-of-range int straight to `logging.setLevel`, producing a meaningless numeric level instead of an error.
**Fix:** Validate up front — `if level not in _LEVEL_MAP: raise ValueError(...)` — then `py_level = _LEVEL_MAP[level]`. Docstring updated with a `Raises:` note.

### Finding 3 (P2) — `src/aerospike_py/numpy_batch.py:157`
**Root cause:** The strict-mode (and general) type-conversion `except` handler re-extracted `pk` (`pk = br.key[2] if br.key and len(br.key) >= 3 else i`), shadowing the loop `pk` already computed earlier — duplicating logic and risking drift from the canonical key (including the malformed-key index fallback).
**Fix:** Drop the re-extraction; reference the existing loop `pk` already computed for the index/collision mapping.

## Verification

- `uv run ruff format --check .` — passes (162 files formatted)
- `uv run ruff check .` — all checks passed
- `uv run pytest tests/unit/test_metrics.py tests/unit/test_numpy_conversion.py -q` — **73 passed**

New/extended tests:
- `TestMetricsServerRestart::test_same_port_rebind_failure_leaves_no_server` — monkeypatches `HTTPServer` to raise after the old server is torn down; asserts `_metrics_server is None`.
- `TestSetLogLevel` — `set_log_level` raises `ValueError` on invalid levels (`99`, `-2`) and maps every valid `LOG_LEVEL_*` constant.
- `TestTypeConversionErrors::test_strict_mode_error_message_includes_primary_key` and `test_error_message_uses_index_fallback_for_malformed_key` — the strict-mode / malformed-key conversion error message still includes the primary key.

---
**Scope note (post-rebase onto origin/main):** of the three originally-bundled fixes, `set_log_level` validation was found already present upstream and dropped. The surviving changes are (1) resetting the metrics-server module globals on a failed same-port re-bind, and (3) reusing the loop-computed primary key in the numpy_batch strict-mode error path. ruff + full unit suite green (20/20 CI checks pass).