### PR TITLE
fix(query): reject empty bin names in predicates, select, and expressions

### DIFF
--- a/rust/src/expressions.rs
+++ b/rust/src/expressions.rs
@@ -119,6 +119,7 @@ pub fn py_to_expression(obj: &Bound<'_, PyAny>) -> PyResult<Expression> {
 /// Convert bin accessor operations that all take a single "name" field.
 fn convert_bin_accessor(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Expression> {
     let name: String = get_required(dict, "name")?;
+    crate::query::validate_bin_name(&name)?;
     match op {
         "int_bin" => Ok(expressions::int_bin(name)),
         "float_bin" => Ok(expressions::float_bin(name)),
@@ -408,6 +409,45 @@ mod tests {
                 vec![int_val_dict(py, 1), int_val_dict(py, 2)],
             );
             py_to_expression(dict.as_any()).expect("non-empty num_add should convert");
+        });
+    }
+
+    /// Build a bin-accessor dict `{"__expr__": op, "name": name}`.
+    fn bin_accessor_dict<'py>(py: Python<'py>, op: &str, name: &str) -> Bound<'py, PyDict> {
+        let dict = PyDict::new(py);
+        dict.set_item("__expr__", op).unwrap();
+        dict.set_item("name", name).unwrap();
+        dict
+    }
+
+    /// A bin-accessor expression with an empty bin name must be rejected
+    /// client-side with `InvalidArgError`, instead of being forwarded to the
+    /// server where it fails far from the call site.
+    #[test]
+    fn bin_accessor_rejects_empty_bin_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = bin_accessor_dict(py, "int_bin", "");
+            let err = py_to_expression(dict.as_any())
+                .expect_err("empty bin name must be rejected for int_bin");
+            assert!(
+                err.is_instance_of::<crate::errors::InvalidArgError>(py),
+                "empty bin name must raise InvalidArgError, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains("Bin name"),
+                "error must mention the bin name: {err:?}"
+            );
+        });
+    }
+
+    /// A bin-accessor expression with a non-empty bin name still converts.
+    #[test]
+    fn bin_accessor_accepts_non_empty_bin_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = bin_accessor_dict(py, "int_bin", "age");
+            py_to_expression(dict.as_any()).expect("non-empty bin name must convert");
         });
     }
 }

--- a/rust/src/query.rs
+++ b/rust/src/query.rs
@@ -76,6 +76,7 @@ fn parse_predicate(pred: &Bound<'_, PyTuple>) -> PyResult<Predicate> {
     }
     let kind: String = pred.get_item(0)?.extract()?;
     let bin: String = pred.get_item(1)?.extract()?;
+    validate_bin_name(&bin)?;
     trace!("Parsing predicate: kind={} bin={}", kind, bin);
 
     match kind.as_str() {
@@ -253,6 +254,25 @@ fn validate_collection_index_type(val: i32) -> PyResult<()> {
     }
 }
 
+/// Reject an empty bin name client-side.
+///
+/// An empty string was previously accepted by the predicate/query/expression
+/// builders and only failed deep in the server with an opaque
+/// `AEROSPIKE_ERR_PARAMETER`/bin-name error that gave the caller no hint about
+/// which builder call produced it. Surfacing it here fails loudly and early,
+/// matching the existing empty-bin-name guard in `py_dict_to_bins` and the
+/// other client-side predicate guards (#392/#393/#395). Shared (`pub(crate)`)
+/// so the query/predicate and expression builders apply one consistent rule.
+pub(crate) fn validate_bin_name(name: &str) -> PyResult<()> {
+    if name.is_empty() {
+        Err(crate::errors::InvalidArgError::new_err(
+            "Bin name must not be empty.",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 /// Execute a query/scan, collect all records, with metrics and OTel span.
 #[allow(unused, clippy::too_many_arguments)]
 fn execute_query_collect(
@@ -426,7 +446,7 @@ impl PyQuery {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_predicate;
+    use super::{parse_predicate, validate_bin_name};
     use pyo3::prelude::*;
     use pyo3::types::PyTuple;
 
@@ -608,6 +628,77 @@ mod tests {
             }
         });
     }
+
+    /// An empty bin name must be rejected client-side for every predicate kind
+    /// (equals/between/contains), instead of being forwarded to the server which
+    /// fails far from the call site with an opaque parameter/bin-name error.
+    #[test]
+    fn parse_predicate_rejects_empty_bin_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            // equals: ("equals", "", value)
+            let pred = PyTuple::new(py, ["equals", "", "v"]).unwrap();
+            assert_empty_bin_rejected(&pred, "equals");
+
+            // between: ("between", "", begin, end) — heterogeneous, build via list
+            let list = pyo3::types::PyList::new(py, ["between", ""]).unwrap();
+            list.append(1i64).unwrap();
+            list.append(9i64).unwrap();
+            let pred = PyTuple::new(py, list.iter()).unwrap();
+            assert_empty_bin_rejected(&pred, "between");
+
+            // contains: ("contains", "", index_type, value)
+            let list = pyo3::types::PyList::new(py, ["contains", ""]).unwrap();
+            list.append(0i64).unwrap();
+            list.append("x").unwrap();
+            let pred = PyTuple::new(py, list.iter()).unwrap();
+            assert_empty_bin_rejected(&pred, "contains");
+        });
+    }
+
+    /// A non-empty bin name still parses successfully (the guard does not reject
+    /// legitimate predicates).
+    #[test]
+    fn parse_predicate_accepts_non_empty_bin_name() {
+        Python::initialize();
+        Python::attach(|py| {
+            let pred = PyTuple::new(py, ["equals", "age", "30"]).unwrap();
+            parse_predicate(&pred).expect("non-empty bin name must parse");
+        });
+    }
+
+    /// The shared `validate_bin_name` guard — used by `Query::select()` as well
+    /// as the predicate and expression builders — rejects empty names and
+    /// accepts non-empty ones.
+    #[test]
+    fn validate_bin_name_rejects_empty_accepts_non_empty() {
+        Python::initialize();
+        Python::attach(|_py| {
+            let err = validate_bin_name("").expect_err("empty bin name must be rejected");
+            let msg = err.to_string();
+            assert!(msg.contains("InvalidArgError"), "got: {msg}");
+            assert!(msg.contains("Bin name"), "got: {msg}");
+
+            validate_bin_name("score").expect("non-empty bin name must be accepted");
+        });
+    }
+
+    fn assert_empty_bin_rejected(pred: &Bound<'_, PyTuple>, kind: &str) {
+        match parse_predicate(pred) {
+            Ok(_) => panic!("empty bin name must be rejected for '{kind}'"),
+            Err(err) => {
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("InvalidArgError"),
+                    "'{kind}' empty bin error must be InvalidArgError: {msg}"
+                );
+                assert!(
+                    msg.contains("Bin name"),
+                    "'{kind}' empty bin error must mention the bin name: {msg}"
+                );
+            }
+        }
+    }
 }
 
 #[pymethods]
@@ -616,7 +707,9 @@ impl PyQuery {
     #[pyo3(signature = (*bins))]
     fn select(&mut self, bins: &Bound<'_, PyTuple>) -> PyResult<()> {
         for bin in bins.iter() {
-            self.bins.push(bin.extract::<String>()?);
+            let name = bin.extract::<String>()?;
+            validate_bin_name(&name)?;
+            self.bins.push(name);
         }
         Ok(())
     }


### PR DESCRIPTION
## 문제

`predicates` / `Query.select()` / `exp` bin accessor 빌더에서 **빈 bin name(`""`)이 클라이언트 측 검증 없이 그대로 통과**되어, 서버까지 전달된 뒤에야 호출 지점과 동떨어진 위치에서 모호한 parameter/bin-name 에러로 실패했습니다. 사용자는 어느 빌더 호출이 문제였는지 알기 어려웠습니다.

## 해결

공유 헬퍼 `validate_bin_name(name: &str) -> PyResult<()>`(`rust/src/query.rs`, `pub(crate)`)를 추가하고 빈 이름이면 설명이 담긴 `InvalidArgError`를 반환합니다. 이를 3개 빌더 경로에서 조기 호출해 클라이언트 측에서 즉시 거부합니다:

- `query.rs` `parse_predicate()` — `bin` 추출 직후 (equals/between/contains 등 모든 predicate 공통)
- `query.rs` `Query::select()` — 각 bin 마다
- `expressions.rs` `convert_bin_accessor()` — `name` 추출 직후 (`int_bin`/`string_bin`/`bin_exists` 등)

헬퍼는 한 곳에 두고 재사용하여 중복을 피했습니다.

## 테스트 추가

- `parse_predicate_rejects_empty_bin_name` — equals/between/contains predicate에서 빈 bin name 거부
- `parse_predicate_accepts_non_empty_bin_name` / `validate_bin_name_rejects_empty_accepts_non_empty` — 정상 동작 확인
- `bin_accessor_rejects_empty_bin_name` / `bin_accessor_accepts_non_empty_bin_name` — bin accessor 표현식 검증

결과: `cargo test --lib` 243 tests 전부 통과(신규 5건 포함), `cargo clippy -D warnings` 경고 없음.

## 참고

이 변경은 #395 (`contains` `index_type` 범위 밖 값 거부)의 `validate_collection_index_type` 가드와 **동일한 패턴**이며, `py_dict_to_bins`에 이미 존재하던 빈 bin name 검사와도 일관됩니다. 공개 API 시그니처 변경 없이 검증만 추가하는 변경입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
