### PR TITLE
fix(exp): reject malformed cond/let operand counts client-side

### DIFF
--- a/rust/src/expressions.rs
+++ b/rust/src/expressions.rs
@@ -169,11 +169,40 @@ fn convert_binary_comparison(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Exp
 /// unary (`convert_unary_op`) and binary-pair (`convert_binary_pair_op`)
 /// operations — using the more specific `InvalidArgError` for this
 /// argument-validation failure (those siblings raise a plain `ValueError`).
+///
+/// `cond` and `let` additionally carry a structural operand shape (an odd
+/// `cond` chain of `(condition, action)` pairs plus a default; a `let` body of
+/// definitions plus a scope expression) that is likewise validated here.
 fn convert_variadic_op(op: &str, dict: &Bound<'_, PyDict>) -> PyResult<Expression> {
     let exprs = parse_sub_expr_list(dict, "exprs")?;
     if exprs.is_empty() {
         return Err(crate::errors::InvalidArgError::new_err(format!(
             "Expression '{op}' requires at least one operand, got an empty 'exprs' list"
+        )));
+    }
+    // `cond` and `let` are not simple "one or more operands" ops: they carry a
+    // structural shape that the underlying `aerospike-core` builder does not
+    // validate, so a malformed operand count is only rejected later by the
+    // server with an opaque parse error far from the call site.
+    //
+    // `cond(bool1, action1, ..., default)` requires pairs of (condition,
+    // action) followed by a single default action — i.e. an odd count of at
+    // least 3. An even count leaves a dangling condition with no action; a
+    // count of 1 is a bare default with no condition.
+    if op == "cond" && (exprs.len() < 3 || exprs.len() % 2 == 0) {
+        return Err(crate::errors::InvalidArgError::new_err(format!(
+            "Expression 'cond' requires an odd number of operands (>= 3): pairs of \
+             (condition, action) followed by a default action, got {} operand(s)",
+            exprs.len()
+        )));
+    }
+    // `let(def1, def2, ..., scope_expr)` requires at least one variable
+    // definition followed by a scope expression — i.e. at least 2 operands.
+    if op == "let" && exprs.len() < 2 {
+        return Err(crate::errors::InvalidArgError::new_err(format!(
+            "Expression 'let' requires at least 2 operands: one or more variable \
+             definitions followed by a scope expression, got {} operand(s)",
+            exprs.len()
         )));
     }
     match op {
@@ -409,6 +438,76 @@ mod tests {
                 vec![int_val_dict(py, 1), int_val_dict(py, 2)],
             );
             py_to_expression(dict.as_any()).expect("non-empty num_add should convert");
+        });
+    }
+
+    /// `cond` requires an odd number of operands (>= 3): pairs of
+    /// `(condition, action)` followed by a default action. A count of 1, or any
+    /// even count, is structurally malformed and must be rejected client-side.
+    #[test]
+    fn cond_rejects_non_odd_or_too_few_operands() {
+        Python::initialize();
+        Python::attach(|py| {
+            // 1 operand (bare default, no condition) and 2/4 operands (dangling
+            // condition with no action) are all invalid.
+            for n in [1usize, 2, 4] {
+                let operands: Vec<_> = (0..n).map(|i| int_val_dict(py, i as i64)).collect();
+                let dict = variadic_dict(py, "cond", operands);
+                let err = py_to_expression(dict.as_any())
+                    .expect_err(&format!("cond with {n} operand(s) must be rejected"));
+                assert!(
+                    err.is_instance_of::<crate::errors::InvalidArgError>(py),
+                    "cond with {n} operand(s) must raise InvalidArgError, got {err:?}"
+                );
+                assert!(
+                    err.to_string().contains("odd number of operands"),
+                    "cond arity error must mention the odd-count requirement: {err:?}"
+                );
+            }
+        });
+    }
+
+    /// A well-formed `cond` (odd count >= 3) still converts successfully.
+    #[test]
+    fn cond_accepts_odd_operand_count() {
+        Python::initialize();
+        Python::attach(|py| {
+            for n in [3usize, 5] {
+                let operands: Vec<_> = (0..n).map(|i| int_val_dict(py, i as i64)).collect();
+                let dict = variadic_dict(py, "cond", operands);
+                py_to_expression(dict.as_any())
+                    .unwrap_or_else(|e| panic!("cond with {n} operands should convert: {e:?}"));
+            }
+        });
+    }
+
+    /// `let` requires at least 2 operands: one or more variable definitions
+    /// followed by a scope expression. A single operand is malformed.
+    #[test]
+    fn let_rejects_single_operand() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = variadic_dict(py, "let", vec![int_val_dict(py, 1)]);
+            let err = py_to_expression(dict.as_any())
+                .expect_err("let with a single operand must be rejected");
+            assert!(
+                err.is_instance_of::<crate::errors::InvalidArgError>(py),
+                "single-operand let must raise InvalidArgError, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains("at least 2 operands"),
+                "let arity error must mention the 2-operand requirement: {err:?}"
+            );
+        });
+    }
+
+    /// A well-formed `let` (>= 2 operands) still converts successfully.
+    #[test]
+    fn let_accepts_two_or_more_operands() {
+        Python::initialize();
+        Python::attach(|py| {
+            let dict = variadic_dict(py, "let", vec![int_val_dict(py, 1), int_val_dict(py, 2)]);
+            py_to_expression(dict.as_any()).expect("two-operand let should convert");
         });
     }
 

--- a/src/aerospike_py/exp.py
+++ b/src/aerospike_py/exp.py
@@ -558,7 +558,13 @@ def geo_compare(left: Expr, right: Expr) -> Expr:
 
 
 def cond(*exprs: Expr) -> Expr:
-    """Create conditional expression: cond(bool1, action1, bool2, action2, ..., default)."""
+    """Create conditional expression: cond(bool1, action1, bool2, action2, ..., default).
+
+    Pass one or more ``(condition, action)`` pairs followed by a single default
+    action — i.e. an **odd** number of arguments, at least 3. An even count
+    (a dangling condition with no action) or a lone default is rejected with
+    ``InvalidArgError`` when the expression is built.
+    """
     return _cmd("cond", exprs=list(exprs))
 
 
@@ -573,5 +579,11 @@ def def_(name: str, value: Expr) -> Expr:
 
 
 def let_(*exprs: Expr) -> Expr:
-    """Create let binding expression: let_(def_("x", ...), def_("y", ...), scope_expr)."""
+    """Create let binding expression: let_(def_("x", ...), def_("y", ...), scope_expr).
+
+    Pass one or more ``def_(...)`` variable definitions followed by a scope
+    expression — i.e. at least 2 arguments. A lone definition (or a lone scope
+    expression) is rejected with ``InvalidArgError`` when the expression is
+    built.
+    """
     return _cmd("let", exprs=list(exprs))


### PR DESCRIPTION
## Problem

The variadic empty-operand guard added in #393 closed the zero-argument case for every op routed through `convert_variadic_op` (`and`/`or`/`xor`, `num_*`, `min`/`max`, `int_*`, `cond`, `let`). But `cond` and `let` carry a *structural* operand shape that the empty-list check does not cover, and that the underlying `aerospike-core` builders do not validate:

- **`cond(bool1, action1, ..., default)`** requires pairs of `(condition, action)` followed by a single default action — an **odd** count of at least 3. An even count leaves a dangling condition with no action; a count of 1 is a bare default with no condition.
- **`let(def1, ..., scope_expr)`** requires at least one variable definition followed by a scope expression — at least **2** operands.

A non-empty but structurally invalid count slipped past the existing guard and was forwarded to the server, e.g.:

```python
from aerospike_py import exp
# even arg count → dangling condition with no action
expr = exp.cond(exp.eq(exp.int_bin("t"), exp.int_val(0)), exp.string_val("a"))
# single operand → a def with no scope expression
expr = exp.let_(exp.def_("x", exp.int_bin("count")))
```

## Root cause

`convert_variadic_op` (`rust/src/expressions.rs`) only rejected an empty `exprs` list, then passed any non-empty list straight to `expressions::cond` / `expressions::exp_let`. Those `aerospike-core` 2.0 builders wrap the operand vector without checking its shape, so the malformed expression was only rejected later by the server with an opaque parse error — far from the call site where the mistake was made. This is the exact failure mode #393 (empty operand list) and #396 (empty bin names) were designed to prevent, just one layer deeper.

## Fix

Add two arity guards in `convert_variadic_op`, immediately after the existing empty-list check, raising `InvalidArgError` with a precise, actionable message:

- `cond`: reject when `len < 3` or `len` is even.
- `let`: reject when `len < 2`.

This mirrors the style and exception type (`InvalidArgError`) of the sibling guards already in this function. The `exp.cond` / `exp.let_` builder docstrings are updated to document the requirement, matching how `predicates.equals` / `predicates.contains` document their validation.

No public API change, no version edits, no behavior change for well-formed expressions.

## How verified

All commands run locally on macOS arm64 (CPython 3.13, Rust 1.93):

| Gate | Command | Result |
|------|---------|--------|
| Rust format | `cargo fmt --all -- --check` | pass |
| Rust clippy | `cargo clippy --features otel --all-targets -- -D warnings` | pass (0 warnings) |
| Rust tests | `cargo test --features otel` | **261 passed**, 0 failed (incl. 4 new: `cond_rejects_non_odd_or_too_few_operands`, `cond_accepts_odd_operand_count`, `let_rejects_single_operand`, `let_accepts_two_or_more_operands`) |
| Ruff lint | `ruff check src/ tests/ benchmark/ examples/` | pass |
| Ruff format | `ruff format --check src/ tests/ benchmark/ examples/` | pass (160 files) |
| Pyright | `pyright src/aerospike_py` | 0 errors, 0 warnings |
| Python unit | `pytest tests/unit/` | **957 passed**, 8 skipped (server-dependent), 0 failed |

## Risk / scope

Low. 2 files, +113 lines. Pure input-validation hardening: it only rejects operand counts that were already structurally invalid and would have failed server-side. Well-formed `cond`/`let` expressions (covered by existing `test_cond` / `test_let_and_var` and the new accept-case Rust tests) are unaffected. The validation lives in the internal `py_to_expression` conversion path (not exposed directly to Python), so it triggers only when an expression is actually submitted via a policy/query — consistent with #393's coverage layer.