### PR TITLE
chore: housekeeping — profile.release, deprecation version, CI action pins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.13"
           enable-cache: true
@@ -172,7 +172,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -213,7 +213,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
@@ -268,7 +268,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.13"
           enable-cache: true
@@ -314,7 +314,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.13"
           enable-cache: true
@@ -376,7 +376,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
@@ -430,7 +430,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.13"
           enable-cache: true
@@ -504,7 +504,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           python-version: "3.13"
           enable-cache: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = ["rust"]
 resolver = "2"
 
+# IMPORTANT: this is the *only* release profile that cargo honours. Cargo
+# ignores `[profile.*]` declared in workspace *member* manifests, so all release
+# tuning for the `rust/` member MUST live here in the workspace root — including
+# the profiling knobs that previously lived (dead) in `rust/Cargo.toml`.
+#
 # `panic = "unwind"` lets us catch panics from aerospike-core in `read` paths
 # (notably `bytes_to_particle()` panicking on PYTHON_BLOB / JAVA_BLOB / etc. —
 # see issue #280). Switching from "abort" adds DWARF unwind tables to the
@@ -9,8 +14,19 @@ resolver = "2"
 # Linux x86_64). Hot-path runtime cost is negligible: LLVM uses `invoke`
 # instead of `call`, indistinguishable from `call` on modern CPUs unless a
 # panic actually propagates.
+#
+# `debug = 2` + `strip = "none"` + `split-debuginfo = "off"` keep full
+# line-number debug info in release builds so profilers (Tachyon `--native`) can
+# resolve Rust function names (record_to_py_inner / value_to_py / key_to_py)
+# instead of opaque <native>. Adds ~5% to wheel size; perf impact negligible.
+# These knobs were previously set in `rust/Cargo.toml` where cargo silently
+# ignored them, so the root's old `strip = "symbols"` won and stripped the very
+# symbols the profiling comment intended to keep — they now live here and take
+# effect.
 [profile.release]
 lto = "fat"
 codegen-units = 1
-strip = "symbols"
+debug = 2
+strip = "none"
+split-debuginfo = "off"
 panic = "unwind"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,10 +58,6 @@ otel = [
     "dep:opentelemetry-otlp",
 ]
 
-# Profiling: keep line-number debug info in release builds so Tachyon `--native`
-# can resolve Rust function names (record_to_py_inner / value_to_py / key_to_py
-# instead of opaque <native>). Adds ~5% to wheel size; perf impact negligible.
-[profile.release]
-debug = 2
-strip = "none"
-split-debuginfo = "off"
+# NOTE: no `[profile.*]` here. Cargo ignores profiles declared in workspace
+# *member* manifests — the release profile (LTO, panic=unwind, and the
+# debug-symbol / profiling knobs) lives in the workspace-root `Cargo.toml`.

--- a/src/aerospike_py/exception.py
+++ b/src/aerospike_py/exception.py
@@ -45,6 +45,11 @@ from aerospike_py._aerospike import (
     IndexError as _IndexError,  # deprecated alias for AerospikeIndexError
 )
 
+# Deprecated aliases scheduled for removal in v1.0.0 (the first major release).
+# They shadow the Python builtins ``TimeoutError`` / ``IndexError``, so they were
+# renamed to ``AerospikeTimeoutError`` / ``AerospikeIndexError``; the old names
+# remain accessible (with a DeprecationWarning) until v1.0.0.
+_ALIAS_REMOVAL_VERSION = "1.0.0"
 _DEPRECATED_ALIASES: dict[str, tuple[type, str]] = {
     "TimeoutError": (_TimeoutError, "AerospikeTimeoutError"),
     "IndexError": (_IndexError, "AerospikeIndexError"),
@@ -55,7 +60,8 @@ def __getattr__(name: str):
     if name in _DEPRECATED_ALIASES:
         cls, replacement = _DEPRECATED_ALIASES[name]
         warnings.warn(
-            f"aerospike_py.exception.{name} is deprecated, use {replacement} instead",
+            f"aerospike_py.exception.{name} is deprecated and will be removed in "
+            f"v{_ALIAS_REMOVAL_VERSION}; use {replacement} instead",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/aerospike_py/exception.pyi
+++ b/src/aerospike_py/exception.pyi
@@ -44,7 +44,7 @@ record-not-found, ``5`` for record-exists, ``22`` for forbidden), matching the
 client-side errors that never received a server response (connection failures,
 client timeouts, invalid arguments) expose the sentinel ``-1``.
 
-Deprecated aliases (emit ``DeprecationWarning`` on access):
+Deprecated aliases (emit ``DeprecationWarning`` on access; **removed in v1.0.0**):
     - ``TimeoutError`` -- use ``AerospikeTimeoutError`` instead.
     - ``IndexError`` -- use ``AerospikeIndexError`` instead.
 """
@@ -78,7 +78,8 @@ class AerospikeTimeoutError(AerospikeError):
 class TimeoutError(AerospikeTimeoutError):
     """Deprecated: use ``AerospikeTimeoutError`` instead.
 
-    Accessing this name emits a ``DeprecationWarning``.
+    Accessing this name emits a ``DeprecationWarning``. Scheduled for removal in
+    v1.0.0.
     """
 
 class BackpressureError(ClientError):
@@ -137,7 +138,8 @@ class AerospikeIndexError(ServerError):
 class IndexError(AerospikeIndexError):
     """Deprecated: use ``AerospikeIndexError`` instead.
 
-    Accessing this name emits a ``DeprecationWarning``.
+    Accessing this name emits a ``DeprecationWarning``. Scheduled for removal in
+    v1.0.0.
     """
 
 class IndexNotFound(AerospikeIndexError):


### PR DESCRIPTION
## Summary

Three small, independent housekeeping cleanups. No functional/API change.

### 1. Fix the dead workspace-member `[profile.release]`

`rust/Cargo.toml` (a workspace *member*) carried a `[profile.release]` block, but
**cargo ignores `[profile.*]` in member manifests** — every build emitted:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root
```

So the member's profiling knobs (`debug = 2`, `strip = "none"`,
`split-debuginfo = "off"`) were silently dead, and the workspace-root
`Cargo.toml`'s `strip = "symbols"` won — **stripping the very debug symbols the
member comment intended to keep** for profiling (Tachyon `--native` resolving
Rust function names instead of opaque `<native>`).

Fix: consolidated the intended knobs into the **root** `[profile.release]` and
removed the dead member block (replaced with a note explaining why no profile
lives there).

Verification — `cargo build --release --features otel` now reports
`[optimized + debuginfo]` (was `[optimized]`), and the release dylib retains
symbols:

```
$ nm target/release/lib_aerospike.dylib | grep -E 'value_to_py|result_code_to_int'
... __aerospike6errors18result_code_to_int
... __aerospike5types5value11value_to_py
```

Trade-off (already documented in the profile comment): keeping symbols adds ~5%
to wheel size — this is the behaviour the profiling comment always intended; it
just never took effect before.

### 2. Deprecated exception aliases name a concrete removal version

`aerospike_py.exception.TimeoutError` / `IndexError` (aliases that shadow the
Python builtins) emit a `DeprecationWarning`. The warning and the `.pyi`
docstrings now state they will be **removed in v1.0.0** (the first major), so
they don't linger indefinitely. They are **not** removed in this PR.

```
DeprecationWarning: aerospike_py.exception.IndexError is deprecated and will be
removed in v1.0.0; use AerospikeIndexError instead
```

### 3. CI action version alignment

- `astral-sh/setup-uv` **v8.1.0 → v8.3.2** (8 occurrences in `ci.yaml`) — matches
  the newest pin used elsewhere in the org (cluster-manager), within major v8.
- `actions/upload-artifact` (`v7.0.1`) and `actions/download-artifact` (`v8.0.1`)
  pins in `publish.yaml` are already internally consistent and within-major, so
  they are left unchanged (kept minimal, no surprises).

## Verification

- `cargo build --release --features otel` ✅ (`[optimized + debuginfo]`, symbols retained)
- `cargo test --features otel` ✅ (277 passed)
- `maturin develop` + `uv run pytest tests/unit` ✅ (957 passed, 8 skipped — server-dependent)
- `ruff check`/`format` + `pyright` ✅
- `actionlint .github/workflows/ci.yaml` ✅ (pre-existing shellcheck nits in an untouched workflow only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)