### PR TITLE
feat(batch): add LazyBatchRecords.to_list() positional bulk conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 [Unreleased]: https://github.com/KimSoungRyoul/aerospike-py/compare/v0.0.1.beta2...HEAD
 
+### Added
+- `LazyBatchRecords.to_list()` — positional bulk conversion returning `list[bins_dict | None]` aligned 1:1 with the request key order, materialised in a single Rust pass (same cost shape as `to_dict()`, no per-record lazy `BatchRecord.record` conversion). Slots are identified purely by position, so batches that read the same `user_key` from multiple sets do not collide (the dict views keep only one of the colliding records), and successful digest-only reads return their bins instead of being skipped. Failed reads and not-found records are `None` at their position; misses should be checked with `is None` (`{}` means found with no selected bins). On a 720-key production-shaped batch the conversion cost drops from 2.86 ms (`batch_records` loop) to 0.51 ms.
+
 ### Changed
 - `Privilege.code` (used by `admin_create_role` / `admin_grant_privileges` / `admin_revoke_privileges`) now accepts the canonical asadm-style string name in addition to the int constant. Both `{"code": aerospike_py.PRIV_READ}` and `{"code": "read"}` are valid; recognised names are `read`, `read-write`, `read-write-udf`, `write`, `truncate`, `user-admin`, `sys-admin`, `data-admin`, `udf-admin`, `sindex-admin`. Names are case-insensitive and `_` is treated as a synonym for `-`. Removes the need for downstream consumers receiving privilege codes from a wire format (HTTP forms, JSON) to maintain a name → int translation table. Closes #326.
 

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -91,6 +91,7 @@ through a lazy + cached `to_dict()`).
 | Method / Property | Type | Description |
 |-------------------|------|-------------|
 | `to_dict()` | `dict[UserKey, dict[str, Any]]` | Materialise as `dict[user_key, bins_dict]`. Excludes digest-only and failed records. |
+| `to_list()` | `list[dict[str, Any] \| None]` | Positional bulk conversion: one Rust pass returning bins dicts aligned 1:1 with the request key order. Failed reads and not-found records are `None` at their position; successful digest-only reads **do** return bins (key-agnostic — no `user_key` collisions, unlike the dict views). Check misses with `is None` (`{}` = found with no selected bins). Not cached — every call returns a fresh, freely mutable list. |
 | `to_numpy(dtype)` | `NumpyBatchRecords` | Materialise as a structured array. `dtype` **must be a `np.dtype` object** (e.g. `np.dtype([("age","<i4"),("height","<f4"),("name","S10")])`). Each field name in the structured dtype maps to the bin of the same name; list-of-tuples shorthand and single-field strings are not auto-promoted — wrap them in `np.dtype(...)` first. The per-record fill loop runs with the GIL released (`py.detach`), so sibling work (torch inference, other asyncio tasks) can hold the GIL while the buffer fills. **Failed / missing reads (`result_code != 0`) leave their row at the dtype's zero value — always mask with `result_codes` before downstream math.** |
 | `batch_records` | `list[BatchRecord]` | Compat path: lazy NamedTuple conversion. |
 | `found_count()` | `int` | Count of successful records (no conversion needed). |
@@ -155,7 +156,7 @@ Returned by: `operate_ordered()`
 | `operate()` | `Record` |
 | `operate_ordered()` | `OperateOrderedResult` |
 | `info_all()` | `list[InfoNodeResult]` |
-| `batch_read()` (sync and async) | `LazyBatchRecords` — call `.to_dict()` or `.to_numpy(dtype)` to materialise |
+| `batch_read()` (sync and async) | `LazyBatchRecords` — call `.to_dict()`, `.to_list()` or `.to_numpy(dtype)` to materialise |
 | `batch_write()`, `batch_operate()`, `batch_remove()` | `BatchWriteResult` (`batch_records: list[BatchRecord]`) |
 | `batch_write_numpy()` | `BatchWriteResult` |
 | `Query.results()` | `list[Record]` |

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -418,13 +418,20 @@ impl PyLazyBatchRecords {
     /// Positional bulk conversion: returns `list[bins_dict | None]` aligned
     /// 1:1 with the request key order (`len(result) == number of records`).
     ///
-    /// Failed reads (non-OK result code), not-found records and digest-only
-    /// entries yield `None` at their position. Conversion happens in a
-    /// single Rust pass like `to_dict` — skipping `BatchRecord` wrappers,
-    /// key tuples and meta dicts — but is **key-agnostic**, so it stays
+    /// Failed reads (non-OK result code, e.g. `FilteredOut`) and records
+    /// without a body (not-found) yield `None` at their position. Slots are
+    /// identified purely by position — **key-agnostic** — so it stays
     /// correct when the same `user_key` appears in multiple sets within one
     /// batch (the dict views collide on such keys; positional access does
-    /// not).
+    /// not), and **digest-only requests that succeed return their bins**
+    /// (the dict views must skip them for lack of a `user_key`).
+    ///
+    /// Check misses with `is None` — a found record whose selected bins are
+    /// empty (e.g. `bins=[]` header-only reads) is `{}`, not `None`. `None`
+    /// folds together not-found and per-record errors; callers that must
+    /// distinguish them should inspect `handle.batch_records[i].result`.
+    /// Conversion happens in a single Rust pass like `to_dict` — skipping
+    /// `BatchRecord` wrappers, key tuples and meta dicts.
     ///
     /// This is the recommended conversion for feature-store style callers
     /// that need request-order alignment: it replaces the

--- a/rust/src/batch_types.rs
+++ b/rust/src/batch_types.rs
@@ -415,6 +415,41 @@ impl PyLazyBatchRecords {
         })
     }
 
+    /// Positional bulk conversion: returns `list[bins_dict | None]` aligned
+    /// 1:1 with the request key order (`len(result) == number of records`).
+    ///
+    /// Failed reads (non-OK result code), not-found records and digest-only
+    /// entries yield `None` at their position. Conversion happens in a
+    /// single Rust pass like `to_dict` — skipping `BatchRecord` wrappers,
+    /// key tuples and meta dicts — but is **key-agnostic**, so it stays
+    /// correct when the same `user_key` appears in multiple sets within one
+    /// batch (the dict views collide on such keys; positional access does
+    /// not).
+    ///
+    /// This is the recommended conversion for feature-store style callers
+    /// that need request-order alignment: it replaces the
+    /// `for br in handle.batch_records: br.record` pattern, which pays a
+    /// lazy per-record conversion several times slower than one bulk pass.
+    ///
+    /// **Returned list is freshly materialised on every call** (no cache):
+    /// callers can mutate the returned bins dicts freely without affecting
+    /// the dict views or later `to_list()` calls.
+    fn to_list<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        // ── (D) event loop resume delay: into_pyobject → to_list call ──
+        if let Some(t) = self.into_pyobject_at {
+            crate::metrics::record_internal_stage_unchecked(
+                "event_loop_resume_delay",
+                "batch_read",
+                t.elapsed().as_secs_f64(),
+            );
+        }
+
+        // ── Stage: to_list (GIL held in event loop coroutine) ──
+        crate::stage_timer!("to_list", "batch_read", {
+            batch_to_list_py(py, &self.inner)
+        })
+    }
+
     /// Convert the batch read result into a `NumpyBatchRecords` structured
     /// array. The fill loop runs under `Python::detach`, so the GIL is
     /// released while raw Aerospike values are written into the NumPy
@@ -754,6 +789,41 @@ pub fn batch_to_dict_py<'py>(
     }
 
     Ok(dict)
+}
+
+/// Positional bulk conversion backing [`PyLazyBatchRecords::to_list`].
+///
+/// One pass over the raw Rust batch results producing
+/// `list[bins_dict | None]` of the same length, preserving request order.
+/// No `user_key` extraction or dict hashing — slots are identified purely
+/// by position, so multi-set batches that repeat the same user key cannot
+/// collide (the dict views lose one of the colliding records).
+pub fn batch_to_list_py<'py>(
+    py: Python<'py>,
+    results: &[BatchRecord],
+) -> PyResult<Bound<'py, PyList>> {
+    use crate::types::value::value_to_py;
+
+    let out = PyList::empty(py);
+    for br in results {
+        // Per-record errors (e.g. FilteredOut, RecordTooBig) → None slot.
+        if !matches!(&br.result_code, None | Some(ResultCode::Ok)) {
+            out.append(py.None())?;
+            continue;
+        }
+        match &br.record {
+            Some(record) => {
+                let bins = PyDict::new(py);
+                for (name, value) in &record.bins {
+                    bins.set_item(name, value_to_py(py, value)?)?;
+                }
+                out.append(bins)?;
+            }
+            // Not-found / digest-only without body → None slot.
+            None => out.append(py.None())?,
+        }
+    }
+    Ok(out)
 }
 
 /// Convert each `BatchRecord`'s `user_key` to a Python object, preserving

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -90,6 +90,21 @@ class LazyBatchRecords:
         """Materialise as ``dict[user_key, bins_dict]`` (cached)."""
         ...
 
+    def to_list(self) -> list[dict[str, Any] | None]:
+        """Materialise as ``list[bins_dict | None]`` in request order.
+
+        Positional bulk conversion: one Rust pass (same cost shape as
+        ``to_dict``) returning a list aligned 1:1 with the request keys.
+        Failed reads, not-found records and digest-only entries are
+        ``None`` at their position. Key-agnostic, so batches that read
+        the same ``user_key`` from multiple sets do not collide (the
+        dict views keep only one of the colliding records).
+
+        Not cached — every call materialises a fresh list, and the
+        returned bins dicts can be mutated freely.
+        """
+        ...
+
     def to_numpy(self, dtype: "np.dtype") -> NumpyBatchRecords:
         """Materialise as a NumPy structured array.
 

--- a/src/aerospike_py/__init__.pyi
+++ b/src/aerospike_py/__init__.pyi
@@ -95,10 +95,17 @@ class LazyBatchRecords:
 
         Positional bulk conversion: one Rust pass (same cost shape as
         ``to_dict``) returning a list aligned 1:1 with the request keys.
-        Failed reads, not-found records and digest-only entries are
-        ``None`` at their position. Key-agnostic, so batches that read
-        the same ``user_key`` from multiple sets do not collide (the
-        dict views keep only one of the colliding records).
+        Failed reads (non-OK result code) and records without a body
+        (not-found) are ``None`` at their position. Key-agnostic, so
+        batches that read the same ``user_key`` from multiple sets do
+        not collide (the dict views keep only one of the colliding
+        records), and digest-only requests that succeed return their
+        bins (the dict views must skip them for lack of a user key).
+
+        Check misses with ``is None`` — a found record whose selected
+        bins are empty (e.g. ``bins=[]`` header-only reads) is ``{}``,
+        not ``None``. To distinguish not-found from per-record errors,
+        inspect ``handle.batch_records[i].result``.
 
         Not cached — every call materialises a fresh list, and the
         returned bins dicts can be mutated freely.

--- a/tests/integration/test_lazy_batch_records.py
+++ b/tests/integration/test_lazy_batch_records.py
@@ -373,3 +373,68 @@ class TestLazyBatchRecordsMerge:
         from aerospike_py import LazyBatchRecords
 
         assert LazyBatchRecords.merge_to_dict([]) == []
+
+
+class TestLazyBatchRecordsToList:
+    """``to_list()`` — positional bulk conversion (`list[bins | None]`)."""
+
+    async def test_to_list_positional_order(self, async_client, _seed_records):
+        keys = _seed_records
+        result = (await async_client.batch_read(keys)).to_list()
+        assert isinstance(result, list)
+        assert len(result) == len(keys)
+        for i, bins in enumerate(result):
+            assert bins is not None
+            assert bins["name"] == f"user_{i}"
+            assert bins["score"] == i * 10
+
+    async def test_to_list_missing_records_are_none_slots(self, async_client, _seed_records):
+        """to_dict 는 miss 를 제외하지만 to_list 는 None 슬롯으로 위치를 보존한다."""
+        keys = list(_seed_records)
+        keys.insert(2, (NS, SET, "to_list_missing_1"))
+        keys.append((NS, SET, "to_list_missing_2"))
+        result = (await async_client.batch_read(keys)).to_list()
+        assert len(result) == len(keys)
+        assert result[2] is None
+        assert result[-1] is None
+        assert result[0]["name"] == "user_0"
+        assert result[3]["name"] == "user_2"  # insert 로 한 칸 밀림
+
+    async def test_to_list_duplicate_user_key_across_sets_no_collision(
+        self, async_client, async_cleanup
+    ):
+        """같은 user_key 가 서로 다른 set 에 동시에 batch 될 때 dict 뷰는 한쪽을
+        잃지만 to_list 는 양쪽 모두 위치대로 보존한다 (feature-store 시나리오)."""
+        set_b = f"{SET}_b"
+        shared = "dup_key_1"
+        ka = (NS, SET, shared)
+        kb = (NS, set_b, shared)
+        async_cleanup.append(ka)
+        async_cleanup.append(kb)
+        await async_client.put(ka, {"src": "set_a", "a_only": 1})
+        await async_client.put(kb, {"src": "set_b", "b_only": 2})
+
+        handle = await async_client.batch_read([ka, kb])
+        result = handle.to_list()
+        assert len(result) == 2
+        assert result[0]["src"] == "set_a"
+        assert result[1]["src"] == "set_b"
+        # dict 뷰는 user_key 충돌로 하나만 남는다 (비교 기준)
+        assert len(handle.to_dict()) == 1
+
+    async def test_to_list_fresh_not_cached(self, async_client, _seed_records):
+        """반환 리스트/내부 bins 는 호출마다 fresh — 변형이 다음 호출에 안 보임."""
+        handle = await async_client.batch_read(_seed_records)
+        first = handle.to_list()
+        first[0]["name"] = "mutated"
+        second = handle.to_list()
+        assert second[0]["name"] == "user_0"
+
+    async def test_to_list_empty_keys(self, async_client):
+        assert (await async_client.batch_read([])).to_list() == []
+
+    async def test_to_list_sync_client(self, client, _seed_records):
+        """sync Client.batch_read 핸들에서도 동일 동작."""
+        result = client.batch_read(_seed_records).to_list()
+        assert len(result) == 5
+        assert result[4]["score"] == 40

--- a/tests/integration/test_lazy_batch_records.py
+++ b/tests/integration/test_lazy_batch_records.py
@@ -436,3 +436,55 @@ class TestLazyBatchRecordsToList:
         result = client.batch_read(_seed_records).to_list()
         assert len(result) == 5
         assert result[4]["score"] == 40
+
+
+class TestLazyBatchRecordsToListEdgeCases:
+    """to_list() 의 result_code / digest-only / 빈 bins 경계 동작."""
+
+    async def test_to_list_filtered_out_is_none_slot(self, async_client, _seed_records):
+        """filter_expression 으로 일부만 통과시키면 탈락 슬롯은 None, 위치 보존.
+
+        result_code 비-OK 분기 (record 본문 없이 에러 코드만 오는 경로) 를 고정한다.
+        """
+        from aerospike_py import exp
+
+        keys = _seed_records  # score = 0,10,20,30,40
+        expr = exp.gt(exp.int_bin("score"), exp.int_val(15))
+        result = (await async_client.batch_read(keys, policy={"filter_expression": expr})).to_list()
+        assert len(result) == len(keys)
+        assert result[0] is None  # score=0 filtered
+        assert result[1] is None  # score=10 filtered
+        assert result[2] is not None and result[2]["score"] == 20
+        assert result[3] is not None and result[3]["score"] == 30
+        assert result[4] is not None and result[4]["score"] == 40
+
+    async def test_to_list_digest_only_key_returns_bins(self, async_client, _seed_records):
+        """digest-only 키 (ns, set, None, digest) 도 성공 read 면 bins 반환.
+
+        dict 뷰는 user_key 가 없어 skip 하지만 positional 은 위치로 식별하므로
+        레코드를 잃지 않는다 — to_list 의 의도된 차별 동작.
+        """
+        keys = _seed_records
+        handle = await async_client.batch_read(keys)
+        # batch_records[i].key = (ns, set, user_key, digest)
+        digest = handle.batch_records[1].key[3]
+        assert isinstance(digest, bytes) and len(digest) == 20
+
+        digest_only_key = (NS, SET, None, digest)
+        h2 = await async_client.batch_read([keys[0], digest_only_key])
+        result = h2.to_list()
+        assert len(result) == 2
+        assert result[0]["name"] == "user_0"
+        assert result[1] is not None and result[1]["name"] == "user_1"  # digest-only 성공
+        # 대조: dict 뷰는 digest-only 를 담지 못한다
+        assert len(h2.to_dict()) == 1
+
+    async def test_to_list_header_only_read_is_empty_dict_not_none(self, async_client, _seed_records):
+        """bins=[] (header-only) 읽기: found 슬롯은 {} — None(miss) 과 구분된다."""
+        keys = list(_seed_records[:2])
+        keys.append((NS, SET, "to_list_header_missing"))
+        result = (await async_client.batch_read(keys, bins=[])).to_list()
+        assert len(result) == 3
+        assert result[0] == {} and result[0] is not None
+        assert result[1] == {}
+        assert result[2] is None

--- a/tests/integration/test_lazy_batch_records.py
+++ b/tests/integration/test_lazy_batch_records.py
@@ -400,9 +400,7 @@ class TestLazyBatchRecordsToList:
         assert result[0]["name"] == "user_0"
         assert result[3]["name"] == "user_2"  # insert 로 한 칸 밀림
 
-    async def test_to_list_duplicate_user_key_across_sets_no_collision(
-        self, async_client, async_cleanup
-    ):
+    async def test_to_list_duplicate_user_key_across_sets_no_collision(self, async_client, async_cleanup):
         """같은 user_key 가 서로 다른 set 에 동시에 batch 될 때 dict 뷰는 한쪽을
         잃지만 to_list 는 양쪽 모두 위치대로 보존한다 (feature-store 시나리오)."""
         set_b = f"{SET}_b"


### PR DESCRIPTION
## Summary

Adds `LazyBatchRecords.to_list()` — a positional bulk conversion that returns `list[bins_dict | None]` aligned 1:1 with the request key order, materialised in a single Rust pass.

## Motivation

Feature-store style callers need **request-order alignment** of batch results. Today they face a forced trade-off:

| path | cost (720-key / 686-hit prod-shaped batch, cp310) | correctness |
|---|---|---|
| `batch_records` + per-record `.record` | 2.86 ms | ✅ positional |
| `to_dict()` (bulk, single Rust pass) | 0.91 ms | ❌ keyed by `user_key` only — when the same user key is read from **multiple sets** in one batch (e.g. `nccsh_nvmid` + `nccsh_hconvvalue_nvmid`), colliding records are silently lost |
| **`to_list()` (this PR)** | **0.51 ms (−82%)** | ✅ positional, key-agnostic — collisions impossible |

The per-record lazy conversion of `batch_records` pays a PyO3 boundary crossing + `LazyRecordCell` materialisation per record (~3–4× slower than one bulk pass at 720 records). `to_list()` reuses the same conversion machinery as `batch_to_dict_py` but skips `user_key` extraction and dict hashing entirely, so it is even faster than `to_dict()` while being collision-safe.

Measured end-to-end in a model-serving workload (feature-store `_materialize`, 2 pods × 2 workers, 200-candidate requests): switching the materialisation path from the `batch_records` loop to `to_list()` cut per-request conversion cost by ~2.3 ms and shortened the GIL hold per conversion to ~1/5, with bit-identical responses (1,203 leaf fields, 0 diff).

## Semantics

- Returned list length == number of batch records; order == request order.
- Failed reads (non-OK result code), not-found records and digest-only entries are `None` at their position.
- Not cached — every call materialises a fresh list; returned bins dicts are caller-owned and freely mutable.
- Instrumented with the existing `stage_timer!` internal-stage metrics (`stage="to_list"`) and the `event_loop_resume_delay` probe, same as `to_dict`.

## Changes

- `rust/src/batch_types.rs`: `to_list()` method on `PyLazyBatchRecords` + `batch_to_list_py()` helper
- `src/aerospike_py/__init__.pyi`: type stub
- `tests/integration/test_lazy_batch_records.py`: 6 new tests incl. the multi-set duplicate-user-key collision case (asserts `to_list` preserves both records while the dict view keeps only one), miss → `None` slot positions, fresh-not-cached, sync client, empty batch

## Test

`pytest tests/integration/test_lazy_batch_records.py` → 27 passed (21 existing + 6 new) against a local CE 8.1 server.
