### PR TITLE
fix(bin): reject empty bin names client-side

### DIFF
--- a/rust/src/types/bin.rs
+++ b/rust/src/types/bin.rs
@@ -6,6 +6,9 @@ use pyo3::types::{PyDict, PyString};
 
 use super::value::py_to_value;
 
+/// Maximum bin name length in bytes, enforced by the Aerospike server.
+const MAX_BIN_NAME_LEN: usize = 15;
+
 /// Convert a Python dict of bins to a Vec<Bin>.
 /// Bin values of None (Nil) are passed through — the server treats them
 /// as bin deletion requests, matching the official Python client behavior.
@@ -13,9 +16,19 @@ pub fn py_dict_to_bins(dict: &Bound<'_, PyDict>) -> PyResult<Vec<Bin>> {
     let mut bins = Vec::with_capacity(dict.len());
     for (key, val) in dict.iter() {
         let name: String = key.cast::<PyString>()?.to_str()?.to_owned();
-        if name.len() > 15 {
+        // An empty bin name is invalid in Aerospike. Without this check it
+        // used to fall through to `Bin::new("", ...)` and only fail at write
+        // time with an opaque server-side parameter error, leaving the caller
+        // unable to tell which bin was malformed. Reject it client-side with a
+        // clear message, matching the over-length check below.
+        if name.is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Bin name must not be empty",
+            ));
+        }
+        if name.len() > MAX_BIN_NAME_LEN {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "Bin name '{}' exceeds the 15-byte limit ({} bytes)",
+                "Bin name '{}' exceeds the {MAX_BIN_NAME_LEN}-byte limit ({} bytes)",
                 name,
                 name.len()
             )));
@@ -24,4 +37,64 @@ pub fn py_dict_to_bins(dict: &Bound<'_, PyDict>) -> PyResult<Vec<Bin>> {
         bins.push(Bin::new(name, value));
     }
     Ok(bins)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A normal bin name converts to a single `Bin`.
+    #[test]
+    fn py_dict_to_bins_accepts_valid_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("name", "alice").unwrap();
+            let bins = py_dict_to_bins(&dict).expect("valid bin should convert");
+            assert_eq!(bins.len(), 1);
+            assert_eq!(bins[0].name, "name");
+        });
+    }
+
+    /// A bin name of exactly 15 bytes is at the limit and accepted.
+    #[test]
+    fn py_dict_to_bins_accepts_15_byte_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            let name = "a".repeat(MAX_BIN_NAME_LEN);
+            dict.set_item(&name, 1).unwrap();
+            let bins = py_dict_to_bins(&dict).expect("15-byte name should convert");
+            assert_eq!(bins.len(), 1);
+            assert_eq!(bins[0].name, name);
+        });
+    }
+
+    /// An empty bin name must be rejected client-side with a clear `ValueError`
+    /// instead of being deferred to an opaque server-side parameter error.
+    #[test]
+    fn py_dict_to_bins_rejects_empty_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("", 1).unwrap();
+            let err = py_dict_to_bins(&dict).expect_err("empty bin name must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            assert!(err.to_string().contains("must not be empty"));
+        });
+    }
+
+    /// A bin name longer than 15 bytes is rejected with the over-length error.
+    #[test]
+    fn py_dict_to_bins_rejects_oversized_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            let name = "a".repeat(MAX_BIN_NAME_LEN + 1);
+            dict.set_item(&name, 1).unwrap();
+            let err = py_dict_to_bins(&dict).expect_err("oversized bin name must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            assert!(err.to_string().contains("exceeds the 15-byte limit"));
+        });
+    }
 }

--- a/tests/unit/test_edge_cases_extended.py
+++ b/tests/unit/test_edge_cases_extended.py
@@ -243,9 +243,13 @@ class TestBinNameEdgeCases:
             c.put(("test", "demo", "key1"), {"\u00e9": "value"})
 
     def test_empty_bin_name(self):
-        """Empty bin name should be accepted at the Python/Rust parsing level."""
+        """An empty bin name should raise ValueError at the client level.
+
+        Aerospike rejects empty bin names server-side with an opaque parameter
+        error; validating client-side surfaces the malformed bin immediately.
+        """
         c = _make_client()
-        with pytest.raises(aerospike_py.ClientError):
+        with pytest.raises(ValueError, match="must not be empty"):
             c.put(("test", "demo", "key1"), {"": "value"})
 
     def test_multiple_bins(self):


### PR DESCRIPTION
## Problem

`py_dict_to_bins` (the dict→`Vec<Bin>` converter used by every `put` / `operate` / batch-write path) validated the **upper** bound on bin-name length (15 bytes) but never checked for the **empty** case.

A put with an empty bin name:

```python
client.put(("test", "demo", "k"), {"": "value"})
```

fell through to `Bin::new("", ...)` and was only rejected later — at write time — with an opaque server-side parameter error (or a generic `ClientError` before a connection exists). The caller could not tell which bin was malformed.

## Root cause

`rust/src/types/bin.rs::py_dict_to_bins` only guarded `name.len() > 15`. An empty string passes that guard, yet an empty bin name is invalid in Aerospike, so the failure was deferred and unhelpful. A pre-existing unit test even asserted the buggy accept-then-fail-at-server behavior.

## Fix

- Reject empty bin names at conversion time with a clear `ValueError("Bin name must not be empty")`, mirroring the existing over-length check and the repo's fail-loudly convention (cf. `py_to_key` malformed-digest rejection, `require_bin`).
- Extract the limit into a `MAX_BIN_NAME_LEN` constant.
- Remove the stale Python test that asserted the old behavior.

## Test evidence

- **Rust** (`rust/src/types/bin.rs`): new test suite — valid, exactly-15-byte, empty (rejected), oversized (rejected).
- **Python** (`tests/unit/test_edge_cases_extended.py::TestBinNameEdgeCases::test_empty_bin_name`): asserts `ValueError` matching "must not be empty".
- Before/after: with the Rust fix stashed and rebuilt, the new Python test **fails** (raises `ClientError` — empty name slipped past validation). With the fix restored, it **passes**.

```
cargo test --lib types::bin   -> 4 passed
cargo test --lib (full)       -> 236 passed
cargo fmt --check             -> clean
cargo clippy -D warnings      -> clean
ruff check / ruff format      -> clean
pytest TestBinNameEdgeCases   -> 6 passed (built extension)
```

## Scope

2 files, well under budget. One focused concern. No version bumps. Distinct from the previously-fixed empty-variadic-expression validation.