### PR TITLE
fix(host): harden host/port parsing (empty tuple, IPv6 telemetry, default-port consistency)

### DIFF
--- a/rust/src/types/host.rs
+++ b/rust/src/types/host.rs
@@ -4,7 +4,11 @@ use log::debug;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
 
+/// Default Aerospike service port used when a host entry omits one.
+const DEFAULT_PORT: u16 = 3000;
+
 /// Result of parsing the hosts config.
+#[derive(Debug)]
 pub struct ParsedHosts {
     /// Connection string: "host1:port1,host2:port2"
     pub connection_string: String,
@@ -25,15 +29,20 @@ pub fn parse_hosts_from_config(config: &Bound<'_, PyDict>) -> PyResult<ParsedHos
     let hosts_list = hosts_obj.cast::<PyList>()?;
     let mut host_strings = Vec::with_capacity(hosts_list.len());
     let mut first_address = String::new();
-    let mut first_port: u16 = 3000;
+    let mut first_port: u16 = DEFAULT_PORT;
 
     for (i, item) in hosts_list.iter().enumerate() {
         if let Ok(tuple) = item.cast::<PyTuple>() {
+            if tuple.is_empty() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "Host tuple must contain at least a host address, got an empty tuple",
+                ));
+            }
             let host: String = tuple.get_item(0)?.extract()?;
             let port: u16 = if tuple.len() > 1 {
                 tuple.get_item(1)?.extract()?
             } else {
-                3000
+                DEFAULT_PORT
             };
             if i == 0 {
                 first_address = host.clone();
@@ -42,8 +51,16 @@ pub fn parse_hosts_from_config(config: &Bound<'_, PyDict>) -> PyResult<ParsedHos
             host_strings.push(format!("{host}:{port}"));
         } else if let Ok(s) = item.extract::<String>() {
             if i == 0 {
-                // Parse "host:port" or just "host"
-                if let Some((h, p)) = s.rsplit_once(':') {
+                // Parse "host:port" or just "host".
+                //
+                // Only treat the string as host:port when there is exactly one
+                // ':'. A bare IPv6 literal (e.g. "fe80::1") contains multiple
+                // ':' and must be treated as a whole address, otherwise
+                // rsplit_once(':') would mis-split it into ("fe80:", "1") and
+                // corrupt the telemetry attributes.
+                if s.matches(':').count() == 1 {
+                    // Safe to unwrap: exactly one ':' guarantees a split.
+                    let (h, p) = s.rsplit_once(':').unwrap();
                     first_address = h.to_string();
                     first_port = p.parse().map_err(|_| {
                         pyo3::exceptions::PyValueError::new_err(format!(
@@ -51,11 +68,24 @@ pub fn parse_hosts_from_config(config: &Bound<'_, PyDict>) -> PyResult<ParsedHos
                         ))
                     })?;
                 } else {
+                    // Bare hostname (no ':') or bare IPv6 literal (multiple
+                    // ':'): the whole string is the address and the default
+                    // port applies.
                     first_address = s.clone();
-                    first_port = 3000;
+                    first_port = DEFAULT_PORT;
                 }
             }
-            host_strings.push(s);
+            // Normalize a bare hostname (no ':') to "host:DEFAULT_PORT" so the
+            // string form matches the tuple form. The downstream
+            // aerospike_core host parser applies the same default port to a
+            // bare hostname, so this is behavior-preserving (see PR notes).
+            // IPv6 literals (multiple ':') are pushed verbatim to avoid
+            // mangling an address the core parser handles itself.
+            if s.contains(':') {
+                host_strings.push(s);
+            } else {
+                host_strings.push(format!("{s}:{DEFAULT_PORT}"));
+            }
         } else {
             return Err(pyo3::exceptions::PyTypeError::new_err(
                 "Host must be a (host, port) tuple or a string",
@@ -76,4 +106,142 @@ pub fn parse_hosts_from_config(config: &Bound<'_, PyDict>) -> PyResult<ParsedHos
         first_address,
         first_port,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::types::{PyDict, PyList, PyTuple};
+    use pyo3::IntoPyObjectExt;
+
+    /// Build a config dict `{"hosts": <list>}` from the given host entries.
+    fn config_with_hosts<'py>(
+        py: Python<'py>,
+        entries: &[Bound<'py, PyAny>],
+    ) -> Bound<'py, PyDict> {
+        let list = PyList::new(py, entries).unwrap();
+        let dict = PyDict::new(py);
+        dict.set_item("hosts", list).unwrap();
+        dict
+    }
+
+    #[test]
+    fn default_port_constant_is_3000() {
+        assert_eq!(DEFAULT_PORT, 3000);
+    }
+
+    /// A bare hostname string must default to `DEFAULT_PORT` for telemetry and
+    /// be normalized to "host:DEFAULT_PORT" in the connection string (matching
+    /// the tuple form; the core parser applies the same default port).
+    #[test]
+    fn bare_string_host_uses_default_port() {
+        Python::initialize();
+        Python::attach(|py| {
+            let host = "node1".into_bound_py_any(py).unwrap();
+            let config = config_with_hosts(py, &[host]);
+            let parsed = parse_hosts_from_config(&config).expect("bare host must parse");
+            assert_eq!(parsed.first_address, "node1");
+            assert_eq!(parsed.first_port, DEFAULT_PORT);
+            assert_eq!(parsed.connection_string, "node1:3000");
+        });
+    }
+
+    /// A "host:port" string must use the explicit port.
+    #[test]
+    fn string_host_with_explicit_port() {
+        Python::initialize();
+        Python::attach(|py| {
+            let host = "node1:4000".into_bound_py_any(py).unwrap();
+            let config = config_with_hosts(py, &[host]);
+            let parsed = parse_hosts_from_config(&config).expect("host:port must parse");
+            assert_eq!(parsed.first_address, "node1");
+            assert_eq!(parsed.first_port, 4000);
+            assert_eq!(parsed.connection_string, "node1:4000");
+        });
+    }
+
+    /// A single-element tuple ("node1",) regression: default port applies.
+    #[test]
+    fn single_element_tuple_uses_default_port() {
+        Python::initialize();
+        Python::attach(|py| {
+            let tuple = PyTuple::new(py, ["node1"]).unwrap().into_any();
+            let config = config_with_hosts(py, &[tuple]);
+            let parsed = parse_hosts_from_config(&config).expect("(host,) must parse");
+            assert_eq!(parsed.first_address, "node1");
+            assert_eq!(parsed.first_port, DEFAULT_PORT);
+            assert_eq!(parsed.connection_string, "node1:3000");
+        });
+    }
+
+    /// A (host, port) tuple regression: explicit port is honored.
+    #[test]
+    fn host_port_tuple_is_honored() {
+        Python::initialize();
+        Python::attach(|py| {
+            let host = "node1".into_pyobject(py).unwrap().into_any();
+            let port = 4000u16.into_pyobject(py).unwrap().into_any();
+            let tuple = PyTuple::new(py, [host, port]).unwrap().into_any();
+            let config = config_with_hosts(py, &[tuple]);
+            let parsed = parse_hosts_from_config(&config).expect("(host, port) must parse");
+            assert_eq!(parsed.first_address, "node1");
+            assert_eq!(parsed.first_port, 4000);
+            assert_eq!(parsed.connection_string, "node1:4000");
+        });
+    }
+
+    /// An empty tuple () must raise a clear ValueError, not an opaque
+    /// IndexError from get_item(0).
+    #[test]
+    fn empty_tuple_raises_value_error() {
+        Python::initialize();
+        Python::attach(|py| {
+            let tuple = PyTuple::empty(py).into_any();
+            let config = config_with_hosts(py, &[tuple]);
+            let err = parse_hosts_from_config(&config).expect_err("empty tuple must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            assert!(err.to_string().contains("empty tuple"));
+        });
+    }
+
+    /// An empty hosts list must raise the existing ValueError.
+    #[test]
+    fn empty_hosts_list_raises_value_error() {
+        Python::initialize();
+        Python::attach(|py| {
+            let config = config_with_hosts(py, &[]);
+            let err =
+                parse_hosts_from_config(&config).expect_err("empty hosts list must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+            assert!(err.to_string().contains("must not be empty"));
+        });
+    }
+
+    /// A bare IPv6 literal must NOT be mis-split: first_address is the whole
+    /// literal and first_port is DEFAULT_PORT. The connection string is left
+    /// verbatim for the core parser to handle.
+    #[test]
+    fn ipv6_literal_is_not_mis_split() {
+        Python::initialize();
+        Python::attach(|py| {
+            let host = "fe80::1".into_bound_py_any(py).unwrap();
+            let config = config_with_hosts(py, &[host]);
+            let parsed = parse_hosts_from_config(&config).expect("IPv6 literal must parse");
+            assert_eq!(parsed.first_address, "fe80::1");
+            assert_eq!(parsed.first_port, DEFAULT_PORT);
+            assert_eq!(parsed.connection_string, "fe80::1");
+        });
+    }
+
+    /// A non-string, non-tuple host entry must raise a TypeError.
+    #[test]
+    fn invalid_host_type_raises_type_error() {
+        Python::initialize();
+        Python::attach(|py| {
+            let host = 12345i64.into_bound_py_any(py).unwrap();
+            let config = config_with_hosts(py, &[host]);
+            let err = parse_hosts_from_config(&config).expect_err("int host must be rejected");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Hardens `rust/src/types/host.rs` — the one client-facing input path (`parse_hosts_from_config`) that previously had **zero unit tests**. Adds an in-module `#[cfg(test)] mod tests` (9 cases) and fixes four input-parsing issues with zero intended regression. The parsed result feeds `ConnectionInfo` / OpenTelemetry span attributes (`server_address`, `server_port`) in both `client.rs` and `async_client.rs`.

## Issues fixed

**Issue 4 — `DEFAULT_PORT` constant (refactor).** Extracted `const DEFAULT_PORT: u16 = 3000;` and used it at all three sites that previously hardcoded `3000` (initial `first_port`, tuple no-port fallback, string no-colon fallback). Pure refactor.

**Issue 2 — empty host tuple `()`.** Previously hit `get_item(0)?` → opaque `IndexError`. Now the tuple branch checks `tuple.is_empty()` first and raises a clear `ValueError`: `"Host tuple must contain at least a host address, got an empty tuple"`, matching the file's existing `PyValueError::new_err` style.

**Issue 3 — IPv6 literal telemetry corruption.** A bare IPv6 string like `"fe80::1"` was mis-split by `rsplit_once(':')` into `first_address="fe80:"`, `first_port=1`, corrupting span attributes. Fixed conservatively: only split host:port when the string contains **exactly one** `':'`; with multiple `':'` (bare IPv6) the whole string is treated as the address with `DEFAULT_PORT`. The common `host:port` case is unchanged.

**Issue 1 — bare-hostname connection-string consistency. PATH TAKEN: the safe normalization path (push `host:DEFAULT_PORT`).**

I verified the downstream core before changing the pushed connection string. The string is passed to `aerospike_core::ToHosts` (`aerospike-core 2.0.0`). Its `impl ToHosts for String` constructs `Parser::new(self, 3000)`, and the core's own unit tests assert:

```rust
assert_eq!(vec![Host::new("foo", 3000)], String::from("foo").to_hosts().unwrap()); // bare
assert_eq!(vec![Host::new("foo", 1234)], "foo:1234".to_hosts().unwrap());          // explicit
```

So a bare `"node1"` and `"node1:3000"` are parsed **identically** by the core (default port 3000 applied), confirmed by the core's regex parser (`net/parser.rs`) using `default_port` when no `:port` capture is present. Because equivalence is confirmed, the string branch now pushes `format!("{addr}:{DEFAULT_PORT}")` for the portless case and sets `first_port = DEFAULT_PORT`, making the string form consistent with the tuple form (which already pushed `host:3000`). IPv6 literals (multiple `:`) are still pushed verbatim so the core parser handles them.

## Tests added (in-module, mirroring `key.rs` / `bin.rs` style)

- `bare_string_host_uses_default_port` — `"node1"` → addr `node1`, port `DEFAULT_PORT`, connection string `node1:3000`
- `string_host_with_explicit_port` — `"node1:4000"` → port 4000
- `single_element_tuple_uses_default_port` — `("node1",)` regression → port `DEFAULT_PORT`
- `host_port_tuple_is_honored` — `("node1", 4000)` regression → port 4000
- `empty_tuple_raises_value_error` — `()` → `ValueError` ("empty tuple")
- `empty_hosts_list_raises_value_error` — `[]` → existing `ValueError`
- `ipv6_literal_is_not_mis_split` — `"fe80::1"` → addr `fe80::1`, port `DEFAULT_PORT`, string verbatim
- `invalid_host_type_raises_type_error` — int host → `TypeError`
- `default_port_constant_is_3000`

(Also added `#[derive(Debug)]` to `ParsedHosts` so `expect_err` works in tests; no behavior change.)

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --lib` — **257 passed, 0 failed** (9 new host tests included)

A full maturin Python build was not required; the Rust unit tests cover the host-parsing path.