### PR TITLE
fix(query): reject invalid contains() collection index_type

### DIFF
--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -92,6 +92,12 @@ fn parse_predicate(pred: &Bound<'_, PyTuple>) -> PyResult<Predicate> {
         "contains" => {
             ensure_predicate_min_len(pred, "contains", 4)?;
             let col_type: i32 = pred.get_item(2)?.extract()?;
+            // Validate the collection index type up front. A typo or an
+            // accidentally-passed constant from another namespace (e.g. a
+            // `LIST_RETURN_*`/`MAP_RETURN_*` value) used to be silently coerced
+            // to `CollectionIndexType::Default`, querying the wrong index type
+            // and returning wrong/empty results with no error.
+            validate_collection_index_type(col_type)?;
             let val_any = pred.get_item(3)?;
             if let Ok(v) = val_any.extract::<i64>() {
                 Ok(Predicate::ContainsInteger {
@@ -214,12 +220,36 @@ fn build_statement(
 }
 
 /// Map a Python integer to a [`CollectionIndexType`] for contains-predicates.
+///
+/// Callers must validate `val` via [`validate_collection_index_type`] first;
+/// any value outside `0..=3` falls back to [`CollectionIndexType::Default`].
 fn int_to_collection_index_type(val: i32) -> CollectionIndexType {
     match val {
         1 => CollectionIndexType::List,
         2 => CollectionIndexType::MapKeys,
         3 => CollectionIndexType::MapValues,
         _ => CollectionIndexType::Default,
+    }
+}
+
+/// Reject an out-of-range collection index type for a `contains` predicate.
+///
+/// Valid values are the `INDEX_TYPE_*` constants: `0` (DEFAULT), `1` (LIST),
+/// `2` (MAPKEYS), `3` (MAPVALUES). Any other value is a caller mistake — a
+/// typo, or a constant borrowed from another namespace such as
+/// `LIST_RETURN_*`/`MAP_RETURN_*`, which overlap this small integer range.
+/// Previously such values were silently coerced to `DEFAULT`, so the query ran
+/// against the wrong index type and returned wrong or empty results with no
+/// error. Surfacing it here fails loudly, matching the other predicate guards.
+fn validate_collection_index_type(val: i32) -> PyResult<()> {
+    if (0..=3).contains(&val) {
+        Ok(())
+    } else {
+        Err(crate::errors::InvalidArgError::new_err(format!(
+            "Predicate 'contains' index_type {val} is invalid; expected one of \
+             INDEX_TYPE_DEFAULT (0), INDEX_TYPE_LIST (1), INDEX_TYPE_MAPKEYS (2), \
+             or INDEX_TYPE_MAPVALUES (3)."
+        )))
     }
 }
 
@@ -510,6 +540,54 @@ mod tests {
                     let msg = err.to_string();
                     assert!(msg.contains("InvalidArgError"));
                     assert!(msg.contains("contains"));
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn parse_predicate_accepts_valid_contains_index_types() {
+        Python::initialize();
+        Python::attach(|py| {
+            // 0..=3 are the valid INDEX_TYPE_* constants. Each must parse for
+            // both an integer value and a string value.
+            for col_type in [0i64, 1, 2, 3] {
+                let list = pyo3::types::PyList::new(py, ["contains", "tags"]).unwrap();
+                list.append(col_type).unwrap();
+                list.append("python").unwrap();
+                let pred = PyTuple::new(py, list.iter()).unwrap();
+                parse_predicate(&pred)
+                    .unwrap_or_else(|e| panic!("index_type {col_type} must parse: {e}"));
+            }
+        });
+    }
+
+    #[test]
+    fn parse_predicate_rejects_invalid_contains_index_type() {
+        Python::initialize();
+        Python::attach(|py| {
+            // Typos and constants borrowed from other namespaces (negative,
+            // or above the 0..=3 range) must be rejected loudly rather than
+            // silently coerced to INDEX_TYPE_DEFAULT.
+            for bad in [-1i64, 4, 5, 99] {
+                let list = pyo3::types::PyList::new(py, ["contains", "tags"]).unwrap();
+                list.append(bad).unwrap();
+                list.append("python").unwrap();
+                let pred = PyTuple::new(py, list.iter()).unwrap();
+                match parse_predicate(&pred) {
+                    Ok(_) => panic!("index_type {bad} must be rejected"),
+                    Err(err) => {
+                        let msg = err.to_string();
+                        assert!(msg.contains("InvalidArgError"), "got: {msg}");
+                        assert!(
+                            msg.contains("contains") && msg.contains("index_type"),
+                            "error must name the predicate and index_type: {msg}"
+                        );
+                        assert!(
+                            msg.contains(&bad.to_string()),
+                            "error must echo the offending value {bad}: {msg}"
+                        );
+                    }
                 }
             }
         });

--- a/src/aerospike_py/predicates.py
+++ b/src/aerospike_py/predicates.py
@@ -45,7 +45,9 @@ def contains(bin_name: str, index_type: int, val: Any) -> tuple[str, str, int, A
 
     Args:
         bin_name: Name of the bin.
-        index_type: Collection index type (INDEX_TYPE_LIST, INDEX_TYPE_MAPKEYS, INDEX_TYPE_MAPVALUES).
+        index_type: Collection index type. One of INDEX_TYPE_DEFAULT, INDEX_TYPE_LIST,
+            INDEX_TYPE_MAPKEYS, or INDEX_TYPE_MAPVALUES. Any other value is rejected with
+            InvalidArgError when the query is built (e.g. via ``query.where(...)``).
         val: The value to search for.
     """
     return ("contains", bin_name, index_type, val)

--- a/src/aerospike_py/predicates.pyi
+++ b/src/aerospike_py/predicates.pyi
@@ -36,8 +36,9 @@ def contains(bin_name: str, index_type: int, val: Any) -> tuple[str, str, int, A
 
     Args:
         bin_name: Name of the bin holding a list or map.
-        index_type: One of ``INDEX_TYPE_LIST``, ``INDEX_TYPE_MAPKEYS``,
-            or ``INDEX_TYPE_MAPVALUES``.
+        index_type: One of ``INDEX_TYPE_DEFAULT``, ``INDEX_TYPE_LIST``,
+            ``INDEX_TYPE_MAPKEYS``, or ``INDEX_TYPE_MAPVALUES``. Any other
+            value is rejected with ``InvalidArgError`` when the query is built.
         val: The value to search for within the collection.
 
     Example::


### PR DESCRIPTION
## Problem

The `contains` secondary-index predicate accepted **any** integer for `index_type`. At statement-build time, `int_to_collection_index_type` mapped anything outside `1..=3` to `CollectionIndexType::Default`:

```rust
fn int_to_collection_index_type(val: i32) -> CollectionIndexType {
    match val {
        1 => CollectionIndexType::List,
        2 => CollectionIndexType::MapKeys,
        3 => CollectionIndexType::MapValues,
        _ => CollectionIndexType::Default,   // silent fallback
    }
}
```

So a caller mistake — a typo like `5`, a negative value, or a constant accidentally borrowed from another namespace (`LIST_RETURN_*` / `MAP_RETURN_*`, whose small integer values overlap the `INDEX_TYPE_*` range) — was **silently coerced to `DEFAULT`**. The query then ran against the wrong collection index type and returned wrong or empty results with **no error**, a data-correctness footgun that is hard to diagnose.

## Root cause

`index_type` was never validated. The lenient `_ =>` arm masked invalid input instead of surfacing it.

## Fix

- Validate `index_type` up front in `parse_predicate` (where the other predicate guards live) via a new `validate_collection_index_type`, accepting only the documented `INDEX_TYPE_*` constants: `0` (DEFAULT), `1` (LIST), `2` (MAPKEYS), `3` (MAPVALUES).
- Any other value now raises a descriptive `InvalidArgError` that names the predicate, the constraint, and echoes the offending value — matching the style established in #392 (`between` integer bounds) and #393.
- `int_to_collection_index_type` is unchanged in behavior but now documented as requiring prior validation.
- Updated `predicates.py` / `predicates.pyi` docstrings to state the constraint and that invalid values are rejected at query-build time.

No public API, signature, or constant changed — purely an added validation guard.

## Tests

Added two Rust unit tests in `rust/src/query.rs`:
- `parse_predicate_accepts_valid_contains_index_types` — `0..=3` all parse.
- `parse_predicate_rejects_invalid_contains_index_type` — `-1, 4, 5, 99` each raise `InvalidArgError` naming the predicate, `index_type`, and the offending value.

Existing `test_predicates.py` builds (tuple construction only) are unaffected.

### Test evidence
- `cargo test --lib` → **238 passed, 0 failed**
- `cargo test --lib query::` → 9 passed (incl. 2 new)
- `cargo clippy --lib` → clean
- `ruff check src/aerospike_py/predicates.py` → all checks passed

## Risk

**Low.** Behavior change is limited to input that was previously a silent mistake: values that used to be coerced to `DEFAULT` now raise `InvalidArgError` at query-build time. Valid `INDEX_TYPE_*` usage is unchanged. No version field touched (auto-release handles it).