### PR TITLE
docs: rewrite guides in plain language

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="LICENSE"><img alt="Apache 2.0 license" src="https://img.shields.io/badge/license-Apache%202.0-647283?logo=apache&amp;logoColor=FFC72C&amp;labelColor=0B1F33"></a>
 </p>
 
-High-performance Aerospike Python Client built with PyO3 + Rust, powered by the [Aerospike Rust Client v2](https://github.com/aerospike/aerospike-client-rust).
+High-performance Python client for Aerospike, built with Rust and PyO3 on top of the [Aerospike Rust Client v2](https://github.com/aerospike/aerospike-client-rust).
 
 ## Features
 
-- Sync and Async (`AsyncClient`) API
-- CRUD, Batch, Query, UDF, Admin, Index, Truncate
-- CDT List/Map Operations, Expression Filters
-- NumPy v2 structured-array results for batch reads (skips Python-object overhead for analytical pipelines)
+- Sync and async (`AsyncClient`) APIs
+- CRUD, batch, query, UDF, admin, index, and truncate operations
+- List and map CDT operations and expression filters
+- NumPy v2 structured-array results for batch reads, without per-record Python objects in analytical pipelines
 - Full type stubs (`.pyi`) for IDE autocompletion
 
 > [Documentation](https://aerospike-ce-ecosystem.github.io/aerospike-py/) — API reference, usage guides, integration examples
@@ -135,11 +135,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, running tests, and
 
 ## Repository Automation
 
-This repo wires several automations that fire on commit, PR, push, and schedule. Knowing they exist helps you understand why a check ran (or refused to).
+This repository runs several automations on commits, pull requests, pushes, and schedules. The following sections explain when each check runs and why it may block an action.
 
 ### Pre-commit hooks — `.pre-commit-config.yaml`
 
-Run on every `git commit`. Install once with `make pre-commit-install`.
+These hooks run on every `git commit`. Install them once with `make pre-commit-install`.
 
 | Hook | Source | Purpose |
 |---|---|---|

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -6,11 +6,11 @@ description: Frequently asked questions about aerospike-py.
 
 ## Why is aerospike-py written in Rust?
 
-aerospike-py wraps the [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust) using [PyO3](https://pyo3.rs/) bindings, which gives several advantages over a pure-Python or C-extension approach:
+aerospike-py uses [PyO3](https://pyo3.rs/) to expose the [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust) to Python. This design offers several advantages over a pure-Python client or a C extension:
 
 - **Performance** -- Rust compiles to native code. Benchmarks show throughput on par with (or better than) the official C-based client, especially for batch and async workloads.
 - **Memory safety** -- Rust's ownership model eliminates whole classes of bugs (use-after-free, buffer overflows, data races) without a garbage collector.
-- **Native async** -- The underlying client is built on Tokio, a production-grade async runtime. This makes the `AsyncClient` a first-class citizen rather than an afterthought.
+- **Native async** -- The underlying client runs on Tokio. `AsyncClient` therefore uses native async I/O instead of wrapping synchronous calls.
 - **Zero Python dependencies** -- The base install (`pip install aerospike-py`) has no external Python dependencies. NumPy and OpenTelemetry are optional extras.
 
 ## How does GIL handling work?
@@ -22,7 +22,7 @@ aerospike-py releases the Python Global Interpreter Lock (GIL) during all databa
 | **Sync `Client`** | `py.detach()` releases the GIL, then `RUNTIME.block_on()` runs the async Rust operation on the internal Tokio runtime. The GIL is re-acquired when the result is returned. |
 | **Async `AsyncClient`** | `future_into_py()` returns a Python awaitable. The actual work runs on the Tokio runtime without holding the GIL. When the future completes, `Python::attach()` re-acquires the GIL to hand the result back. |
 
-In both cases, the GIL is **not held** while the request travels to the Aerospike cluster, which means Python threads (or other async tasks) are free to run concurrently.
+In both cases, the request travels to the Aerospike cluster without holding the GIL. Other Python threads or async tasks can run concurrently.
 
 ## Is aerospike-py thread-safe?
 
@@ -52,7 +52,7 @@ client.close()
 
 Yes. aerospike-py builds and runs on the experimental free-threaded CPython (PEP 703). CI runs unit tests **and** concurrency stress tests on Python 3.14t to verify correctness without the GIL.
 
-Because the core logic lives in Rust -- which has its own memory safety guarantees -- the library is inherently safe even when the GIL is removed entirely.
+The core logic runs in Rust and relies on Rust's memory-safety guarantees. It remains safe when Python removes the GIL entirely.
 
 ## Is NumPy required?
 
@@ -66,11 +66,11 @@ pip install aerospike-py
 pip install aerospike-py[numpy]
 ```
 
-When NumPy is installed, you gain access to `LazyBatchRecords.to_numpy(dtype)` (the `batch_read()` return value), which produces a `NumpyBatchRecords` backed by a NumPy structured array — the buffer fill runs with the GIL released, so the result hands straight to `torch.from_numpy(...)` zero-copy. `batch_write_numpy()` performs the inverse direction for bulk writes from structured arrays. All other functionality works identically without NumPy.
+With NumPy installed, call `LazyBatchRecords.to_numpy(dtype)` on the value returned by `batch_read()`. It produces `NumpyBatchRecords` backed by a NumPy structured array. The client fills the buffer with the GIL released, and you can pass the result directly to `torch.from_numpy(...)` without copying it. Use `batch_write_numpy()` for bulk writes from structured arrays. All other features work without NumPy.
 
 ## Can I migrate from the official C client?
 
-Yes. aerospike-py is designed as a near-drop-in replacement. The import alias pattern makes the transition straightforward:
+Yes. aerospike-py is designed as a near-drop-in replacement. Start by changing the import:
 
 ```python
 # Before
@@ -136,4 +136,4 @@ Open an issue on the GitHub repository:
 - **Bug reports:** [github.com/aerospike-ce-ecosystem/aerospike-py/issues/new](https://github.com/aerospike-ce-ecosystem/aerospike-py/issues/new)
 - **Feature requests:** Same link -- use the "Feature Request" template if available.
 
-Please include your Python version, OS, aerospike-py version (`aerospike_py.__version__`), and a minimal reproduction when reporting bugs.
+For a bug report, include your Python version, operating system, aerospike-py version (`aerospike_py.__version__`), and a minimal reproduction.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -16,10 +16,10 @@ pip install aerospike-py
 
 **Requirements:** Python 3.10+ (CPython)
 
-From a source checkout, start the local Aerospike CE container with
-`make run-aerospike-ce`; it listens on `127.0.0.1:18710`. If you start
-Aerospike manually on the default service port, use `3000` in the examples
-below instead.
+If you work from a source checkout, run `make run-aerospike-ce` to start the
+local Aerospike CE container on `127.0.0.1:18710`. If you start Aerospike
+manually on its default service port, replace `18710` with `3000` in the
+examples below.
 
 ## Quick Start
 

--- a/docs/docs/guides/admin/admin.md
+++ b/docs/docs/guides/admin/admin.md
@@ -6,7 +6,7 @@ slug: /guides/admin
 description: User and role management for security-enabled Aerospike clusters.
 ---
 
-Requires a security-enabled Aerospike server.
+These operations require an Aerospike server with security enabled.
 
 ## User Management
 

--- a/docs/docs/guides/admin/udf.md
+++ b/docs/docs/guides/admin/udf.md
@@ -6,7 +6,7 @@ slug: /guides/udf
 description: Register, execute, and remove Lua UDFs on the Aerospike server.
 ---
 
-User Defined Functions (UDFs) are Lua scripts that execute on the Aerospike server node owning the record.
+User-Defined Functions (UDFs) are Lua scripts. Aerospike runs each script on the server node that owns the target record.
 
 ## API
 
@@ -60,6 +60,6 @@ await client.udf_remove("counter")
 
 ## Notes
 
-- Lua is the only supported UDF language
-- UDF changes take a few seconds to propagate to all nodes
-- Keep UDFs simple for best performance
+- Lua is the only supported UDF language.
+- UDF changes take a few seconds to reach every node.
+- Keep UDFs simple for the best performance.

--- a/docs/docs/guides/api-comparison.md
+++ b/docs/docs/guides/api-comparison.md
@@ -6,7 +6,7 @@ slug: /guides/api-comparison
 description: Side-by-side API comparison between the official C-based client and aerospike-py.
 ---
 
-A comprehensive comparison between the **official C-based client** (`aerospike` on PyPI) and **aerospike-py** (Rust-based). For migration steps, see the [Migration Guide](/docs/guides/migration).
+This page compares the **official C-based client** (`aerospike` on PyPI) with the Rust-based **aerospike-py** client. For step-by-step migration instructions, see the [Migration Guide](/docs/guides/migration).
 
 ## Connection
 

--- a/docs/docs/guides/architecture.md
+++ b/docs/docs/guides/architecture.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Architecture
 
-aerospike-py is a Python client for [Aerospike](https://aerospike.com) built on the [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust) via [PyO3](https://pyo3.rs). The Rust core compiles into a native Python extension module, giving Python applications near-native I/O performance while keeping a Pythonic API with full type annotations.
+aerospike-py uses [PyO3](https://pyo3.rs) to expose the [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust) as a native Python extension. Applications get a typed, Python-friendly API while the Rust core handles Aerospike I/O.
 
 **Key properties:**
 
@@ -63,7 +63,7 @@ print(record.bins)  # {"name": "Alice"}
 client.close()
 ```
 
-Under the hood, each call releases the GIL, runs the Rust future on a Tokio runtime via `block_on()`, then re-acquires the GIL to return the result. Other Python threads can execute freely during the I/O wait.
+Each call releases the GIL and runs the Rust future on a Tokio runtime through `block_on()`. It reacquires the GIL only when returning the result, so other Python threads can run during the I/O wait.
 
   </TabItem>
   <TabItem value="async" label="Async">
@@ -91,7 +91,7 @@ Each call returns a Python awaitable backed by a Tokio future. The GIL is not he
 | Sync (sequential) | ~1.1x slower | ~1.1x slower | — |
 | Async (concurrent) | **2.1x faster** | **1.6x faster** | **3.4x faster** |
 
-The sync gap (~10%) comes from the `block_on()` overhead per call. Async is where aerospike-py shines — concurrent I/O eliminates per-call overhead entirely.
+The sync path pays about 10% for `block_on()` on each call. The async path overlaps concurrent I/O and avoids that per-call scheduling cost.
 
 ## Data Flow
 
@@ -213,7 +213,7 @@ except AerospikeError as e:
     print(f"Unexpected error: {e}")
 ```
 
-For batch operations, individual failures do not raise exceptions — check `br.result` on each `BatchRecord` instead. See the [Error Handling guide](./admin/error-handling.md) for the full exception hierarchy and batch error patterns.
+Batch operations report failures per record instead of raising for the whole batch. Check `br.result` on each `BatchRecord`. See the [Error Handling guide](./admin/error-handling.md) for the exception hierarchy and batch patterns.
 
 ## Observability
 

--- a/docs/docs/guides/config/client-config.md
+++ b/docs/docs/guides/config/client-config.md
@@ -66,14 +66,14 @@ config: ClientConfig = {
 }
 ```
 
-- `max_conns_per_node`: Match to expected concurrent requests per node
-- `min_conns_per_node`: Avoid cold-start latency
-- `conn_pools_per_node`: Number of connection pools per node. Machines with 8 or fewer CPU cores typically need only 1. On machines with more cores, increasing this value reduces lock contention on pooled connections
-- `idle_timeout`: Keep below server `proto-fd-idle-ms` (default 60s)
+- `max_conns_per_node`: Match this to the expected number of concurrent requests per node.
+- `min_conns_per_node`: Pre-warm connections to avoid cold-start latency.
+- `conn_pools_per_node`: Use one pool on machines with eight or fewer CPU cores. On larger machines, additional pools can reduce connection-pool lock contention.
+- `idle_timeout`: Keep this below the server's `proto-fd-idle-ms` value, which defaults to 60 seconds.
 
 ## Backpressure
 
-When running many concurrent operations (e.g., `asyncio.gather` with hundreds of tasks), the upstream connection pool can be exhausted, causing `NoMoreConnections` errors. Backpressure limits how many operations are in-flight simultaneously:
+Hundreds of concurrent operations, such as a large `asyncio.gather`, can exhaust the connection pool and raise `NoMoreConnections`. Backpressure prevents this by limiting the number of in-flight operations:
 
 ```python
 config: ClientConfig = {
@@ -147,7 +147,7 @@ async def health():
     return {"status": "ok" if ok else "degraded"}
 ```
 
-The background **tend** process (configured via `tend_interval`, default 1000 ms) automatically monitors cluster membership and connection health. `ping()` complements this by providing on-demand verification.
+The background **tend** process monitors cluster membership and connection health. It runs every 1,000 ms by default, as configured by `tend_interval`. Use `ping()` when you also need an immediate liveness check.
 
 ## Sync vs Async
 
@@ -189,5 +189,6 @@ finally:
   </TabItem>
 </Tabs>
 
-**Use async for:** High-concurrency web servers, fan-out reads, mixed I/O.
-**Sync is fine for:** Scripts, batch jobs, sequential pipelines.
+**Use async for:** high-concurrency web servers, fan-out reads, and mixed I/O.
+
+**Use sync for:** scripts, batch jobs, and sequential pipelines.

--- a/docs/docs/guides/config/performance-tuning.md
+++ b/docs/docs/guides/config/performance-tuning.md
@@ -80,19 +80,20 @@ client.put(key, bins, meta={"ttl": aerospike.TTL_NAMESPACE_DEFAULT}) # use names
 
 ## Concurrency & Backpressure Tuning
 
-High-concurrency Python services (FastAPI, Gunicorn workers, Celery
-fan-out) can saturate the two layers underneath `aerospike-py`:
+High-concurrency Python services can saturate two layers beneath
+`aerospike-py`. This includes FastAPI services, Gunicorn workers, and Celery
+fan-out workloads:
 
 1. The **internal Tokio runtime** that drives the Rust async client.
 2. The **per-node connection pool** to the Aerospike server.
 
-There are two independent knobs — pick the right one for the symptom.
+Tune these layers independently. Choose the setting that matches the symptom.
 
 ### `AEROSPIKE_RUNTIME_WORKERS` (env var)
 
-Controls the number of Tokio worker threads used by the embedded async
-runtime. **Default: `2`**, which keeps CPU overhead low when colocated
-with CPU-heavy workloads (PyTorch inference, sklearn, etc.).
+This variable controls the number of Tokio worker threads in the embedded
+async runtime. It defaults to `2` to limit CPU overhead when the process also
+runs CPU-heavy work such as PyTorch inference or scikit-learn.
 
 ```bash
 # Bump worker count when 10+ concurrent FastAPI requests each call
@@ -114,16 +115,16 @@ export AEROSPIKE_RUNTIME_WORKERS=4
 - `tokio-console` (or a Tokio runtime metric) shows a queue depth that
   grows unboundedly during load.
 
-The env var is read **once at runtime initialization** (first
-`AsyncClient.connect()`). Changing it after the runtime is up has no
-effect — set it before importing `aerospike_py`.
+The client reads this variable once, when the first `AsyncClient.connect()`
+initializes the runtime. Set it before importing `aerospike_py`; changing it
+after initialization has no effect.
 
 ### `max_concurrent_operations` (client config)
 
-Caps the number of in-flight operations dispatched into the Rust client
-at any moment. **Disabled by default** (`0`, zero overhead). When set,
-excess callers **queue** for a slot instead of failing or exhausting the
-connection pool.
+This setting caps the number of operations dispatched to the Rust client at
+one time. It is disabled by default (`0`) and adds no overhead. When enabled,
+extra callers wait for a slot instead of failing or exhausting the connection
+pool.
 
 ```python
 config = {
@@ -141,15 +142,13 @@ When enabled:
 - `aerospike_py.BackpressureError` is raised only if
   `operation_queue_timeout_ms` expires before a slot frees up.
 
-**Choosing the value:** set this close to (but no higher than)
-`max_conns_per_node` (default `256`). For a 3-node cluster, `64` is a
-conservative starting point that prevents pool exhaustion while keeping
-throughput high.
+**Choose a value:** keep it close to, but no higher than,
+`max_conns_per_node` (default `256`). For a three-node cluster, start at `64`.
+This conservative value protects the pool while preserving throughput.
 
-**Enable when:** high-fanout batch reads where the `spawn_blocking`
-queue would otherwise stall, or when an upstream caller (FastAPI under
-load test) can issue more concurrent ops than the connection pool can
-serve.
+**Enable it when:** high-fan-out batch reads stall the `spawn_blocking` queue,
+or an upstream caller can issue more operations than the connection pool can
+serve. A FastAPI load test is one common example.
 
 ### Quick before/after
 
@@ -183,9 +182,10 @@ For a FastAPI service deployed under Gunicorn with `uvicorn` workers
 | Gunicorn `--workers` | `2 * CPU` | Each worker has its own client + Tokio runtime. |
 | `max_conns_per_node` | `256` | Stay well above `max_concurrent_operations`. |
 
-A single Gunicorn worker with the values above can sustain ~64 concurrent
-in-flight Aerospike ops without exhausting the pool. Total cluster-side
-load = `gunicorn_workers * max_concurrent_operations`; size accordingly.
+With these starting values, one Gunicorn worker can sustain about 64
+concurrent Aerospike operations without exhausting the pool. Calculate total
+cluster-side load as `gunicorn_workers * max_concurrent_operations`, then size
+the cluster for that result.
 
 ## Async Client
 

--- a/docs/docs/guides/crud/numpy-batch-write.md
+++ b/docs/docs/guides/crud/numpy-batch-write.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 ## Overview
 
-`batch_write_numpy()` writes multiple records to Aerospike directly from a **numpy structured array**. Each row becomes a separate write operation, with dtype fields mapped to Aerospike bins.
+`batch_write_numpy()` writes records directly from a **NumPy structured array**. Each row becomes one write operation, and each dtype field maps to an Aerospike bin.
 
 - **Direct array-to-record mapping** — no intermediate Python dicts or loops
 - **Key field extraction** — a designated dtype field (default `_key`) is used as the record's user key
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 
 :::tip[When to use]
 
-Use `batch_write_numpy()` when your data is already in numpy arrays (e.g., ML feature stores, sensor data pipelines, scientific datasets). For regular Python dicts, use `put()` or standard batch operations instead.
+Use `batch_write_numpy()` when your data already lives in NumPy arrays, such as ML feature-store data, sensor streams, or scientific datasets. For Python dictionaries, use `put()` or the standard batch operations.
 
 :::
 
@@ -434,7 +434,7 @@ for br in results.batch_records:
         print(f"Write failed for key {br.key} after retries (code={br.result})")
 ```
 
-The backoff schedule is 10ms, 20ms, 40ms, ... capped at 500ms between attempts. Only the failed records are re-submitted on each retry, not the entire batch.
+The delay starts at 10 ms, doubles to 20 ms, 40 ms, and so on, and stops growing at 500 ms. Each retry submits only failed records, not the entire batch.
 
 :::tip
 For large bulk ingestion where occasional transient failures are expected, `retry=3` is a good starting point. Set `retry=0` (default) when you want full control over retry logic in your application.

--- a/docs/docs/guides/crud/numpy-batch.md
+++ b/docs/docs/guides/crud/numpy-batch.md
@@ -9,12 +9,12 @@ description: Use batch_read with numpy structured arrays for high-performance co
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-`batch_read(...).to_numpy(dtype)` returns a **numpy structured array** instead of Python objects:
+`batch_read(...).to_numpy(dtype)` materializes batch results as a **NumPy structured array** instead of per-record Python objects:
 
-- **Zero-copy columnar access** -- `batch.batch_records["temperature"]` returns a numpy array; pair with `torch.from_numpy(...)` for an O(1) tensor hand-off
-- **GIL released during fill** -- the per-record `Value → buffer` writes happen with the GIL dropped, so other asyncio tasks / threads can run concurrently
-- **Vectorized computation** -- use numpy/pandas directly on results
-- **Memory efficiency** -- Rust writes directly into numpy buffer, bypassing Python objects
+- **Zero-copy column access** -- `batch.batch_records["temperature"]` returns a NumPy array. Pass it to `torch.from_numpy(...)` for an O(1) tensor handoff.
+- **GIL-free buffer fill** -- The client writes each `Value` to the buffer with the GIL released, so other asyncio tasks and threads can run.
+- **Vectorized computation** -- Use NumPy or pandas directly on the results.
+- **Lower object overhead** -- Rust writes into the NumPy buffer without creating a Python object for every value.
 
 :::tip[Performance]
 For 10K records with 5 bins, this eliminates ~60K intermediate Python objects compared to materialising via `lazy_records.to_dict()`.
@@ -116,11 +116,11 @@ asyncio.run(main())
 
 ## NumpyBatchRecords
 
-Call `.to_numpy(dtype)` on the `LazyBatchRecords` that `batch_read()` returns to get a `NumpyBatchRecords` object. The structured-array fill runs with the GIL released so the result hands directly to `torch.from_numpy(...)` zero-copy:
+Call `.to_numpy(dtype)` on the `LazyBatchRecords` returned by `batch_read()` to create a `NumpyBatchRecords` object. Because the client fills the structured array with the GIL released, you can pass its arrays directly to `torch.from_numpy(...)` without copying them:
 
 :::warning[Missing reads silently zero-fill]
 
-Rows whose `result_codes[i] != 0` (including `RecordNotFound`) leave their data and meta entries at the dtype's zero value — the buffer alone cannot tell them apart from a record whose bins are genuinely zero. Always mask downstream math with `batch.result_codes == 0` (or check `lazy_records.found_count()`) before averaging, summing, or feeding into inference.
+Rows with `result_codes[i] != 0`, including `RecordNotFound`, keep the dtype's zero value in both data and metadata. The buffer alone cannot distinguish these rows from records whose bins really contain zero. Before aggregating values or running inference, mask the array with `batch.result_codes == 0` or check `lazy_records.found_count()`.
 
 :::
 
@@ -391,11 +391,10 @@ lazy_records: LazyBatchRecords = await client.batch_read(
 batch: NumpyBatchRecords = lazy_records.to_numpy(dtype)
 ```
 
-The `LazyBatchRecords.to_numpy(dtype)` call performs the structured-array
-materialisation with the GIL released — the per-record fill loop is a
-sequence of raw `ptr::write_unaligned` writes, so sibling Python work
-(other asyncio tasks, torch inference threads) can hold the GIL while
-the buffer fills.
+`LazyBatchRecords.to_numpy(dtype)` materializes the structured array with the
+GIL released. Its per-record loop uses raw `ptr::write_unaligned` writes, so
+other Python work, such as asyncio tasks or PyTorch inference threads, can
+hold the GIL while the buffer fills.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/docs/guides/crud/numpy-guide.md
+++ b/docs/docs/guides/crud/numpy-guide.md
@@ -6,7 +6,7 @@ slug: /guides/numpy-integration
 description: High-performance batch operations using NumPy structured arrays.
 ---
 
-High-performance batch reads and writes using NumPy structured arrays. Data flows directly between Aerospike and NumPy buffers via Rust, bypassing per-element Python object creation.
+Use NumPy structured arrays for high-performance batch reads and writes. The Rust client moves data directly between Aerospike and NumPy buffers without creating a Python object for each element.
 
 :::note[Requirement]
 Requires `numpy >= 2.0`. Install with: `pip install aerospike-py[numpy]`

--- a/docs/docs/guides/crud/write.md
+++ b/docs/docs/guides/crud/write.md
@@ -141,7 +141,7 @@ result = await client.operate_ordered(key, ops)
 
 ## Batch Write
 
-Write multiple records with **per-record bins** in a single batch call. This is the batch version of `put()` — each record can have different bin names and values.
+Use one batch call to write multiple records with **per-record bins**. Like `put()`, each record may use different bin names and values.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -226,7 +226,7 @@ results = await client.batch_write(records_with_ttl)
   </TabItem>
 </Tabs>
 
-**Retry with auto-recovery:** Records that fail with transient errors (timeout, device overload, key busy) are automatically retried with exponential backoff:
+**Automatic retries:** Set `retry` to retry transient failures such as timeouts, device overload, or busy keys with exponential backoff:
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -248,7 +248,7 @@ results = await client.batch_write(records, retry=5)
 </Tabs>
 
 :::tip[in_doubt flag]
-When `br.in_doubt` is `True`, the write may have completed on the server despite the error (e.g., timeout after the write was sent). Check `in_doubt` before retrying to avoid duplicate writes on non-idempotent operations.
+When `br.in_doubt` is `True`, the server may have completed the write before the error occurred. A timeout after sending the write is one example. Check `in_doubt` before retrying a non-idempotent operation so you do not apply it twice.
 :::
 
 ## Batch Operate / Remove

--- a/docs/docs/guides/query-scan/expression-filters.md
+++ b/docs/docs/guides/query-scan/expression-filters.md
@@ -6,7 +6,7 @@ slug: /guides/expression-filters
 description: Server-side record filtering with 104+ composable expression functions.
 ---
 
-Server-side filtering during read, write, and query operations. The server evaluates the expression and only returns (or modifies) matching records.
+Expression filters apply to read, write, and query operations. The server evaluates each expression and returns or modifies only matching records.
 
 :::note[Server Requirement]
 Expression filters require Aerospike Server **5.2+**.

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -6,7 +6,7 @@ description: Common problems and solutions when using aerospike-py.
 
 # Troubleshooting
 
-This guide covers common issues you may encounter when using aerospike-py, along with their causes and solutions.
+Use this guide to identify common aerospike-py errors, check their likely causes, and apply the corresponding fix.
 
 ## Connection Issues
 
@@ -43,7 +43,7 @@ aerospike_py.ClusterError: Failed to connect to host(s)
    }).connect()
    ```
 
-3. If running in a container, ensure the port is correctly mapped and accessible from the host network.
+3. If Aerospike runs in a container, verify that the service port is mapped and reachable from the host.
 
 ### TimeoutError
 
@@ -185,7 +185,7 @@ ERROR: Failed building wheel for aerospike-py
 
 **Solutions:**
 
-1. For most users, pre-built wheels are available -- just use pip:
+1. Most users can install a pre-built wheel from PyPI:
    ```bash
    pip install aerospike-py
    ```
@@ -344,7 +344,7 @@ TypeError: numpy dtype mismatch
 
 ## Python 3.14t (Free-Threaded) Notes
 
-aerospike-py supports Python 3.14t (free-threaded / no-GIL builds). However, keep in mind:
+aerospike-py supports Python 3.14t free-threaded builds. Keep these points in mind:
 
 - **Experimental support**: Free-threaded Python is still experimental in CPython. Some third-party libraries may not work correctly.
 - **Thread safety**: aerospike-py's `Client` and `AsyncClient` are thread-safe. The Rust client handles internal synchronization.

--- a/docs/docs/integrations/observability/internal-stage-metrics.md
+++ b/docs/docs/integrations/observability/internal-stage-metrics.md
@@ -5,11 +5,11 @@ sidebar_position: 4
 description: Fine-grained per-stage timing for debugging aerospike-py latency, with zero production overhead when disabled.
 ---
 
-aerospike-py exposes a second, more granular histogram alongside `db_client_operation_duration_seconds`:
+Alongside `db_client_operation_duration_seconds`, aerospike-py exposes a second histogram with finer-grained timing:
 
 **`db_client_internal_stage_seconds`** — a histogram that breaks a single `batch_read` down into its internal stages (key parsing, Tokio scheduling, I/O, `to_dict` / `to_numpy` conversion, event-loop resume, etc.).
 
-Unlike operational metrics which are always on, internal stage profiling is **off by default**. When disabled, every stage timer call site skips `Instant::now()` entirely — the disabled path costs a single atomic load (~1ns per batch).
+Operational metrics are always enabled, but internal stage profiling is **off by default**. In the disabled path, each timer skips `Instant::now()` and performs only one atomic load, which costs about 1 ns per batch.
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ with aerospike_py.internal_stage_profiling():
 | `aerospike_py.set_internal_stage_metrics_enabled(True)` | Runtime toggle from application code. |
 | `with aerospike_py.internal_stage_profiling(): ...` | Temporary — restores the previous state on exit. |
 
-The env var is read once during native module init. Runtime calls win over the env var.
+The native module reads the environment variable once during initialization. A later runtime call overrides that value.
 
 ## `db_client_internal_stage_seconds`
 
@@ -80,7 +80,7 @@ Stage profiling adds measurable latency: each `batch_read` pays ~10× `Instant::
 | p95 | 4.67 ms | 7.61 ms | +2.94 ms |
 | p99 | 4.93 ms | 9.51 ms | +4.58 ms |
 
-Leave it **off in production**, and flip it on only when you are actively hunting a latency regression.
+Leave profiling **off in production**. Enable it only while investigating a latency regression.
 
 ## Scraping and Visualization
 
@@ -95,7 +95,7 @@ histogram_quantile(
 )
 ```
 
-A stacked timeseries of all stages gives you a quick view of where each `batch_read` is spending its time:
+A stacked time series of all stages shows where each `batch_read` spends its time:
 
 ```promql
 sum by (stage, db_operation_name) (

--- a/docs/docs/integrations/observability/logging.md
+++ b/docs/docs/integrations/observability/logging.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 description: Rust-to-Python logging bridge for observing Aerospike client internals.
 ---
 
-Built-in **Rust-to-Python logging bridge** that forwards all internal Rust logs to Python's `logging` module. Initialized automatically on import.
+aerospike-py includes a **Rust-to-Python logging bridge**. It forwards internal Rust logs to Python's `logging` module and initializes automatically when you import the package.
 
 ## Quick Start
 
@@ -124,7 +124,7 @@ for name in ["aerospike_core", "aerospike_py"]:
 
 ## Shutdown Fallback
 
-When the Python GIL is unavailable (e.g., during interpreter shutdown), the logging bridge cannot forward messages to Python. In this case:
+The logging bridge cannot forward messages when the Python GIL is unavailable, such as during interpreter shutdown. In that case:
 
 - **WARN and ERROR** messages are emitted to **stderr** so critical diagnostics are not lost
 - **INFO, DEBUG, TRACE** messages are silently dropped

--- a/docs/docs/integrations/observability/metrics.md
+++ b/docs/docs/integrations/observability/metrics.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 description: Prometheus metrics for monitoring Aerospike operations.
 ---
 
-aerospike-py collects operation-level metrics in Rust and exposes them in **Prometheus text format**. Metric names follow [OpenTelemetry DB Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/).
+aerospike-py records operation-level metrics in Rust and exposes them in **Prometheus text format**. The metric names follow the [OpenTelemetry DB Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/).
 
 ## Quick Start
 

--- a/docs/docs/integrations/observability/tracing.md
+++ b/docs/docs/integrations/observability/tracing.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 description: OpenTelemetry distributed tracing for Aerospike operations.
 ---
 
-Built-in **OpenTelemetry tracing** for every data operation. Spans follow [Database Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/) and export via **OTLP gRPC**.
+aerospike-py can trace every data operation with **OpenTelemetry**. Spans follow the [Database Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/) and use **OTLP gRPC** for export.
 
 ## Quick Start
 

--- a/docs/docs/performance/bottleneck-analysis.mdx
+++ b/docs/docs/performance/bottleneck-analysis.mdx
@@ -6,9 +6,9 @@ description: Per-stage profiling and optimisation recipes for aerospike-py. Pend
 ---
 
 :::caution TODO — pending re-measurement
-The previous bottleneck-analysis content was authored against the deleted `benchmark/results/*` artifacts (`bottleneck-analysis.md`, `internal-stage-toggle-comparison.md`). Those measurements identified the `spawn_blocking_delay` + `event_loop_resume_delay` stages as the dominant cost under GIL — that story is preserved in [Production Benchmark → Python 3.14t](./production-benchmark#what-gets-faster-and-why), where the same stages are shown collapsing to near-zero under free-threaded Python.
+The previous analysis relied on deleted `benchmark/results/*` artifacts (`bottleneck-analysis.md` and `internal-stage-toggle-comparison.md`). Those measurements found that `spawn_blocking_delay` and `event_loop_resume_delay` dominated the cost under the GIL. The [Production Benchmark → Python 3.14t](./production-benchmark#what-gets-faster-and-why) section preserves that result and shows both stages falling to nearly zero under free-threaded Python.
 
-What's missing is a fresh per-stage breakdown taken on the new [Isolated Benchmark](./isolated-benchmark) harness (s1–s5, oha, podman, local Aerospike CE 8.1.2.1_3). The harness already supports stage profiling — `AEROSPIKE_PY_INTERNAL_METRICS=1` toggles `db_client_internal_stage_seconds` histograms with negligible overhead — but the matrix has not yet been run and reduced into a page.
+The page still needs a fresh per-stage breakdown from the new [Isolated Benchmark](./isolated-benchmark) harness (s1–s5, oha, Podman, and local Aerospike CE 8.1.2.1_3). The harness already supports stage profiling through `AEROSPIKE_PY_INTERNAL_METRICS=1`, which enables the `db_client_internal_stage_seconds` histograms with negligible disabled-path overhead. The full matrix has not yet been run and summarized.
 
 Tracked work:
 
@@ -23,4 +23,4 @@ Tracked work:
 2. **Stage-profiling activation** — `AEROSPIKE_PY_INTERNAL_METRICS=1` env var, `aerospike_py.set_internal_stage_metrics_enabled(True)` runtime toggle, scoped context manager. All three exist today; their overhead is roughly one `AtomicBool` load per stage entry when disabled.
 3. **Recipes that measurably help.** The known winners from the previous round were (a) switch to aerospike-py, (b) consolidate `gather(N batch_reads)` into a single `batch_read(mixed keys)`, (c) move to Python 3.14t free-threaded. (a) and (c) are already quantified on the new harness in [Isolated Benchmark](./isolated-benchmark) and [Production Benchmark](./production-benchmark); (b) is what **s4_gather vs s4_single** is set up to re-measure.
 
-Until the re-measurement lands, treat the [Production Benchmark's 3.14t stage breakdown](./production-benchmark#what-gets-faster-and-why) as the canonical "where the time goes" reference.
+Until new measurements are available, use the [Production Benchmark's 3.14t stage breakdown](./production-benchmark#what-gets-faster-and-why) as the reference for where time is spent.

--- a/docs/docs/performance/isolated-benchmark.mdx
+++ b/docs/docs/performance/isolated-benchmark.mdx
@@ -8,9 +8,9 @@ description: 5-scenario uvicorn ASGI benchmark suite (benchmark/) — strips Fas
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-A focused comparison of **aerospike-py vs the official `aerospike` Python client** behind a real uvicorn ASGI process. The suite intentionally **strips response serialisation cost** (each endpoint returns a single derived scalar — `found`, `pred_sum`, `subset_sum`) so the measured latency reflects `batch_read` + materialisation + (optional) inference, not JSON encoding.
+This benchmark compares **aerospike-py with the official `aerospike` Python client** behind a real uvicorn ASGI process. Each endpoint returns one derived scalar (`found`, `pred_sum`, or `subset_sum`) to remove response-serialization cost. The measured latency therefore covers `batch_read`, materialization, and optional inference instead of JSON encoding.
 
-The opposite end of the spectrum is the [Production Benchmark](./production-benchmark), which keeps every cost a real serving pod pays (HTTP parse, full record marshalling, DLRM, network out). Use this page when you want to know **how much of the gap belongs to the client library itself**, and that page when you want **capacity-planning numbers**.
+The [Production Benchmark](./production-benchmark) measures the other end of the spectrum. It includes HTTP parsing, full-record marshaling, DLRM inference, and network output. Use this page to isolate the client library's contribution. Use the production benchmark for capacity planning.
 
 > **Source**: `benchmark/` in this repo. Runs locally on podman/docker against Aerospike CE 8.1.2.1_3.
 
@@ -24,12 +24,12 @@ make bench-all CONCURRENCY=10 DURATION=30s BATCH_SIZE=50
 make report       # → markdown comparison grouped per scenario
 ```
 
-`make bench` starts a uvicorn process per CLIENT, waits for `/healthz`, runs `oha` for the given duration, kills the process, and moves on. `oha` is the load generator (`oha --output-format json --no-tui -c $C -z $D -m POST …`); each run drops a `meta.json` next to `oha.json` so `loadtest/report.py` can group runs by `(scenario, batch_size, concurrency, python)`.
+`make bench` starts one uvicorn process for each client and waits for `/healthz`. It then runs `oha` for the requested duration, stops the process, and continues to the next client. Each run writes `meta.json` beside `oha.json`, which lets `loadtest/report.py` group results by `(scenario, batch_size, concurrency, python)`.
 
-The Aerospike CE container mounts `scripts/aerospike.template.conf` so `access-address` is pinned to `127.0.0.1`. aerospike-py performs full cluster discovery on `connect()` and would otherwise re-connect to the podman-internal IP and fail; the official client only hits the seed host and gets away without it.
+The Aerospike CE container mounts `scripts/aerospike.template.conf` and pins `access-address` to `127.0.0.1`. aerospike-py performs full cluster discovery during `connect()`. Without this setting, it would reconnect to the Podman-internal address and fail. The official client uses only the seed host in this benchmark.
 
 :::caution Real measurement is follow-up
-The numbers per scenario below come from a short development sanity matrix (py3.11, concurrency=4, batch=30, 3s per run) with everything cache-warm. Use them for **shape** (which scenario widens or compresses the gap), not for absolute claims. Production-grade matrices want larger seed (10k–100k), longer duration (60s), higher concurrency (10–50).
+The scenario results below come from a short, warm-cache development matrix: Python 3.11, concurrency 4, batch size 30, and three seconds per run. Use them to compare the **shape** of the results, not as absolute performance claims. A production-grade matrix needs 10,000–100,000 seed records, 60-second runs, and concurrency between 10 and 50.
 :::
 
 ## Scenarios
@@ -79,7 +79,7 @@ Materialise records into per-row Python lists, build a `torch.tensor`, run a 2-l
 | aerospike-py | `result.to_dict()` → `bins_by_key.get(key)` per record (key order from request list) |
 | official | iterate `result.batch_records` (preserves request order per aerospike 19.x, verified) |
 
-Both paths build a Python list of lists and call `torch.tensor(rows, dtype=torch.float32)` exactly once — no cell-by-cell tensor assignment that would unfairly punish either side.
+Both paths build a Python list of lists and call `torch.tensor(rows, dtype=torch.float32)` exactly once. Neither path assigns tensor cells one by one, so the comparison treats both clients equally.
 
 **Smoke**
 
@@ -187,7 +187,7 @@ Smaller gap than s3 because the wire payload is identical and the official clien
 
 **Expected on 3.14t**
 
-aerospike-py's `to_numpy(subset_dtype)` releases the GIL during the per-record fill, so multiple s5 requests can materialise in parallel under 3.14t. Official client's per-request dict build is also GIL-released inside the C extension itself, but the resulting dict ownership flips the GIL on the Python side. Ratio likely holds.
+aerospike-py's `to_numpy(subset_dtype)` releases the GIL while filling each record, so Python 3.14t can materialise several s5 requests in parallel. The official client also releases the GIL while its C extension builds each request's dict. However, Python must take ownership of the resulting dict. The ratio will likely remain similar.
 
   </TabItem>
 </Tabs>
@@ -198,7 +198,7 @@ aerospike-py's `to_numpy(subset_dtype)` releases the GIL during the per-record f
 |---|---|
 | Response body serialisation | Each endpoint returns `{found: N}` (or `+ pred_sum / subset_sum`) — a single scalar derived from the records. JSON encoding of full records would add a cost both clients pay but with different key/digest shapes, inflating the official-client side asymmetrically and burying the client gap. |
 | OTel / Prometheus / nelo | Measurement noise. The parent client library exposes those features; the benchmark suite stays clean. |
-| Docker image / k8s manifests | The point is to isolate the client library — adding a deploy/registry/manifests path drags in noise unrelated to it. |
+| Docker image / k8s manifests | The benchmark isolates the client library. Deployment, registry, and manifest work would add unrelated variance. |
 | Bin projection (`bins=[…]` on the wire) | Server-side optimisation, orthogonal to the client comparison. **s5** measures client-side materialisation cost on the same wire payload. |
 
 For the inverse — measurement that *includes* all the production cost — see the [Production Benchmark](./production-benchmark).

--- a/docs/docs/performance/overview.mdx
+++ b/docs/docs/performance/overview.mdx
@@ -8,7 +8,7 @@ description: TL;DR — measured latency, throughput, and Python 3.14t gains for 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Measured benchmarks comparing **aerospike-py** (Rust/PyO3, native async) against the **official `aerospike` Python client** (C extension wrapped with `loop.run_in_executor`).
+These benchmarks compare **aerospike-py** (Rust, PyO3, and native async) with the **official `aerospike` Python client** (a C extension wrapped with `loop.run_in_executor`).
 
 :::tip TL;DR — cumulative effect on DLRM-serving p95
 **324 ms → 97 ms (−70%)** by stacking 3 actions: switch client → batch_read consolidation → Python 3.14t.
@@ -37,12 +37,12 @@ Setup: FastAPI + DLRM + Aerospike CE, k6 10 VUs × 60s, 2 replicas (4 CPU / 4 Gi
 
 ## Pick your environment (Python 3.11 + GIL)
 
-The thinner the surrounding stack, the larger the gap. Tail-latency advantage survives even in production-shaped workloads.
+A thinner application stack makes the client-level difference easier to see. The tail-latency advantage remains visible in production-shaped workloads.
 
 <Tabs>
   <TabItem value="dlrm" label="C — uvicorn + DLRM (real serving)" default>
 
-Full HTTP → batch_read → DLRM CPU inference → response. Closest to a real recsys serving pod.
+This environment covers the full path from HTTP through `batch_read` and DLRM CPU inference to the response. It most closely resembles a recommendation-serving pod.
 
 | Metric | aerospike-py | official | aerospike-py advantage |
 |---|---:|---:|---:|
@@ -67,7 +67,7 @@ FastAPI + uvicorn around `batch_read`, no model inference. The "REST API in fron
   </TabItem>
   <TabItem value="pure" label="A — Pure DB client (no HTTP/ML)">
 
-Python loop drives `batch_read` directly. Largest gap — surrounding stack is as thin as possible.
+A Python loop calls `batch_read` directly. With no HTTP or ML layers, this environment shows the largest client-level difference.
 
 | Metric | aerospike-py | official | advantage |
 |---|---:|---:|---:|
@@ -85,7 +85,7 @@ Python loop drives `batch_read` directly. Largest gap — surrounding stack is a
 | Page | When to read it |
 |---|---|
 | **[Isolated Benchmark](./isolated-benchmark)** | "How much of the gap belongs to the client library itself?" — 5 scenarios (s1..s5) on a local podman/oha harness, response serialisation stripped out. Each scenario isolates one materialisation path (dict / `to_numpy` zero-copy / gather vs single / lazy subset). Includes a 3.14t section. |
-| **[Production Benchmark](./production-benchmark)** | "What do real serving pods see?" — FastAPI + DLRM + Aerospike CE on k8s, k6 load, response body serialised, two replicas. The headline 324→189→97 ms cumulative-gain story. Includes a 3.14t section. |
+| **[Production Benchmark](./production-benchmark)** | "What do real serving pods see?" — FastAPI + DLRM + Aerospike CE on k8s, k6 load, response body serialised, and two replicas. Shows how the measured p95 falls from 324 to 189 to 97 ms as the changes accumulate. Includes a 3.14t section. |
 | **[Bottleneck Analysis](./bottleneck-analysis)** | Internal stage profiling and recipes (`gather→single`, etc.). Currently being re-measured on the new isolated harness. |
 
 To reproduce locally, see `benchmark/README.md`.

--- a/docs/docs/performance/production-benchmark.mdx
+++ b/docs/docs/performance/production-benchmark.mdx
@@ -8,9 +8,9 @@ description: End-to-end production-shaped benchmark — FastAPI + DLRM inference
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-End-to-end measurement against a **production-shaped deployment**: FastAPI on uvicorn, DLRM (CPU inference) in the request path, Aerospike CE behind it, real HTTP load from k6, and the response body serialised back to the client.
+This end-to-end benchmark uses a **production-shaped deployment**: FastAPI on uvicorn, DLRM CPU inference in the request path, Aerospike CE, k6 HTTP load, and a serialized response body.
 
-Everything that a real recsys serving pod pays for — HTTP parse, JSON serialise, model forward — is in the measurement, so the headline numbers compress relative to an [Isolated Benchmark](./isolated-benchmark), but they're the ones to quote for **capacity planning**.
+The measurement includes HTTP parsing, JSON serialization, and the model forward pass. These shared costs make the client difference smaller than in the [Isolated Benchmark](./isolated-benchmark), but they produce the numbers to use for **capacity planning**.
 
 > **Sources**: internal benchmark runs, April 2026. Raw measurement artifacts are not committed to the repo (see git history before the `benchmark/` rewrite for the original `benchmark/results/*.md` files). The headline numbers below are reproduced from those artifacts; a clean re-measurement on the new isolated harness is tracked in [Bottleneck Analysis](./bottleneck-analysis).
 
@@ -32,7 +32,7 @@ official-client result conversion at the tail.
 
 ## Environment A — Pure DB Client
 
-**What this isolates.** No FastAPI, no model inference, no HTTP loadgen. A Python loop drives `batch_read` directly — the surrounding stack is as thin as possible, so aerospike-py's advantage is **largest** here.
+**What this isolates.** This environment removes FastAPI, model inference, and HTTP load generation. A Python loop calls `batch_read` directly, so the client difference is **largest** here.
 
 ### Setup
 
@@ -66,7 +66,7 @@ Outlier: set_8 (0% found rate) → fast not-found path, not real read latency.
 0% found rate — the official client returns errors faster than success paths, so this row reflects "fast not-found" rather than real read latency. **All other sets show 4–8× mean speedup.**
 :::
 
-**`official-async`** (the sync C client wrapped with `loop.run_in_executor`) is slightly slower than the bare sync client across every set — each request pays a thread-pool hop. aerospike-py's gap over `official-async` is therefore consistently *larger* than its gap over `official`.
+**`official-async`** wraps the synchronous C client with `loop.run_in_executor`. It is slightly slower than the bare sync client for every set because each request crosses the thread pool. As a result, aerospike-py's lead over `official-async` is consistently larger than its lead over `official`.
 
   </TabItem>
   <TabItem value="B" label="B — uvicorn ASGI only">
@@ -178,7 +178,7 @@ B) uvicorn ASGI              mean 1.27×             ≈ noise at C=5
 C) uvicorn + DLRM            mean 1.24×             p95 −42%  🔥
 ```
 
-As layers are added around the DB call, the **ratio compresses** (4.8× → 1.24× mean) but **upper-percentile advantage holds** — aerospike-py keeps the GIL released during I/O, while the official client serialises GIL acquisition through `run_in_executor` and spikes at the tail.
+Adding layers around the database call reduces the mean ratio from 4.8× to 1.24×. The **upper-percentile advantage remains**: aerospike-py releases the GIL during I/O, while the official client serializes GIL acquisition through `run_in_executor`, increasing tail latency.
 
 ---
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/contributing.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/contributing.md
@@ -68,14 +68,14 @@ aerospike-py/
 
 ## 변경 가이드
 
-1. **Rust** (`rust/src/`): 편집 후 `maturin develop` 으로 재빌드
-2. **Python** (`src/aerospike_py/`): 변경 즉시 반영
-3. **Tests**: `tests/unit/` 또는 `tests/integration/` 에 추가
-4. **Docs**: `docs/docs/` 편집, `cd docs && npm start` 로 미리보기
+1. **Rust** (`rust/src/`): 파일을 수정한 뒤 `maturin develop`로 다시 빌드합니다.
+2. **Python** (`src/aerospike_py/`): 변경 사항이 즉시 반영됩니다.
+3. **Tests**: `tests/unit/` 또는 `tests/integration/`에 테스트를 추가합니다.
+4. **Docs**: `docs/docs/`를 수정하고 `cd docs && npm start`로 미리 봅니다.
 
 ## 아키텍처 노트
 
-- **Sync Client**: 전역 Tokio runtime, `py.allow_threads(|| RUNTIME.block_on(...))` 가 GIL release
-- **Async Client**: `pyo3_async_runtimes::tokio::future_into_py()` 가 Python coroutine 반환
-- **Type conversion**: `types/value.rs` 안에서 Python ↔ Rust `Value` enum
-- **Error mapping**: `errors.rs` 안에서 `aerospike_core::Error` → Python exception
+- **Sync Client**: 전역 Tokio runtime을 사용합니다. `py.allow_threads(|| RUNTIME.block_on(...))`가 GIL을 해제합니다.
+- **Async Client**: `pyo3_async_runtimes::tokio::future_into_py()`가 Python coroutine을 반환합니다.
+- **Type conversion**: `types/value.rs`에서 Python 값과 Rust `Value` enum을 서로 변환합니다.
+- **Error mapping**: `errors.rs`에서 `aerospike_core::Error`를 Python exception으로 변환합니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/faq.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/faq.md
@@ -6,27 +6,27 @@ description: Frequently asked questions about aerospike-py.
 
 ## aerospike-py 는 왜 Rust 로 작성되었나요?
 
-aerospike-py 는 [PyO3](https://pyo3.rs/) bindings 으로 [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust) 를 wrap 합니다. 순수 Python 이나 C-extension 접근 대비 다음 이점이 있습니다:
+aerospike-py는 [PyO3](https://pyo3.rs/)를 사용해 [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust)를 Python에 제공합니다. 순수 Python client나 C extension과 비교하면 다음과 같은 장점이 있습니다.
 
-- **Performance** — Rust 는 native code 로 컴파일됩니다. 벤치마크에 따르면 throughput 이 공식 C 기반 client 와 동등하거나 그 이상, 특히 batch 와 async workload 에서 두드러집니다.
-- **Memory safety** — Rust 의 ownership 모델이 use-after-free, buffer overflow, data race 같은 광범위한 버그 종류를 garbage collector 없이 제거합니다.
-- **Native async** — 내부 client 가 production-grade async runtime 인 Tokio 위에 빌드됩니다. `AsyncClient` 가 후순위가 아닌 first-class 시민입니다.
-- **Zero Python dependencies** — base install (`pip install aerospike-py`) 은 외부 Python dependency 가 없습니다. NumPy 와 OpenTelemetry 는 선택적 extras 입니다.
+- **Performance** — Rust는 native code로 컴파일됩니다. 벤치마크에서 공식 C 기반 client와 대등하거나 더 높은 throughput을 보이며, 특히 batch와 async workload에서 차이가 큽니다.
+- **Memory safety** — Rust의 ownership 모델은 garbage collector 없이 use-after-free, buffer overflow, data race 같은 오류를 방지합니다.
+- **Native async** — 내부 client가 Tokio 위에서 실행되므로 `AsyncClient`는 sync call을 감싸지 않고 native async I/O를 사용합니다.
+- **Zero Python dependencies** — 기본 설치(`pip install aerospike-py`)에는 외부 Python dependency가 없습니다. NumPy와 OpenTelemetry는 선택 사항입니다.
 
 ## GIL 처리는 어떻게 되나요?
 
-aerospike-py 는 모든 데이터베이스 I/O 동안 Python GIL (Global Interpreter Lock) 을 release 하므로, 한 request 가 in-flight 인 동안 다른 Python thread 들이 진행할 수 있습니다.
+aerospike-py는 모든 database I/O 중에 Python GIL(Global Interpreter Lock)을 해제합니다. 요청을 처리하는 동안 다른 Python thread도 실행될 수 있습니다.
 
 | Client | Mechanism |
 |--------|-----------|
-| **Sync `Client`** | `py.detach()` 가 GIL 을 release 한 뒤 `RUNTIME.block_on()` 이 내부 Tokio runtime 위에서 async Rust operation 을 실행. 결과 반환 시 GIL 재획득. |
-| **Async `AsyncClient`** | `future_into_py()` 가 Python awaitable 을 반환. 실제 작업은 Tokio runtime 위에서 GIL 없이 실행. future 완료 시 `Python::attach()` 가 GIL 을 재획득해 결과 전달. |
+| **Sync `Client`** | `py.detach()`가 GIL을 해제한 뒤 `RUNTIME.block_on()`이 내부 Tokio runtime에서 async Rust operation을 실행합니다. 결과를 반환할 때 GIL을 다시 획득합니다. |
+| **Async `AsyncClient`** | `future_into_py()`가 Python awaitable을 반환합니다. 실제 작업은 GIL을 잡지 않고 Tokio runtime에서 실행됩니다. future가 완료되면 `Python::attach()`가 GIL을 다시 획득해 결과를 전달합니다. |
 
-두 경우 모두, request 가 Aerospike cluster 로 이동하는 동안 GIL 이 **유지되지 않습니다** — 즉 Python thread (또는 다른 async task) 가 자유롭게 동시 실행 가능.
+두 방식 모두 Aerospike cluster와 통신하는 동안 GIL을 **잡지 않습니다**. 따라서 다른 Python thread나 async task가 동시에 실행될 수 있습니다.
 
 ## aerospike-py 는 thread-safe 한가요?
 
-네. 단일 `Client` 인스턴스를 여러 thread 에서 안전하게 공유할 수 있습니다. Rust client 가 내부적으로 connection pool 을 관리하며, 모든 공유 상태는 lock-free 또는 mutex-guarded 구조로 보호됩니다.
+네. 하나의 `Client` 인스턴스를 여러 thread에서 안전하게 공유할 수 있습니다. Rust client가 connection pool을 관리하며, 공유 상태는 lock-free 또는 mutex로 보호되는 구조에 저장됩니다.
 
 ```python
 import threading
@@ -50,13 +50,13 @@ client.close()
 
 ## Python free-threaded mode (3.14t) 를 지원하나요?
 
-네. aerospike-py 는 experimental free-threaded CPython (PEP 703) 위에서 빌드되고 실행됩니다. CI 가 Python 3.14t 에서 unit test **및** concurrency stress test 를 돌려 GIL 없이도 정확성을 검증합니다.
+네. aerospike-py는 experimental free-threaded CPython(PEP 703)에서 빌드되고 실행됩니다. CI는 Python 3.14t에서 unit test와 concurrency stress test를 실행해 GIL이 없어도 올바르게 동작하는지 확인합니다.
 
-핵심 로직이 Rust 에 있기 때문에 — Rust 자체 memory safety 보장 덕에 — GIL 이 완전히 제거되어도 라이브러리는 본질적으로 안전합니다.
+핵심 로직은 Rust의 memory-safety 보장을 따릅니다. 따라서 Python에서 GIL을 완전히 제거해도 안전하게 동작합니다.
 
 ## NumPy 는 필수인가요?
 
-아니요. NumPy 는 **선택적** dependency 입니다.
+아닙니다. NumPy는 **선택적 dependency**입니다.
 
 ```bash
 # Base install — NumPy 불필요
@@ -66,11 +66,11 @@ pip install aerospike-py
 pip install aerospike-py[numpy]
 ```
 
-NumPy 가 설치되어 있으면 `LazyBatchRecords.to_numpy(dtype)` (즉 `batch_read()` 반환값) 사용 가능 — NumPy structured array 로 backed 된 `NumpyBatchRecords` 를 생성하며, buffer fill 이 GIL released 상태로 실행되므로 결과를 `torch.from_numpy(...)` 에 zero-copy 로 바로 넘길 수 있습니다. `batch_write_numpy()` 가 structured array 로부터의 bulk write 방향 (역방향) 을 처리합니다. 다른 모든 기능은 NumPy 없이도 동일하게 동작합니다.
+NumPy를 설치하면 `batch_read()`가 반환한 `LazyBatchRecords`에서 `to_numpy(dtype)`를 호출할 수 있습니다. 이 메서드는 NumPy structured array를 사용하는 `NumpyBatchRecords`를 만듭니다. Client가 GIL을 해제한 상태에서 buffer를 채우므로 결과를 복사하지 않고 `torch.from_numpy(...)`에 바로 전달할 수 있습니다. Structured array를 bulk write할 때는 `batch_write_numpy()`를 사용합니다. 그 밖의 기능은 NumPy 없이도 동일하게 동작합니다.
 
 ## 공식 C client 에서 migrate 가능한가요?
 
-네. aerospike-py 는 near-drop-in replacement 로 설계되었습니다. import alias 패턴으로 전환이 직관적:
+네. aerospike-py는 기존 client를 거의 그대로 대체할 수 있도록 설계되었습니다. 먼저 import를 바꾸세요.
 
 ```python
 # Before
@@ -80,7 +80,7 @@ import aerospike
 import aerospike_py as aerospike
 ```
 
-대부분의 API 시그니처, 상수, exception class, policy dict 가 호환됩니다. 단계별 walkthrough 는 [Migration Guide](/docs/guides/migration), 자세한 비교표는 [API Comparison](/docs/guides/api-comparison) 참조.
+대부분의 API signature, 상수, exception class, policy dict가 호환됩니다. 단계별 절차는 [Migration Guide](/docs/guides/migration), 자세한 비교는 [API Comparison](/docs/guides/api-comparison)을 참고하세요.
 
 ## OpenTelemetry tracing 은 어떻게 활성화하나요?
 
@@ -104,11 +104,11 @@ client.close()
 aerospike_py.shutdown_tracing()
 ```
 
-Span 은 OTLP gRPC 로 export (기본 endpoint `http://localhost:4317`). 표준 `OTEL_*` 환경변수로 설정. 자세한 내용은 [Tracing guide](/docs/integrations/observability/tracing) 참조.
+Span은 OTLP gRPC로 export됩니다. 기본 endpoint는 `http://localhost:4317`입니다. 표준 `OTEL_*` 환경변수로 설정할 수 있으며, 자세한 내용은 [Tracing guide](/docs/integrations/observability/tracing)를 참고하세요.
 
 ## Prometheus metrics 는 어떻게 활성화하나요?
 
-aerospike-py 는 내장 Prometheus metrics HTTP server 를 ships 합니다:
+aerospike-py에는 Prometheus metrics를 제공하는 HTTP server가 내장되어 있습니다.
 
 ```python
 import aerospike_py
@@ -123,11 +123,11 @@ client.close()
 aerospike_py.stop_metrics_server()
 ```
 
-Prometheus 에서 `http://localhost:9464/metrics` 를 scrape. operation type 별 latency histogram 이 기록됩니다. 자세한 내용은 [Metrics guide](/docs/integrations/observability/metrics) 참조.
+Prometheus에서 `http://localhost:9464/metrics`를 scrape하세요. Operation type별 latency histogram이 기록됩니다. 자세한 내용은 [Metrics guide](/docs/integrations/observability/metrics)를 참고하세요.
 
 ## 어떤 Aerospike server 버전을 지원하나요?
 
-aerospike-py 는 **Aerospike Server 6.x 와 7.x** (Community 및 Enterprise) 에 대해 테스트됩니다. Aerospike Rust Client v2.0.0-alpha.9 위에 빌드됨.
+aerospike-py는 **Aerospike Server 6.x와 7.x**의 Community 및 Enterprise edition을 대상으로 테스트합니다. 내부적으로 Aerospike Rust Client v2.0.0-alpha.9를 사용합니다.
 
 ## bug 신고 또는 기능 요청은 어떻게 하나요?
 
@@ -136,4 +136,4 @@ GitHub 저장소에 issue 를 등록하세요:
 - **Bug report:** [github.com/aerospike-ce-ecosystem/aerospike-py/issues/new](https://github.com/aerospike-ce-ecosystem/aerospike-py/issues/new)
 - **Feature request:** 같은 링크 — 가능하면 "Feature Request" template 사용.
 
-bug 신고 시 Python 버전, OS, aerospike-py 버전 (`aerospike_py.__version__`), 그리고 minimal reproduction 을 포함해 주세요.
+Bug를 신고할 때는 Python 버전, OS, aerospike-py 버전(`aerospike_py.__version__`), 최소 재현 코드를 포함해 주세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -16,7 +16,7 @@ pip install aerospike-py
 
 **Requirements:** Python 3.10+ (CPython)
 
-소스 checkout 에서 `make run-aerospike-ce` 로 로컬 Aerospike CE 컨테이너를 시작합니다; `127.0.0.1:18710` 에서 listen. Aerospike 를 default service port 로 직접 시작했다면 아래 예제에서 `3000` 으로 바꿔 쓰세요.
+소스 checkout에서 작업한다면 `make run-aerospike-ce`를 실행해 로컬 Aerospike CE 컨테이너를 시작하세요. 컨테이너는 `127.0.0.1:18710`에서 요청을 받습니다. Aerospike를 기본 service port로 직접 실행했다면 아래 예제의 `18710`을 `3000`으로 바꾸세요.
 
 ## Quick Start
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/admin.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/admin.md
@@ -6,7 +6,7 @@ slug: /guides/admin
 description: User and role management for security-enabled Aerospike clusters.
 ---
 
-security-enabled Aerospike server 가 필요합니다.
+이 기능을 사용하려면 security가 활성화된 Aerospike server가 필요합니다.
 
 ## User Management
 
@@ -65,8 +65,8 @@ client.admin_drop_role("data_reader")
 
 ## Privilege Code
 
-`code` 는 int 상수 또는 canonical string 이름 (asadm 스타일) 둘 다 허용.
-이름은 case-insensitive 로 매칭, `_` 는 `-` 의 동의어
+`code`에는 int 상수 또는 asadm에서 사용하는 표준 string 이름을 지정할 수 있습니다.
+이름은 대소문자를 구분하지 않으며 `_`와 `-`를 같은 문자로 처리합니다.
 (`"sys_admin"` == `"sys-admin"`).
 
 | Constant | Name | 설명 |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/error-handling.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/error-handling.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 ## Exception Hierarchy
 
-모든 aerospike-py exception 은 `AerospikeError` 를 상속하며, `AerospikeError` 는 Python builtin `Exception` 을 상속:
+모든 aerospike-py exception은 `AerospikeError`를 상속합니다. `AerospikeError`는 Python builtin `Exception`을 상속합니다.
 
 ```
 Exception
@@ -56,7 +56,7 @@ from aerospike_py.exception import (
 
 ## 기본 error handling
 
-항상 더 구체적인 exception 을 더 넓은 것보다 먼저 catch:
+구체적인 exception을 먼저 catch하고, 더 넓은 exception은 나중에 처리하세요.
 
 ```python
 from aerospike_py.exception import (
@@ -85,7 +85,7 @@ except AerospikeError as e:
 
 ## Batch error handling
 
-Batch operation 은 개별 record 실패에 대해 exception 을 raise 하지 않음. 대신 각 `BatchRecord` 가 자체 result code 를 carry:
+Batch operation은 개별 record가 실패해도 exception을 발생시키지 않습니다. 대신 각 `BatchRecord`에 result code가 들어 있습니다.
 
 ```python
 keys = [("test", "demo", f"id-{i}") for i in range(100)]
@@ -125,7 +125,7 @@ for br in results.batch_records:
 
 ### `batch_write` 와 `in_doubt` flag
 
-`batch_write` 는 `in_doubt` flag 를 포함한 per-record 결과를 반환. `in_doubt` 가 `True` 일 때 일시적 error 에도 불구하고 write 가 server 에서 완료되었을 수 있음 (예: write 전송 후 timeout). non-idempotent operation 의 중복 write 방지 위해 retry 전 `in_doubt` 확인:
+`batch_write`는 record별 결과에 `in_doubt` flag를 포함합니다. 이 값이 `True`이면 transient error가 발생했어도 server에서 write를 완료했을 수 있습니다. Write를 보낸 뒤 timeout이 난 경우가 한 예입니다. Non-idempotent operation을 두 번 적용하지 않도록 retry 전에 `in_doubt`를 확인하세요.
 
 ```python
 from aerospike_py.exception import AerospikeError
@@ -228,7 +228,7 @@ async def fetch_many(client, keys: list) -> list[dict | None]:
 
 ### CREATE_ONLY (Insert-Only)
 
-record 가 이미 존재하면 `RecordExistsError` raise:
+Record가 이미 있으면 `RecordExistsError`가 발생합니다.
 
 ```python
 import aerospike_py as aerospike
@@ -289,7 +289,7 @@ except ClusterError as e:
 
 ### Reconnection 패턴
 
-node 가 down 되면 client 가 생존한 node 들로 자동 재연결. 다만 전체 cluster 가 도달 불가이면 operation 이 `ClusterError` 또는 `AerospikeTimeoutError` raise. retry-with-backoff 패턴이 transient failure 처리:
+Node가 중단되면 client는 정상 node로 자동 재연결합니다. 전체 cluster에 연결할 수 없으면 operation에서 `ClusterError`나 `AerospikeTimeoutError`가 발생합니다. Transient failure는 retry와 backoff로 처리할 수 있습니다.
 
 ```python
 import time
@@ -370,7 +370,7 @@ client.put(key, bins, policy=write_policy)
 | `sleep_between_retries` | `int` | `0` | retry 간 지연 (ms) |
 
 :::warning[기본 timeout 상호작용]
-기본값에서 `total_timeout` (1000ms) 이 `socket_timeout` (30000ms) 보다 **짧음**. 즉 개별 socket timeout 이 trigger 되기 전에 total deadline 에 도달. 실질적으로 30초 socket timeout 과 무관하게 1초 후 client 가 전체 operation (진행 중인 socket read/write 포함) 을 abort. `socket_timeout` 을 올리면 `total_timeout` 도 예상 latency 와 retry 횟수를 수용하는지 확인.
+기본값에서는 `total_timeout`(1,000 ms)이 `socket_timeout`(30,000 ms)보다 **짧습니다**. 따라서 개별 socket timeout보다 total deadline이 먼저 끝납니다. Client는 30초 socket timeout과 관계없이 1초 뒤에 진행 중인 socket I/O를 포함한 전체 operation을 중단합니다. `socket_timeout`을 늘릴 때는 `total_timeout`도 예상 latency와 retry 횟수를 수용하는지 확인하세요.
 :::
 
 :::tip

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/udf.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/udf.md
@@ -6,7 +6,7 @@ slug: /guides/udf
 description: Register, execute, and remove Lua UDFs on the Aerospike server.
 ---
 
-User Defined Function (UDF) 은 record 를 소유한 Aerospike server node 위에서 실행되는 Lua 스크립트.
+User-Defined Function(UDF)은 Lua 스크립트입니다. Aerospike는 대상 record를 소유한 server node에서 스크립트를 실행합니다.
 
 ## API
 
@@ -60,6 +60,6 @@ await client.udf_remove("counter")
 
 ## 비고
 
-- Lua 가 유일한 UDF 언어
-- UDF 변경이 모든 node 에 전파되는 데 수 초 소요
-- 최선의 성능을 위해 UDF 는 단순하게 유지
+- UDF는 Lua로만 작성할 수 있습니다.
+- UDF 변경 사항이 모든 node에 전달되기까지 몇 초가 걸립니다.
+- 성능을 위해 UDF는 단순하게 유지하세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/api-comparison.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/api-comparison.md
@@ -6,7 +6,7 @@ slug: /guides/api-comparison
 description: Side-by-side API comparison between the official C-based client and aerospike-py.
 ---
 
-**공식 C-based client** (PyPI `aerospike`) 와 **aerospike-py** (Rust-based) 의 포괄 비교. Migration 단계는 [Migration Guide](/docs/guides/migration) 참조.
+이 문서는 **공식 C 기반 client**(PyPI의 `aerospike`)와 Rust 기반 **aerospike-py**를 비교합니다. 단계별 이전 방법은 [Migration Guide](/docs/guides/migration)를 참고하세요.
 
 ## Connection
 
@@ -44,8 +44,8 @@ description: Side-by-side API comparison between the official C-based client and
 | Batch get | `client.get_many(keys)` | `client.batch_read(keys)` | **Method 명 변경**; sync 와 async 둘 다 `LazyBatchRecords` 반환 — materialise 하려면 `.to_dict()` 또는 `.to_numpy(dtype)` 호출 |
 | Batch exists | `client.exists_many(keys)` | `client.batch_read(keys, bins=[])` | existence check 용으로 빈 `bins` list |
 | Batch select | `client.select_many(keys, bins)` | `client.batch_read(keys, bins=bins)` | `batch_read` 로 통합 |
-| Batch operate | `client.batch_operate(keys, ops)` | `client.batch_operate(keys, ops)` | 동일; 공식 client 는 `aerospike_helpers` 사용 |
-| Batch remove | `client.batch_remove(keys)` | `client.batch_remove(keys)` | 동일; 공식 client 는 `aerospike_helpers` 사용 |
+| Batch operate | `client.batch_operate(keys, ops)` | `client.batch_operate(keys, ops)` | API는 같지만 공식 client는 `aerospike_helpers` 사용 |
+| Batch remove | `client.batch_remove(keys)` | `client.batch_remove(keys)` | API는 같지만 공식 client는 `aerospike_helpers` 사용 |
 | Batch read (NumPy) | N/A | `client.batch_read(keys).to_numpy(dt)` | **aerospike-py 신규** |
 | Batch write (NumPy) | N/A | `client.batch_write_numpy(data, ...)` | **aerospike-py 신규** |
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/architecture.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/architecture.md
@@ -9,13 +9,13 @@ import TabItem from '@theme/TabItem';
 
 # Architecture
 
-aerospike-py 는 [PyO3](https://pyo3.rs) 위에서 [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust) 를 사용한 [Aerospike](https://aerospike.com) 용 Python client 입니다. Rust core 가 native Python extension module 로 컴파일되어, Python application 이 거의 native I/O 성능을 누리면서도 type annotation 이 완전한 Pythonic API 를 유지합니다.
+aerospike-py는 [PyO3](https://pyo3.rs)를 사용해 [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust)를 native Python extension으로 제공합니다. Python application은 type annotation을 갖춘 익숙한 API를 사용하고, Rust core가 Aerospike I/O를 처리합니다.
 
 **주요 속성:**
 
-- **GIL-free I/O** — 모든 데이터베이스 호출 동안 GIL release, 다른 Python thread 와 coroutine 이 동시 실행 가능.
-- **Type-safe** — IDE autocompletion 과 type checker 지원을 위한 `.pyi` stub 동봉.
-- **Zero dependencies** — base install 은 외부 Python dependency 없음. NumPy 와 OpenTelemetry 는 선택적 extras.
+- **GIL-free I/O** — 모든 database call 중에 GIL을 해제하므로 다른 Python thread와 coroutine이 동시에 실행될 수 있습니다.
+- **Type-safe** — IDE autocompletion과 type checker를 지원하는 `.pyi` stub을 제공합니다.
+- **Zero dependencies** — 기본 설치에는 외부 Python dependency가 없습니다. NumPy와 OpenTelemetry는 선택 사항입니다.
 
 ## Layers
 
@@ -48,7 +48,7 @@ aerospike-py 는 [PyO3](https://pyo3.rs) 위에서 [Aerospike Rust Client](https
 
 ## Sync vs Async
 
-두 client 가 동일한 API surface 를 노출. 차이는 내부 Tokio runtime 위에서 I/O 를 schedule 하는 방식.
+두 client는 같은 API를 제공합니다. 차이는 내부 Tokio runtime에서 I/O를 schedule하는 방식입니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -63,7 +63,7 @@ print(record.bins)  # {"name": "Alice"}
 client.close()
 ```
 
-내부적으로 각 호출이 GIL 을 release 하고, `block_on()` 을 통해 Tokio runtime 위에서 Rust future 를 실행한 뒤, 결과를 반환하기 위해 GIL 을 재획득합니다. I/O 대기 동안 다른 Python thread 는 자유롭게 실행 가능.
+각 호출은 GIL을 해제하고 `block_on()`을 통해 Tokio runtime에서 Rust future를 실행합니다. 결과를 반환할 때만 GIL을 다시 획득하므로 I/O를 기다리는 동안 다른 Python thread가 실행될 수 있습니다.
 
   </TabItem>
   <TabItem value="async" label="Async">
@@ -91,7 +91,7 @@ await client.close()
 | Sync (sequential) | ~1.1x 느림 | ~1.1x 느림 | — |
 | Async (concurrent) | **2.1x 빠름** | **1.6x 빠름** | **3.4x 빠름** |
 
-Sync gap (~10%) 은 호출당 `block_on()` overhead 에서 옴. Async 가 aerospike-py 의 진가 — 동시 I/O 가 호출당 overhead 를 완전히 제거.
+Sync path에서는 호출마다 `block_on()` 비용이 들어 약 10%의 차이가 납니다. Async path는 여러 I/O를 겹쳐 실행해 이 scheduling 비용을 피합니다.
 
 ## Data Flow
 
@@ -99,12 +99,12 @@ Sync gap (~10%) 은 호출당 `block_on()` overhead 에서 옴. Async 가 aerosp
 
 1. Python dict `{"name": "Alice"}` 가 Rust `Vec<Bin>` 으로 변환.
 2. Key tuple `("test", "demo", "user1")` 이 Aerospike `Key` 로 (RIPEMD-160 digest 포함).
-3. GIL release. Rust client 가 bin 을 Aerospike wire protocol 로 직렬화해 TCP 로 전송.
+3. GIL을 해제합니다. Rust client가 bin을 Aerospike wire protocol로 직렬화해 TCP로 전송합니다.
 4. Server 가 ack. GIL 재획득하고 `None` 을 Python 으로 반환.
 
 ### Read path (`get`)
 
-1. GIL release. Rust client 가 read 요청 전송 후 응답 수신.
+1. GIL을 해제합니다. Rust client가 read request를 보내고 response를 받습니다.
 2. Rust `Record` (bins + generation + TTL) 가 Python tuple `(key, meta, bins)` 로 변환.
 3. Python wrapper layer 가 이를 `Record` NamedTuple 로 wrap:
 
@@ -162,7 +162,7 @@ for user_key, bins in batch.items():
   </TabItem>
 </Tabs>
 
-높은 throughput pipeline 을 위해 NumPy dtype 을 전달하면 zero-copy columnar 접근 가능한 structured array 를 받음. 자세한 내용은 [NumPy Batch Read guide](./crud/numpy-batch.md) 참조.
+처리량이 높은 pipeline에서는 NumPy dtype을 전달해 zero-copy columnar access를 지원하는 structured array를 받을 수 있습니다. 자세한 내용은 [NumPy Batch Read guide](./crud/numpy-batch.md)를 참고하세요.
 
 ```python
 import numpy as np
@@ -174,7 +174,7 @@ print(result.batch_records["score"].mean())  # columnar 접근
 
 ### batch_write
 
-각 record 는 `(key, bins)` tuple. 세 번째 element 로 per-record metadata (TTL 등) 를 선택적으로 추가:
+각 record는 `(key, bins)` tuple입니다. 세 번째 element에 TTL 같은 record별 metadata를 선택적으로 추가할 수 있습니다.
 
 ```python
 records = [
@@ -200,7 +200,7 @@ for br in results.batch_records:
 
 ## Error Handling
 
-server 로부터의 error 는 `AerospikeError` 를 root 로 하는 Python exception hierarchy 로 매핑. 각 exception 이 원본 error message 와 result code 를 carry.
+Server error는 `AerospikeError`를 최상위로 하는 Python exception hierarchy에 매핑됩니다. 각 exception에는 원본 error message와 result code가 들어 있습니다.
 
 ```python
 from aerospike_py.exception import RecordNotFound, AerospikeError
@@ -213,11 +213,11 @@ except AerospikeError as e:
     print(f"Unexpected error: {e}")
 ```
 
-Batch operation 의 경우 개별 실패는 exception 을 raise 하지 않음 — 각 `BatchRecord` 의 `br.result` 를 확인. 전체 exception hierarchy 와 batch error 패턴은 [Error Handling guide](./admin/error-handling.md) 참조.
+Batch operation은 개별 record가 실패해도 전체 batch에 exception을 발생시키지 않습니다. 각 `BatchRecord`의 `br.result`를 확인하세요. 전체 exception hierarchy와 batch error 처리 방법은 [Error Handling guide](./admin/error-handling.md)를 참고하세요.
 
 ## Observability
 
-aerospike-py 는 tracing, metrics, logging 에 대해 내장 지원. 셋 다 선택적이며 비활성 시 거의 0 overhead.
+aerospike-py는 tracing, metrics, logging을 기본으로 지원합니다. 세 기능 모두 선택 사항이며, 비활성화하면 overhead가 거의 없습니다.
 
 ### OpenTelemetry Tracing
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/client-config.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/client-config.md
@@ -42,7 +42,7 @@ client = aerospike.client(config).connect()
 
 ## Multi-Node Cluster
 
-client 는 도달 가능한 어떤 seed 에서든 모든 node 를 discover:
+Client는 연결할 수 있는 seed 하나를 통해 cluster의 모든 node를 찾습니다.
 
 ```python
 config: ClientConfig = {
@@ -66,14 +66,14 @@ config: ClientConfig = {
 }
 ```
 
-- `max_conns_per_node`: node 당 예상 동시 request 수에 맞춤
-- `min_conns_per_node`: cold-start latency 회피
-- `conn_pools_per_node`: node 당 connection pool 수. 8 이하 CPU core 머신은 보통 1 로 충분. 더 많은 core 머신은 값을 늘리면 pooled connection 의 lock contention 감소
-- `idle_timeout`: server `proto-fd-idle-ms` (default 60s) 보다 낮게 유지
+- `max_conns_per_node`: node당 예상 동시 request 수에 맞춥니다.
+- `min_conns_per_node`: connection을 미리 열어 cold-start latency를 줄입니다.
+- `conn_pools_per_node`: CPU core가 8개 이하인 machine에서는 보통 1이면 충분합니다. Core가 더 많다면 값을 늘려 connection pool의 lock contention을 줄일 수 있습니다.
+- `idle_timeout`: server의 `proto-fd-idle-ms`보다 낮게 설정합니다. 기본값은 60초입니다.
 
 ## Backpressure
 
-다수의 concurrent operation 을 실행할 때 (예: 수백 task 의 `asyncio.gather`) upstream connection pool 이 exhaust 되어 `NoMoreConnections` error 발생 가능. Backpressure 는 동시 in-flight operation 수를 제한:
+수백 개 task를 `asyncio.gather`로 실행하면 connection pool이 고갈되어 `NoMoreConnections`가 발생할 수 있습니다. Backpressure는 동시에 실행할 수 있는 operation 수를 제한해 이를 방지합니다.
 
 ```python
 config: ClientConfig = {
@@ -130,10 +130,10 @@ version: str = client.info_random_node("build")
 
 ## Health Check
 
-client 가 cluster health 를 확인하는 두 가지 방법 제공:
+Client는 두 가지 방법으로 cluster health를 확인합니다.
 
 - **`is_connected()`** — 로컬 상태만 확인 (I/O 없음). 빠르지만 cluster 가 일시적으로 도달 불가여도 `True` 반환 가능.
-- **`ping()`** — 임의 node 에 가벼운 `info("build")` command 전송. liveness 검증 위해 실제 네트워크 round-trip 수행. node 응답 시 `True`, 아니면 `False` 반환 (raise 안 함).
+- **`ping()`** — 임의의 node에 가벼운 `info("build")` command를 보내 실제 network round trip으로 liveness를 확인합니다. Node가 응답하면 `True`, 응답하지 않으면 exception 대신 `False`를 반환합니다.
 
 ```python
 # Kubernetes readiness probe / load-balancer health check
@@ -147,7 +147,7 @@ async def health():
     return {"status": "ok" if ok else "degraded"}
 ```
 
-백그라운드 **tend** 프로세스 (`tend_interval` 로 설정, default 1000 ms) 가 cluster membership 과 connection health 를 자동 모니터링. `ping()` 은 on-demand 검증으로 이를 보완.
+백그라운드 **tend** process는 cluster membership과 connection health를 자동으로 확인합니다. `tend_interval`의 기본값은 1,000 ms입니다. 즉시 상태를 확인해야 할 때는 `ping()`을 함께 사용하세요.
 
 ## Sync vs Async
 
@@ -189,5 +189,6 @@ finally:
   </TabItem>
 </Tabs>
 
-**Async 사용 적합:** 고동시성 web server, fan-out read, 혼합 I/O.
-**Sync 도 충분:** script, batch job, sequential pipeline.
+**Async가 적합한 경우:** 동시성이 높은 web server, fan-out read, 여러 종류의 I/O를 함께 처리하는 workload.
+
+**Sync가 적합한 경우:** script, batch job, 순차 pipeline.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/migration.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/migration.md
@@ -68,7 +68,7 @@ from aerospike_py.exception import RecordNotFound, RecordExistsError
 ```
 
 :::note[Exception Rename]
-Python builtin shadow 방지를 위해 `TimeoutError` → `AerospikeTimeoutError`, `IndexError` → `AerospikeIndexError`. 옛 이름은 deprecated alias 로 동작.
+Python built-in 이름과 겹치지 않도록 `TimeoutError`는 `AerospikeTimeoutError`로, `IndexError`는 `AerospikeIndexError`로 바뀌었습니다. 이전 이름도 deprecated alias로 동작합니다.
 :::
 
 ## CDT, Expressions, Query — 호환
@@ -92,7 +92,7 @@ records = query.results()
 
 ## Async Client (신규)
 
-공식 client 에 없는 기능:
+공식 client에는 없는 기능입니다.
 
 ```python
 import asyncio

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/performance-tuning.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/performance-tuning.md
@@ -80,19 +80,20 @@ client.put(key, bins, meta={"ttl": aerospike.TTL_NAMESPACE_DEFAULT}) # 네임스
 
 ## 동시성 및 Backpressure 튜닝
 
-고동시성 Python 서비스(FastAPI, Gunicorn 워커, Celery 팬아웃)는
-`aerospike-py` 하부의 두 계층을 포화시킬 수 있습니다:
+동시성이 높은 Python 서비스는 `aerospike-py` 아래의 두 계층을 포화시킬
+수 있습니다. FastAPI, Gunicorn worker, Celery fan-out workload가 여기에
+해당합니다.
 
 1. Rust 비동기 클라이언트를 구동하는 **내부 Tokio 런타임**.
 2. Aerospike 서버에 대한 **노드별 커넥션 풀**.
 
-증상에 따라 적절한 튜닝 노브를 선택하세요. 두 노브는 독립적입니다.
+두 계층은 서로 독립적으로 조정합니다. 나타나는 증상에 맞는 설정을 선택하세요.
 
 ### `AEROSPIKE_RUNTIME_WORKERS` (환경 변수)
 
-내장 비동기 런타임이 사용하는 Tokio 워커 스레드 수를 제어합니다. **기본값: `2`**.
-CPU 집약적 워크로드(PyTorch 추론, sklearn 등)와 함께 배치되었을 때
-CPU 오버헤드를 낮게 유지합니다.
+내장 async runtime이 사용하는 Tokio worker thread 수를 제어합니다.
+기본값은 `2`입니다. 같은 process에서 PyTorch inference나 scikit-learn처럼
+CPU를 많이 쓰는 작업을 실행할 때 overhead를 낮게 유지하기 위한 값입니다.
 
 ```bash
 # 동시 FastAPI 요청 10개 이상이 각각 batch_read를 호출하고
@@ -120,9 +121,9 @@ export AEROSPIKE_RUNTIME_WORKERS=4
 
 ### `max_concurrent_operations` (클라이언트 설정)
 
-매 순간 Rust 클라이언트로 디스패치되는 진행 중 작업 수의 상한을 둡니다.
-**기본값은 비활성화**(`0`, 오버헤드 없음). 값을 설정하면 초과 호출자는
-실패하거나 커넥션 풀을 고갈시키는 대신 슬롯을 **대기**합니다.
+Rust client에 동시에 전달할 operation 수의 상한을 설정합니다. 기본값 `0`은
+제한을 비활성화하며 overhead도 없습니다. 제한을 활성화하면 초과 요청은
+실패하거나 connection pool을 고갈시키는 대신 빈 slot을 기다립니다.
 
 ```python
 config = {
@@ -140,9 +141,9 @@ config = {
 - 슬롯이 비기 전에 `operation_queue_timeout_ms`가 만료되면
   `aerospike_py.BackpressureError`가 발생합니다.
 
-**값 선정:** `max_conns_per_node`(기본값 `256`)에 가깝되 그 이상은
-넘지 않도록 설정합니다. 3노드 클러스터의 경우 `64`가 풀 고갈을 막으면서
-처리량을 유지하는 보수적인 출발점입니다.
+**값 선택:** `max_conns_per_node`(기본값 `256`)에 가깝게 설정하되 이 값을
+넘기지 마세요. 3-node cluster에서는 `64`부터 시작하는 것이 안전합니다.
+Connection pool을 보호하면서 throughput을 유지할 수 있는 보수적인 값입니다.
 
 **활성화 시점:** `spawn_blocking` 큐가 정체될 가능성이 있는 고-팬아웃
 배치 읽기, 또는 상위 호출자(부하 테스트 중인 FastAPI)가 커넥션 풀이
@@ -180,9 +181,10 @@ await client.connect()
 | Gunicorn `--workers` | `2 * CPU` | 각 워커마다 자체 클라이언트 + Tokio 런타임. |
 | `max_conns_per_node` | `256` | `max_concurrent_operations`보다 충분히 높게 유지. |
 
-위 값을 사용한 단일 Gunicorn 워커는 풀을 고갈시키지 않고도 동시 진행
-중인 Aerospike 작업 ~64개를 유지할 수 있습니다. 클러스터 전체 부하 =
-`gunicorn_workers * max_concurrent_operations`이므로 이에 맞춰 사이징하세요.
+위 설정을 사용하면 Gunicorn worker 하나가 connection pool을 고갈시키지
+않고 약 64개의 Aerospike operation을 동시에 처리할 수 있습니다. Cluster가
+받는 전체 부하는 `gunicorn_workers * max_concurrent_operations`로 계산한 뒤
+그 값에 맞춰 capacity를 정하세요.
 
 ## Async Client
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch-write.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch-write.md
@@ -11,16 +11,16 @@ import TabItem from '@theme/TabItem';
 
 ## 개요
 
-`batch_write_numpy()` 는 **numpy structured array** 로부터 Aerospike 에 다수 record 를 직접 write. 각 row 가 별도의 write operation 이 되며, dtype field 가 Aerospike bin 으로 매핑됨.
+`batch_write_numpy()`는 **NumPy structured array**에서 Aerospike로 record를 직접 씁니다. 각 row는 하나의 write operation이 되고, 각 dtype field는 Aerospike bin에 매핑됩니다.
 
-- **Array-to-record 직접 매핑** — 중간 Python dict 나 loop 없음
-- **Key field 추출** — 지정된 dtype field (default `_key`) 가 record 의 user key 로 사용
-- **자동 bin 매핑** — `_` prefix 없는 모든 field 가 bin 이 됨
-- **Batch 실행** — 모든 row 가 single batch 호출로 write
+- **Array-to-record 직접 매핑** — 중간 Python dict나 loop를 만들지 않습니다.
+- **Key field 추출** — 지정한 dtype field(기본값 `_key`)를 record의 user key로 사용합니다.
+- **자동 bin 매핑** — 이름이 `_`로 시작하지 않는 모든 field가 bin이 됩니다.
+- **Batch 실행** — 모든 row를 한 번의 batch call로 씁니다.
 
 :::tip[언제 쓰나]
 
-데이터가 이미 numpy array 일 때 `batch_write_numpy()` 사용 (예: ML feature store, sensor 데이터 pipeline, scientific dataset). 일반 Python dict 의 경우 `put()` 또는 표준 batch operation 사용.
+데이터가 이미 NumPy array에 있다면 `batch_write_numpy()`를 사용하세요. ML feature store, sensor data pipeline, scientific dataset이 대표적인 예입니다. Python dict를 쓸 때는 `put()`이나 표준 batch operation을 사용합니다.
 
 :::
 
@@ -131,7 +131,7 @@ numpy structured array             Aerospike
 ```
 
 1. `key_field` (default `"_key"`) column 이 각 record 의 user key 로 추출됨
-2. `_` 로 prefix 되지 **않은** 모든 field 가 Aerospike bin 이 됨
+2. `_`로 시작하지 **않은** 나머지 field는 Aerospike bin이 됩니다.
 3. `_` 로 prefix 된 field (key field 외) 는 무시됨
 
 ## Key Field
@@ -422,7 +422,7 @@ results = client.batch_write_numpy(data, "test", "users", dtype)
 
 ## Transient 실패에 대한 Retry
 
-`retry > 0` 이면 transient error (timeout, device overload, key busy, server memory, partition unavailable) 로 실패한 record 가 exponential backoff 로 자동 재시도. 영구 error (key exists, record too big) 는 절대 retry 안 함.
+`retry > 0`이면 transient error(timeout, device overload, key busy, server memory, partition unavailable)가 발생한 record를 exponential backoff로 자동 재시도합니다. Key exists나 record too big 같은 영구 error는 재시도하지 않습니다.
 
 ```python
 # transient 실패 시 최대 3회 retry
@@ -434,10 +434,10 @@ for br in results.batch_records:
         print(f"Write failed for key {br.key} after retries (code={br.result})")
 ```
 
-Backoff 스케줄은 시도 사이 10ms, 20ms, 40ms, ... 로 500ms 에서 cap. 매 retry 마다 실패한 record 만 재제출 (전체 batch 아님).
+Retry 간격은 10 ms에서 시작해 20 ms, 40 ms 순으로 늘어나며 최대 500 ms입니다. 매 retry에서는 전체 batch가 아니라 실패한 record만 다시 보냅니다.
 
 :::tip
-간헐적 transient 실패가 예상되는 대형 bulk ingestion 에선 `retry=3` 이 좋은 시작점. application 안에서 retry 로직을 full control 하고 싶을 땐 `retry=0` (default).
+대규모 bulk ingestion에서 간헐적인 transient failure가 예상된다면 `retry=3`부터 시작하세요. Application에서 retry logic을 직접 제어하려면 기본값인 `retry=0`을 사용합니다.
 :::
 
 ## Error Handling
@@ -456,11 +456,11 @@ except AerospikeError as e:
 
 ## Best Practice
 
-- **dtype 을 데이터에 맞춤** — 메모리와 네트워크 전송 절감 위해 충분한 최소 dtype 사용 (`"f8"` 대신 `"f4"`, `"i8"` 대신 `"i2"`)
-- **Batch size** — 최적 성능을 위해 호출당 100-5,000 row 유지
-- **Key field 규약** — 컨벤션 일관성 위해 default key field 로 `"_key"` 사용
+- **dtype을 데이터에 맞추기** — 메모리 사용량과 네트워크 전송량을 줄이려면 데이터를 표현할 수 있는 가장 작은 dtype을 사용하세요(`"f8"` 대신 `"f4"`, `"i8"` 대신 `"i2"`).
+- **Batch size** — 호출 하나에 100~5,000개 row를 넣을 때 성능이 가장 좋습니다.
+- **Key field 규칙** — 일관성을 위해 기본 key field인 `"_key"`를 사용하세요.
 - **Underscore prefix** — `_` 로 시작하는 field 는 bin 에서 제외, metadata field 에 활용
-- **batch_read 로 roundtrip** — 효율적 read-back 을 위해 동일 dtype field (`_key` 제외) 로 `batch_read(...).to_numpy(dtype)` 사용 (buffer fill 이 GIL released 상태로 실행)
+- **`batch_read`로 다시 읽기** — 같은 dtype에서 `_key`를 제외한 field를 사용해 `batch_read(...).to_numpy(dtype)`를 호출하세요. GIL을 해제한 상태에서 buffer를 채우므로 효율적입니다.
 - **대형 dataset** — 큰 array 를 chunk 로 나눠 batch 단위 write:
 
 ```python

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch.md
@@ -9,15 +9,15 @@ description: Use batch_read with numpy structured arrays for high-performance co
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-`batch_read(...).to_numpy(dtype)` 는 Python object 대신 **numpy structured array** 를 반환:
+`batch_read(...).to_numpy(dtype)`는 batch result를 record별 Python object 대신 **NumPy structured array**로 materialize합니다.
 
-- **Zero-copy columnar access** — `batch.batch_records["temperature"]` 가 numpy array 반환; `torch.from_numpy(...)` 와 결합해 O(1) tensor hand-off
-- **Fill 동안 GIL release** — per-record `Value → buffer` write 가 GIL 해제된 상태로 발생, 다른 asyncio task / thread 가 동시 실행 가능
-- **Vectorised 연산** — 결과에 numpy/pandas 직접 사용
-- **메모리 효율** — Rust 가 numpy buffer 에 직접 write, Python object 우회
+- **Zero-copy column access** — `batch.batch_records["temperature"]`는 NumPy array를 반환합니다. `torch.from_numpy(...)`에 전달하면 O(1)로 tensor를 만들 수 있습니다.
+- **GIL-free buffer fill** — Client는 GIL을 해제한 상태에서 record별 `Value`를 buffer에 씁니다. 이 동안 다른 asyncio task와 thread가 실행될 수 있습니다.
+- **Vectorized 연산** — 결과를 NumPy나 pandas에서 바로 사용할 수 있습니다.
+- **낮은 object overhead** — Rust가 NumPy buffer에 직접 쓰므로 value마다 Python object를 만들지 않습니다.
 
 :::tip[Performance]
-record 10K + bin 5개에서 `lazy_records.to_dict()` materialisation 대비 ~60K 개 중간 Python object 제거.
+Record 10,000개와 bin 5개를 읽을 때 `lazy_records.to_dict()`로 materialize하는 방식보다 중간 Python object를 약 60,000개 줄입니다.
 :::
 
 ## 설치
@@ -26,7 +26,7 @@ record 10K + bin 5개에서 `lazy_records.to_dict()` materialisation 대비 ~60K
 pip install "aerospike-py[numpy]"
 ```
 
-선택적 dependency 로 `numpy>=2.0` 설치됨.
+선택적 dependency로 `numpy>=2.0`을 설치합니다.
 
 ## Quick Start
 
@@ -116,17 +116,17 @@ asyncio.run(main())
 
 ## NumpyBatchRecords
 
-`batch_read()` 가 반환하는 `LazyBatchRecords` 에 `.to_numpy(dtype)` 를 호출하면 `NumpyBatchRecords` 객체를 얻음. structured-array fill 이 GIL release 된 상태로 실행되어 결과를 `torch.from_numpy(...)` 에 zero-copy 로 바로 넘길 수 있음:
+`batch_read()`가 반환한 `LazyBatchRecords`에서 `.to_numpy(dtype)`를 호출하면 `NumpyBatchRecords` 객체를 얻습니다. Client가 GIL을 해제하고 structured array를 채우므로 결과를 복사하지 않고 `torch.from_numpy(...)`에 바로 전달할 수 있습니다.
 
-:::warning[Missing read 는 silently zero-fill]
+:::warning[찾지 못한 record는 0으로 채워짐]
 
-`result_codes[i] != 0` 인 row (`RecordNotFound` 포함) 는 data 와 meta entry 가 dtype 의 zero 값으로 남음 — buffer 만으로는 실제로 bin 이 zero 인 record 와 구분 불가. averaging, summing, inference 전에 항상 `batch.result_codes == 0` 으로 mask (또는 `lazy_records.found_count()` 확인).
+`RecordNotFound`를 포함해 `result_codes[i] != 0`인 row는 data와 metadata가 dtype의 0 값으로 남습니다. Buffer만 봐서는 실제 bin 값이 0인 record와 구분할 수 없습니다. 평균이나 합계를 계산하거나 inference에 전달하기 전에 `batch.result_codes == 0`으로 mask하거나 `lazy_records.found_count()`를 확인하세요.
 
 :::
 
 | Attribute | Type | 설명 |
 |-----------|------|-------------|
-| `batch_records` | `np.ndarray` | 사용자 지정 dtype 의 structured array |
+| `batch_records` | `np.ndarray` | 사용자 지정 dtype을 사용하는 structured array |
 | `meta` | `np.ndarray` | dtype `[("gen", "u4"), ("ttl", "u4")]` 의 structured array |
 | `result_codes` | `np.ndarray` | per-record result code 의 `int32` array (0 = success) |
 | `_map` | `dict` | key 기반 lookup 을 위한 `{primary_key: index}` 매핑 |
@@ -194,7 +194,7 @@ print(f"Failed: {failed.sum()} / {len(batch.result_codes)}")
 
 ## dtype 정의
 
-dtype field 이름이 Aerospike bin 이름과 정확히 일치해야 함.
+dtype field 이름은 Aerospike bin 이름과 정확히 일치해야 합니다.
 
 ### Numeric bin
 
@@ -323,7 +323,7 @@ valid_data = batch.batch_records[success_mask]
 
 ### Missing Bin
 
-record 가 존재하지만 bin 이 missing 이면 field 가 zero 로 default (해당 dtype 의 numpy zero-value):
+Record는 있지만 bin이 없으면 해당 field에는 dtype에 맞는 NumPy zero value가 들어갑니다.
 
 ```python
 # record 가 "temperature" 는 있지만 "humidity" 가 없음
@@ -364,11 +364,11 @@ print(hot_sensors.describe())
 
 ## Best Practice
 
-- **dtype 을 bin 에 맞춤** — dtype field 이름이 Aerospike bin 이름과 일치
+- **dtype을 bin에 맞추기** — dtype field 이름을 Aerospike bin 이름과 같게 지정하세요.
 - **`bins` 파라미터 사용** — `.to_numpy(dtype)` 와 결합해 네트워크 전송 줄이기
 - **`result_codes` 확인** — 분석 전 실패한 record 필터링
-- **충분한 최소 dtype 사용** — 메모리 절감 위해 `"f8"` 대신 `"f4"`, `"i8"` 대신 `"i2"`
-- **Batch size** — 최적 성능을 위해 batch 를 100-5,000 key 로 유지
+- **데이터를 표현할 수 있는 가장 작은 dtype 사용** — 메모리를 줄이려면 `"f8"` 대신 `"f4"`, `"i8"` 대신 `"i2"`를 사용하세요.
+- **Batch size** — batch 하나에 100~5,000개 key를 넣을 때 성능이 가장 좋습니다.
 - **Vector 데이터** — embedding 을 `tobytes()` blob 으로 저장하고 sub-array dtype 으로 read
 
 ## API Reference
@@ -391,7 +391,7 @@ lazy_records: LazyBatchRecords = await client.batch_read(
 batch: NumpyBatchRecords = lazy_records.to_numpy(dtype)
 ```
 
-`LazyBatchRecords.to_numpy(dtype)` 호출은 GIL 해제된 상태로 structured-array materialisation 을 수행 — per-record fill loop 가 raw `ptr::write_unaligned` write 시퀀스라, sibling Python 작업 (다른 asyncio task, torch inference thread) 이 buffer fill 중 GIL 보유 가능.
+`LazyBatchRecords.to_numpy(dtype)`는 GIL을 해제한 상태에서 structured array를 materialize합니다. Record별 fill loop는 raw `ptr::write_unaligned`를 사용하므로 buffer를 채우는 동안 다른 asyncio task나 PyTorch inference thread가 GIL을 사용할 수 있습니다.
 
 | Parameter | Type | Default | 설명 |
 |-----------|------|---------|-------------|

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-guide.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-guide.md
@@ -6,7 +6,7 @@ slug: /guides/numpy-integration
 description: High-performance batch operations using NumPy structured arrays.
 ---
 
-NumPy structured array 를 사용한 고성능 batch read/write. 데이터가 Rust 를 통해 Aerospike 와 NumPy buffer 사이를 직접 흘러, per-element Python object 생성을 우회.
+NumPy structured array로 batch read와 write의 성능을 높일 수 있습니다. Rust client는 Aerospike와 NumPy buffer 사이에서 데이터를 직접 옮기므로 element마다 Python object를 만들지 않습니다.
 
 :::note[Requirement]
 `numpy >= 2.0` 필요. 설치: `pip install aerospike-py[numpy]`
@@ -26,7 +26,7 @@ NumPy structured array 를 사용한 고성능 batch read/write. 데이터가 Ru
 
 ### dtype 정의
 
-dtype 의 각 field 가 Aerospike bin name 으로 매핑:
+dtype의 각 field는 이름이 같은 Aerospike bin에 매핑됩니다.
 
 ```python
 import numpy as np
@@ -103,7 +103,7 @@ results = client.batch_write_numpy(data, "test", "demo", dtype)
 
 - 기본 key field: `"_key"` (`key_field` 파라미터로 설정 가능)
 - `_` 로 prefix 된 field 는 bin 에서 제외 (record key 로는 `_key` 만 사용)
-- 다른 모든 field 가 Aerospike bin 이 됨
+- 나머지 모든 field는 Aerospike bin이 됩니다.
 
 ```python
 # 사용자 정의 key field 이름
@@ -175,15 +175,15 @@ result = client.batch_read(keys, bins=["score", "count"]).to_numpy(dtype)
 | `batch_records` | bin 데이터의 structured numpy array |
 | `meta` | `(gen, ttl)` structured array |
 | `result_codes` | `int32` array (0 = success) |
-| `get(key)` | primary key 로 단일 record 가져오기 |
+| `get(key)` | primary key로 record 하나 읽기 |
 | `len(result)` | record 수 |
 | `key in result` | primary key 존재 여부 |
 | `for r in result` | record 순회 |
 
 ## Performance 팁
 
-1. **dtype 사전 할당** — dtype 을 한 번 정의하고 호출 간 재사용
-2. **dtype 을 데이터에 맞춤** — 충분한 최소 타입 사용 (`i4` vs `i8`, `f4` vs `f8`)
+1. **dtype 미리 정의하기** — dtype을 한 번 정의한 뒤 여러 호출에서 재사용하세요.
+2. **dtype을 데이터에 맞추기** — 데이터를 표현할 수 있는 가장 작은 타입을 사용하세요(`i4` 대 `i8`, `f4` 대 `f8`).
 3. **Batch size** — 최적 범위: 호출당 500–5000 record
 4. **fixed-length string 사용** — `S16` 이 가변 길이 대안보다 훨씬 빠름
 5. **server-side filter** — expression filter 와 결합해 데이터 전송 줄이기

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/operations.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/operations.md
@@ -9,7 +9,7 @@ description: Atomic server-side List (31 ops) and Map (27 ops) collection data t
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-`client.operate()` 를 통한 atomic server-side collection data type (CDT) operation.
+`client.operate()`로 서버에서 원자적으로 실행하는 collection data type(CDT) operation을 설명합니다.
 
 ```python
 from aerospike_py import list_operations as list_ops
@@ -22,7 +22,7 @@ import aerospike_py as aerospike
 
 ## List CDT Operations
 
-각 `list_ops.*` function 은 `client.operate()` 또는 `client.operate_ordered()` 에 전달할 operation dict 를 반환:
+각 `list_ops.*` 함수는 `client.operate()` 또는 `client.operate_ordered()`에 전달할 operation dict를 반환합니다.
 
 ```python
 ops = [

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/read.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/read.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 ## Key
 
-모든 record 는 key tuple `(namespace, set, primary_key)` 로 식별:
+모든 record는 `(namespace, set, primary_key)` key tuple로 식별합니다.
 
 ```python
 key = ("test", "demo", "user1")      # string PK
@@ -64,7 +64,7 @@ if result.meta is not None:
 
 ## Batch Read
 
-다수 record 를 단일 네트워크 호출로 read.
+여러 record를 한 번의 network call로 읽습니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -104,6 +104,6 @@ for user_key, bins in batch.items():
 
 ## 팁
 
-- **Batch size**: batch 당 100-5,000 key 가 최적. 너무 크면 timeout 가능.
-- **Timeout**: 큰 batch operation 의 경우 `total_timeout` 증가.
-- **Error handling**: 개별 batch record 는 독립적으로 실패 가능. `br.record` 가 `None` 인지 항상 확인.
+- **Batch size**: batch당 100–5,000개 key를 권장합니다. Batch가 너무 크면 timeout이 발생할 수 있습니다.
+- **Timeout**: 큰 batch operation에는 더 긴 `total_timeout`을 사용하세요.
+- **Error handling**: 각 batch record는 독립적으로 실패할 수 있습니다. 항상 `br.record`가 `None`인지 확인하세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/write.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/write.md
@@ -108,7 +108,7 @@ client.touch(key, val=600)  # 또는: await client.touch(key, val=600)
 
 ## Multi-Operation (Operate)
 
-단일 record 에 여러 operation 을 atomic 하게 실행.
+한 record에 여러 operation을 atomic하게 실행합니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -141,7 +141,7 @@ result = await client.operate_ordered(key, ops)
 
 ## Batch Write
 
-**per-record bin** 으로 다수 record 를 한 batch 호출로 write. `put()` 의 batch 버전 — 각 record 가 다른 bin name 과 value 를 가질 수 있음.
+한 번의 batch call로 여러 record의 **per-record bin**을 씁니다. `put()`과 마찬가지로 record마다 서로 다른 bin name과 value를 사용할 수 있습니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -226,7 +226,7 @@ results = await client.batch_write(records_with_ttl)
   </TabItem>
 </Tabs>
 
-**auto-recovery retry:** transient error (timeout, device overload, key busy) 로 실패한 record 는 exponential backoff 로 자동 재시도:
+**자동 retry:** `retry`를 설정하면 timeout, device overload, key busy 같은 transient error를 exponential backoff로 다시 시도합니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -248,7 +248,7 @@ results = await client.batch_write(records, retry=5)
 </Tabs>
 
 :::tip[in_doubt flag]
-`br.in_doubt` 가 `True` 일 때 error 에도 불구하고 write 가 server 에서 완료되었을 수 있음 (예: write 전송 후 timeout). non-idempotent operation 의 중복 write 방지 위해 retry 전 `in_doubt` 확인.
+`br.in_doubt`가 `True`이면 error가 발생했어도 server에서 write를 완료했을 수 있습니다. Write를 보낸 뒤 timeout이 난 경우가 한 예입니다. Non-idempotent operation을 두 번 적용하지 않도록 retry 전에 `in_doubt`를 확인하세요.
 :::
 
 ## Batch Operate / Remove
@@ -291,4 +291,4 @@ except RecordGenerationError:
 
 - **Batch size**: batch 당 100-5,000 key 가 최적. 너무 크면 timeout 가능.
 - **Timeout**: 큰 batch operation 의 경우 `total_timeout` 증가.
-- **Error handling**: 개별 batch record 는 독립적으로 실패 가능. `br.record` 가 `None` 인지 항상 확인.
+- **Error handling**: Batch 안의 record는 각각 독립적으로 실패할 수 있습니다. 항상 `br.record`가 `None`인지 확인하세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/expression-filters.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/expression-filters.md
@@ -6,10 +6,10 @@ slug: /guides/expression-filters
 description: Server-side record filtering with 104+ composable expression functions.
 ---
 
-read, write, query operation 동안 server-side filtering. server 가 expression 을 평가하여 매칭되는 record 만 반환 (또는 수정).
+Expression filter는 read, write, query operation에 적용할 수 있습니다. Server가 expression을 평가해 조건에 맞는 record만 반환하거나 수정합니다.
 
 :::note[서버 요구사항]
-Expression filter 는 Aerospike Server **5.2+** 필요.
+Expression filter를 사용하려면 Aerospike Server **5.2 이상**이 필요합니다.
 :::
 
 ## Import

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/query-scan.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/query-scan.md
@@ -8,7 +8,7 @@ description: Secondary index queries with predicates.
 
 ## Secondary Index Query
 
-Query 는 query 대상 bin 에 secondary index 가 필요합니다.
+Query하려는 bin에는 secondary index가 있어야 합니다.
 
 ### Index 생성 + 데이터 insert
 
@@ -58,7 +58,7 @@ query.where(predicates.between("age", 25, 35))
 query.foreach(process)
 ```
 
-callback 에서 `False` 반환 시 조기 종료:
+Callback에서 `False`를 반환하면 순회를 일찍 끝낼 수 있습니다.
 
 ```python
 count = 0
@@ -105,4 +105,4 @@ point = '{"type":"Point","coordinates":[126.978, 37.5665]}'
 query.where(predicates.geo_contains_geojson_point("coverage", point))
 ```
 
-secondary index 없이 server-side filtering 은 [Expression Filters](./expression-filters.md) 참조.
+Secondary index 없이 server-side filtering을 사용하려면 [Expression Filters](./expression-filters.md)를 참고하세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/troubleshooting.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/troubleshooting.md
@@ -6,7 +6,7 @@ description: Common problems and solutions when using aerospike-py.
 
 # Troubleshooting
 
-aerospike-py 사용 시 자주 만나는 문제, 원인, 해결책을 다룹니다.
+이 문서에서는 자주 발생하는 aerospike-py error의 원인을 확인하고 해결 방법을 안내합니다.
 
 ## 연결 문제
 
@@ -43,7 +43,7 @@ aerospike_py.ClusterError: Failed to connect to host(s)
    }).connect()
    ```
 
-3. 컨테이너에서 실행 시 port mapping 이 올바르고 host network 에서 접근 가능한지 확인.
+3. Aerospike를 container에서 실행한다면 service port가 올바르게 mapping되었고 host에서 접근할 수 있는지 확인하세요.
 
 ### TimeoutError
 
@@ -185,7 +185,7 @@ ERROR: Failed building wheel for aerospike-py
 
 **해결책:**
 
-1. 대부분의 사용자는 pre-built wheel 사용 가능 — pip 만 사용:
+1. 대부분의 사용자는 PyPI의 pre-built wheel을 설치하면 됩니다.
    ```bash
    pip install aerospike-py
    ```
@@ -344,11 +344,11 @@ TypeError: numpy dtype mismatch
 
 ## Python 3.14t (Free-Threaded) 노트
 
-aerospike-py 는 Python 3.14t (free-threaded / no-GIL build) 를 지원합니다. 다만 다음을 유의:
+aerospike-py는 Python 3.14t free-threaded build를 지원합니다. 다음 사항을 확인하세요.
 
-- **Experimental 지원**: Free-threaded Python 은 CPython 에서 아직 experimental. 일부 third-party 라이브러리가 제대로 동작 안 할 수 있음.
-- **Thread safety**: aerospike-py 의 `Client` 와 `AsyncClient` 는 thread-safe. Rust client 가 내부 동기화 처리.
-- **Performance 특성**: GIL 없이 Python thread 간 진정한 병렬성이 가능. 다만 GIL contention 이 더 이상 요인이 아니므로 Tokio runtime worker 수 (`AEROSPIKE_RUNTIME_WORKERS`) 튜닝이 필요할 수 있음.
+- **Experimental 지원**: Free-threaded Python은 아직 CPython의 experimental 기능입니다. 일부 third-party library가 올바르게 동작하지 않을 수 있습니다.
+- **Thread safety**: aerospike-py의 `Client`와 `AsyncClient`는 thread-safe합니다. Rust client가 내부 synchronization을 처리합니다.
+- **Performance 특성**: GIL이 없으면 Python thread를 병렬로 실행할 수 있습니다. Workload에 따라 Tokio runtime worker 수(`AEROSPIKE_RUNTIME_WORKERS`)를 조정해야 할 수 있습니다.
 
 free-threaded Python 특화 문제 발생 시:
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/fastapi.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/fastapi.md
@@ -128,7 +128,7 @@ async def delete_user(user_id: str, request: Request):
 
 ## 전체 예제
 
-[`examples/sample-fastapi/`](https://github.com/aerospike-ce-ecosystem/aerospike-py/tree/main/examples/sample-fastapi) 디렉토리에 router 11개, Pydantic 모델, Docker Compose 셋업, 테스트를 포함한 완전한 애플리케이션이 있습니다.
+[`examples/sample-fastapi/`](https://github.com/aerospike-ce-ecosystem/aerospike-py/tree/main/examples/sample-fastapi)에는 router 11개, Pydantic 모델, Docker Compose 설정, 테스트를 갖춘 완성된 애플리케이션이 있습니다.
 
 ```bash
 cd examples/sample-fastapi

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/internal-stage-metrics.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/internal-stage-metrics.md
@@ -5,11 +5,11 @@ sidebar_position: 4
 description: Fine-grained per-stage timing for debugging aerospike-py latency, with zero production overhead when disabled.
 ---
 
-aerospike-py 는 `db_client_operation_duration_seconds` 옆에 두 번째, 더 세분화된 histogram 을 노출합니다:
+`db_client_operation_duration_seconds`와 함께 더 세밀한 timing을 제공하는 두 번째 histogram도 사용할 수 있습니다.
 
 **`db_client_internal_stage_seconds`** — 단일 `batch_read` 를 내부 stage 별로 쪼개는 histogram (key parsing, Tokio scheduling, I/O, `to_dict` / `to_numpy` 변환, event-loop resume 등).
 
-운영용 metric 은 항상 켜져 있지만, internal stage profiling 은 **기본 off**. 비활성 상태에서는 모든 stage timer 호출 지점이 `Instant::now()` 를 완전히 skip — 비활성 path 비용은 batch 당 single atomic load (~1ns) 수준.
+운영 metric은 항상 활성화되지만 internal stage profiling은 **기본적으로 꺼져 있습니다**. 비활성 path에서는 각 timer가 `Instant::now()`를 건너뛰고 atomic load 한 번만 실행합니다. Batch당 비용은 약 1 ns입니다.
 
 ## Quick Start
 
@@ -38,7 +38,7 @@ with aerospike_py.internal_stage_profiling():
 | `aerospike_py.set_internal_stage_metrics_enabled(True)` | 애플리케이션 코드에서 런타임 토글. |
 | `with aerospike_py.internal_stage_profiling(): ...` | 일시적 — exit 시 이전 상태 복원. |
 
-env var 는 native module init 시 1회 읽음. 런타임 호출이 env var 보다 우선.
+Native module은 초기화할 때 env var를 한 번 읽습니다. 이후 runtime call을 사용하면 env var 값을 덮어씁니다.
 
 ## `db_client_internal_stage_seconds`
 
@@ -80,7 +80,7 @@ Stage profiling 은 측정 가능한 latency 를 추가합니다: 각 `batch_rea
 | p95 | 4.67 ms | 7.61 ms | +2.94 ms |
 | p99 | 4.93 ms | 9.51 ms | +4.58 ms |
 
-production 에선 **off** 로 두고 latency regression 을 능동적으로 추적할 때만 flip on.
+Production에서는 **꺼 둡니다**. Latency regression을 조사할 때만 활성화하세요.
 
 ## Scraping 과 Visualization
 
@@ -95,7 +95,7 @@ histogram_quantile(
 )
 ```
 
-모든 stage 의 stacked timeseries 로 각 `batch_read` 가 시간을 어디 쓰는지 한눈에 파악:
+모든 stage를 stacked time series로 표시하면 `batch_read`가 어느 단계에서 시간을 쓰는지 바로 확인할 수 있습니다.
 
 ```promql
 sum by (stage, db_operation_name) (
@@ -113,7 +113,7 @@ sum by (stage, db_operation_name) (
 [aerospike-py] internal_stage_metrics_enabled=False (AEROSPIKE_PY_INTERNAL_METRICS=None)
 ```
 
-dashboard 가시성을 위해 본인 앱에서 Prometheus gauge 로 publish 도 가능:
+Dashboard에서 확인하려면 애플리케이션이 이 값을 Prometheus gauge로 내보내도록 구성할 수도 있습니다.
 
 ```python
 from prometheus_client import Gauge
@@ -127,7 +127,7 @@ g.set(1 if aerospike_py.is_internal_stage_metrics_enabled() else 0)
 ## Troubleshooting
 
 **`db_client_internal_stage_seconds` 가 `/metrics` 에는 보이는데 sample 이 없음**
-`# HELP` / `# TYPE` header 는 항상 등록됨; sample 은 toggle 이 ON 이고 **그리고** `batch_read` 가 실제로 완료된 후에만 나타남.
+`# HELP`와 `# TYPE` header는 항상 등록됩니다. Sample은 toggle을 켠 상태에서 `batch_read`가 한 번 이상 끝난 뒤에 나타납니다.
 
 **context-manager block 에서 exception 발생 — flag 가 아직 ON?**
 아니요. `internal_stage_profiling()` 이 `finally` 로 이전 상태 복원, `contextlib.contextmanager` 의미와 동일.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/logging.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/logging.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 description: Rust-to-Python logging bridge for observing Aerospike client internals.
 ---
 
-내장 **Rust-to-Python logging bridge** 가 모든 내부 Rust log 를 Python `logging` 모듈로 forward 합니다. import 시 자동 초기화.
+aerospike-py에는 **Rust-to-Python logging bridge**가 내장되어 있습니다. 내부 Rust log를 Python `logging` module로 전달하며 package를 import할 때 자동으로 초기화됩니다.
 
 ## Quick Start
 
@@ -124,12 +124,12 @@ for name in ["aerospike_core", "aerospike_py"]:
 
 ## Shutdown Fallback
 
-Python GIL 을 사용할 수 없을 때 (예: interpreter shutdown 중) logging bridge 는 메시지를 Python 으로 forward 할 수 없습니다. 이 경우:
+Interpreter가 종료되는 동안처럼 Python GIL을 사용할 수 없으면 logging bridge가 메시지를 Python으로 전달할 수 없습니다. 이 경우 다음과 같이 동작합니다.
 
-- **WARN 과 ERROR** 메시지는 **stderr** 로 emit — 중요한 진단 정보 유실 방지
-- **INFO, DEBUG, TRACE** 메시지는 silently drop
+- **WARN과 ERROR** 메시지는 중요한 진단 정보가 사라지지 않도록 **stderr**에 출력합니다.
+- **INFO, DEBUG, TRACE** 메시지는 버립니다.
 
-drop 된 메시지 수는 `dropped_log_count()` 로 확인:
+버린 메시지 수는 `dropped_log_count()`로 확인할 수 있습니다.
 
 ```python
 import aerospike_py

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/metrics.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/metrics.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 description: Prometheus metrics for monitoring Aerospike operations.
 ---
 
-aerospike-py 는 operation-level metric 을 Rust 에서 수집해 **Prometheus text format** 으로 노출합니다. metric 이름은 [OpenTelemetry DB Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/) 를 따름.
+aerospike-py는 operation-level metric을 Rust에서 기록하고 **Prometheus text format**으로 제공합니다. Metric 이름은 [OpenTelemetry DB Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/)를 따릅니다.
 
 ## Quick Start
 
@@ -25,7 +25,7 @@ aerospike_py.stop_metrics_server()
 
 ## `db_client_operation_duration_seconds`
 
-모든 데이터 operation 의 duration 을 추적하는 **histogram**.
+모든 data operation의 duration을 추적하는 **histogram**입니다.
 
 **Labels:**
 
@@ -122,4 +122,4 @@ sum by (db_namespace, db_operation_name) (rate(db_client_operation_duration_seco
 | 네트워크 round-trip 대비 | 0.001-0.01% |
 | `get_metrics()` encoding | ~50-200 μs |
 
-Metric 수집은 항상 활성, 오버헤드는 무시 가능.
+Metric 수집은 항상 활성화되어 있으며 overhead는 무시할 수 있는 수준입니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/tracing.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/tracing.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 description: OpenTelemetry distributed tracing for Aerospike operations.
 ---
 
-모든 데이터 operation 에 대해 내장 **OpenTelemetry tracing** 제공. Span 은 [Database Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/) 를 따르고 **OTLP gRPC** 로 export.
+aerospike-py는 모든 data operation을 위한 **OpenTelemetry tracing**을 제공합니다. Span은 [Database Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/)를 따르며 **OTLP gRPC**로 export됩니다.
 
 ## Quick Start
 
@@ -37,7 +37,7 @@ aerospike_py.shutdown_tracing()
 | `init_tracing()` | OTLP tracer 초기화. `OTEL_*` 환경변수 사용. |
 | `shutdown_tracing()` | Flush 후 shutdown. process exit 전 호출. |
 
-둘 다 thread-safe 하고 idempotent.
+두 function은 모두 thread-safe하고 idempotent합니다.
 
 ## 환경변수
 
@@ -65,7 +65,7 @@ aerospike_py.shutdown_tracing()
 
 ## Context Propagation
 
-`aerospike-py[otel]` 설치 시 W3C TraceContext 가 Python active span 에서 Rust span 으로 자동 propagate:
+`aerospike-py[otel]`을 설치하면 W3C TraceContext가 활성 Python span에서 Rust span으로 자동 전파됩니다.
 
 | Setup | 동작 |
 |---|---|
@@ -134,7 +134,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_SERVICE_NAME=my-aerospike-app
 ```
 
-`http://localhost:16686` 방문해서 trace 확인.
+Trace는 `http://localhost:16686`에서 확인할 수 있습니다.
 
 ## Tracing 비활성화
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/bottleneck-analysis.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/bottleneck-analysis.mdx
@@ -6,9 +6,9 @@ description: aerospike-py 의 stage-별 profiling 및 최적화 recipe. 새 isol
 ---
 
 :::caution TODO — 재측정 대기 중
-이전 bottleneck-analysis 콘텐츠는 삭제된 `benchmark/results/*` 산출물 (`bottleneck-analysis.md`, `internal-stage-toggle-comparison.md`) 을 기반으로 작성되었습니다. 그 측정에서 `spawn_blocking_delay` + `event_loop_resume_delay` 가 GIL 환경의 지배적 비용으로 식별되었고, 그 스토리는 [Production Benchmark → Python 3.14t](./production-benchmark#what-gets-faster-and-why) 에 보존되어 있습니다 — free-threaded Python 에서 두 stage 가 거의 0으로 collapse 되는 것을 확인 가능.
+이전 분석은 현재 삭제된 `benchmark/results/*` 산출물(`bottleneck-analysis.md`, `internal-stage-toggle-comparison.md`)을 사용했습니다. 당시 측정에서는 GIL 환경에서 `spawn_blocking_delay`와 `event_loop_resume_delay`가 가장 큰 비용을 차지했습니다. [Production Benchmark → Python 3.14t](./production-benchmark#what-gets-faster-and-why)에는 이 결과와 함께 free-threaded Python에서 두 stage가 거의 0으로 줄어드는 과정이 남아 있습니다.
 
-빠진 것: 새 [Isolated Benchmark](./isolated-benchmark) 하네스 (s1–s5, oha, podman, 로컬 Aerospike CE 8.1.2.1_3) 기반의 stage breakdown 신규 측정. 하네스 자체는 stage profiling 을 이미 지원합니다 — `AEROSPIKE_PY_INTERNAL_METRICS=1` 로 `db_client_internal_stage_seconds` 히스토그램이 켜지며 오버헤드는 무시 가능 — 다만 매트릭스 측정 + 페이지 reduction 이 아직.
+아직 필요한 작업은 새 [Isolated Benchmark](./isolated-benchmark) harness(s1–s5, oha, Podman, 로컬 Aerospike CE 8.1.2.1_3)에서 stage별 결과를 다시 측정하는 것입니다. Harness는 `AEROSPIKE_PY_INTERNAL_METRICS=1`을 통해 `db_client_internal_stage_seconds` histogram을 이미 지원합니다. 하지만 전체 matrix를 실행하고 결과를 문서로 정리하는 작업은 끝나지 않았습니다.
 
 추적 항목:
 
@@ -23,4 +23,4 @@ description: aerospike-py 의 stage-별 profiling 및 최적화 recipe. 새 isol
 2. **stage profiling 활성화 방법** — `AEROSPIKE_PY_INTERNAL_METRICS=1` env var, `aerospike_py.set_internal_stage_metrics_enabled(True)` 런타임 토글, scoped context manager. 세 가지 모두 현재 존재; 비활성 시 오버헤드는 stage entry 당 `AtomicBool` 로드 1회 수준.
 3. **유의미한 최적화 recipe**. 이전 round 의 우승자: (a) aerospike-py 로 교체, (b) `gather(N batch_reads)` 를 단일 `batch_read(mixed keys)` 로 통합, (c) Python 3.14t free-threaded 로 전환. (a) 와 (c) 는 [Isolated Benchmark](./isolated-benchmark) 와 [Production Benchmark](./production-benchmark) 에 이미 정량화되어 있고, (b) 는 **s4_gather vs s4_single** 에서 재측정 예정.
 
-재측정 전까지는 [Production Benchmark 의 3.14t stage breakdown](./production-benchmark#what-gets-faster-and-why) 을 canonical "시간이 어디 가는지" reference 로 사용하세요.
+새 측정이 나오기 전까지는 [Production Benchmark의 3.14t stage breakdown](./production-benchmark#what-gets-faster-and-why)을 각 단계의 비용을 설명하는 기준 자료로 사용하세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/isolated-benchmark.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/isolated-benchmark.mdx
@@ -8,9 +8,9 @@ description: 5-시나리오 uvicorn ASGI 벤치마크 스위트 (benchmark/) —
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-실제 uvicorn ASGI 프로세스 위에서 **aerospike-py vs 공식 `aerospike` Python client** 를 비교하는 focused 스위트. 각 endpoint 는 의도적으로 **응답 직렬화 비용을 제거**하고 단일 파생 scalar (`found`, `pred_sum`, `subset_sum`) 만 반환합니다 — 측정된 latency 는 `batch_read` + materialisation + (선택적) inference 만 반영하고 JSON encoding 은 들어가지 않습니다.
+이 benchmark는 실제 uvicorn ASGI process에서 **aerospike-py와 공식 `aerospike` Python client**를 비교합니다. 각 endpoint는 `found`, `pred_sum`, `subset_sum` 중 하나의 scalar만 반환해 response serialization 비용을 제외합니다. 따라서 측정 latency에는 `batch_read`, materialization, 선택적 inference가 포함되고 JSON encoding은 포함되지 않습니다.
 
-반대편 끝은 [Production Benchmark](./production-benchmark) — 실 서빙 pod 가 부담하는 모든 비용 (HTTP parse, full record marshalling, DLRM, network out) 을 그대로 포함. **client 라이브러리 자체가 격차에서 얼마나 차지하나** 를 보고 싶을 때 이 페이지를, **capacity planning 숫자** 가 필요할 땐 그 페이지를 보세요.
+[Production Benchmark](./production-benchmark)는 반대 범위를 측정합니다. HTTP parsing, 전체 record marshaling, DLRM, network output처럼 serving pod가 실제로 부담하는 비용을 모두 포함합니다. Client library 자체의 차이를 확인하려면 이 문서를, capacity planning에는 production benchmark를 사용하세요.
 
 > **Source**: 본 repo 의 `benchmark/`. podman/docker 로 Aerospike CE 8.1.2.1_3 띄워서 로컬 실행.
 
@@ -24,12 +24,12 @@ make bench-all CONCURRENCY=10 DURATION=30s BATCH_SIZE=50
 make report       # → 시나리오별 markdown 비교 표
 ```
 
-`make bench` 는 CLIENT 별 uvicorn 프로세스를 띄우고 `/healthz` 대기 후 `oha` 를 주어진 duration 만큼 실행, 죽이고 다음 client 로. `oha` 가 부하 생성기 (`oha --output-format json --no-tui -c $C -z $D -m POST …`). 각 run 은 `oha.json` 옆에 `meta.json` 을 남기므로 `loadtest/report.py` 가 `(scenario, batch_size, concurrency, python)` 단위로 그룹화 가능.
+`make bench`는 client마다 uvicorn process를 시작하고 `/healthz`를 기다립니다. 지정한 시간 동안 `oha`를 실행한 뒤 process를 종료하고 다음 client로 넘어갑니다. 각 run은 `oha.json` 옆에 `meta.json`을 저장하므로 `loadtest/report.py`가 결과를 `(scenario, batch_size, concurrency, python)` 단위로 묶을 수 있습니다.
 
-Aerospike CE 컨테이너는 `scripts/aerospike.template.conf` 를 마운트해서 `access-address` 를 `127.0.0.1` 로 고정합니다. aerospike-py 는 `connect()` 시 full cluster discovery 를 수행해서 그 옵션 없으면 podman 내부 IP 로 재연결을 시도하고 실패합니다; 공식 client 는 seed host 만 hit 하므로 이 옵션 없이도 우연히 동작.
+Aerospike CE container는 `scripts/aerospike.template.conf`를 mount하고 `access-address`를 `127.0.0.1`로 고정합니다. aerospike-py는 `connect()` 중에 전체 cluster를 찾습니다. 이 설정이 없으면 Podman 내부 IP로 다시 연결하다 실패합니다. 이 benchmark에서 공식 client는 seed host만 사용합니다.
 
 :::caution 실측은 follow-up
-아래 시나리오마다 적힌 숫자는 개발 중 sanity 매트릭스 (py3.11, concurrency=4, batch=30, 3s per run, 모든 데이터 cache-warm) 기준입니다. **격차의 모양** (어느 시나리오가 격차를 벌리고 어느 시나리오가 좁히는지) 을 보세요 — 절대값으로 인용하지 마세요. 본격 측정은 더 큰 시드 (10k–100k), 더 긴 duration (60s), 더 높은 concurrency (10–50) 가 필요.
+아래 수치는 warm cache에서 실행한 짧은 개발용 matrix를 사용합니다. 조건은 Python 3.11, concurrency 4, batch size 30, run당 3초입니다. 어느 시나리오에서 차이가 커지거나 작아지는지 비교할 때만 사용하고 절대 성능 수치로 인용하지 마세요. Production 수준의 matrix에는 seed record 10,000–100,000개, 60초 run, concurrency 10–50이 필요합니다.
 :::
 
 ## 시나리오
@@ -48,7 +48,7 @@ Aerospike CE 컨테이너는 `scripts/aerospike.template.conf` 를 마운트해�
 | aerospike-py | `result.found_count()` — pure-Rust filter+count, PyDict build 없음 |
 | official | `sum(1 for br in result.batch_records if br.result == 0)` — BatchRecord 리스트 Python 순회 |
 
-공식 client 는 batch_read 호출 자체에 `asyncio.to_thread` hop 비용을 항상 지불; s1 이 그 hop 비용을 가장 깔끔히 격리합니다.
+공식 client는 `batch_read`를 호출할 때마다 `asyncio.to_thread` 전환 비용을 부담합니다. s1은 이 비용을 가장 직접적으로 측정합니다.
 
 **Smoke (py3.11, c=4, batch=30, 3s)**
 
@@ -62,7 +62,7 @@ Aerospike CE 컨테이너는 `scripts/aerospike.template.conf` 를 마운트해�
 
 **3.14t 예상**
 
-양 client 의 가장 큰 절대 drop — `spawn_blocking_delay` 와 `event_loop_resume_delay` 가 짧은 request 의 큰 비중. client 간 ratio 는 좁아질 수 있음 (production-benchmark same-workload 3.14t run 에서 42% 격차가 ~2ms 로 collapse 한 사례).
+두 client 모두 이 시나리오에서 절대 latency가 가장 크게 줄어들 것으로 예상합니다. 짧은 request에서 `spawn_blocking_delay`와 `event_loop_resume_delay`가 큰 비중을 차지하기 때문입니다. Client 간 비율은 줄어들 수 있습니다. Production Benchmark의 같은 workload를 사용한 Python 3.14t run에서는 42%였던 차이가 약 2 ms로 줄었습니다.
 
   </TabItem>
 
@@ -89,11 +89,11 @@ Aerospike CE 컨테이너는 `scripts/aerospike.template.conf` 를 마운트해�
 | aerospike-py | 2206.6 | 1.81 | 2.56 |
 | **speedup** | **1.11×** | **1.11×** | — |
 
-1.11× 라는 비율이 s2 vs s3 비교의 baseline — 양 client 가 per-record dict 를 순회해야 할 때의 격차는 modest. **s3 는 이걸 1.33× 로 벌립니다** — aerospike-py 가 Rust-side zero-copy 경로를 쓰기 때문 (공식 client 엔 equivalent 없음).
+1.11×는 s2와 s3를 비교하는 기준입니다. 두 client가 record별 dict를 순회할 때는 차이가 작습니다. **s3에서는 이 차이가 1.33×로 커집니다.** aerospike-py는 Rust-side zero-copy 경로를 사용하지만 공식 client에는 같은 기능이 없기 때문입니다.
 
 **3.14t 예상**
 
-양 client 모두 개선. DLRM CPU inference 경로 자체도 이득 (`torch` GIL release) — production-benchmark side-effect 노트가 3.14t 에서 inference 43.5→20.7 ms (−52%) 를 관찰. client 간 ratio 는 좁아지지만 *격차의 종류* (dict iteration cost) 는 사라지지 않음.
+두 client 모두 개선됩니다. `torch`가 GIL을 해제하므로 DLRM CPU inference도 빨라집니다. Production Benchmark에서는 Python 3.14t에서 inference가 43.5 ms에서 20.7 ms로 52% 줄었습니다. Client 간 비율은 작아지지만 dict iteration 비용의 차이는 남습니다.
 
   </TabItem>
 
@@ -123,11 +123,11 @@ zero-copy 검증: numpy 2.x + 64-`<f4` packed dtype 에서 `np_batch.batch_recor
 | **aerospike-py** | **2466.2** | **1.62** | **2.36** |
 | **speedup** | **1.33×** | **1.33×** | **1.16×** |
 
-**s2 → s3 점프 (1.11× → 1.33×) 가 격리된 `to_numpy()` 우위** — 같은 DLRM, 같은 DB shape, materialisation 경로만 다름. 페이지의 헤드라인: 다운스트림 consumer 가 numpy-친화 framework (PyTorch, JAX, scikit-learn) 일 때 aerospike-py 는 Python-loop materialisation 을 우회.
+**s2에서 s3로 증가한 차이(1.11× → 1.33×)가 `to_numpy()`만의 효과입니다.** DLRM과 DB shape는 같고 materialisation 경로만 다릅니다. PyTorch, JAX, scikit-learn처럼 NumPy를 지원하는 downstream framework를 사용하면 aerospike-py는 Python loop를 거치지 않고 데이터를 materialise합니다.
 
 **3.14t 예상**
 
-우위가 **구조적** (단일 Rust→numpy fill with GIL released, vs Python loop). GIL 제거 후에도 다른 시나리오보다 더 잘 살아남음 — s3 vs s2 ratio 는 3.14t 에서 더 벌어질 것 (s2 도 GIL 제거로 이득이지만 s3 는 애초에 GIL 을 우회했음).
+이 차이는 **구조에서 비롯됩니다.** aerospike-py는 GIL을 해제한 상태에서 Rust가 NumPy array를 한 번에 채우지만, 공식 client는 Python loop를 사용합니다. s2도 GIL 제거의 이점을 얻지만 s3는 이미 GIL을 대부분 우회하므로, Python 3.14t에서는 s3와 s2의 비율이 더 벌어질 가능성이 있습니다.
 
   </TabItem>
 
@@ -135,11 +135,11 @@ zero-copy 검증: numpy 2.x + 64-`<f4` packed dtype 에서 `np_batch.batch_recor
 
 ### s4 — `asyncio.gather(N batch_reads)` vs 단일 `batch_read(mixed keys)`
 
-같은 총 key 수, 두 endpoint. **`/s4/gather`** 는 `n_groups` 개 parallel `batch_read` 를 fan-out; **`/s4/single`** 은 모든 key 를 한 호출로 합침. DB wire payload 동일, fixed-cost 분할 방식만 다름.
+두 endpoint는 같은 수의 key를 처리합니다. **`/s4/gather`**는 `n_groups`개의 `batch_read`를 병렬로 실행하고, **`/s4/single`**은 모든 key를 한 번의 호출로 처리합니다. DB wire payload는 같고 고정 비용을 나누는 방식만 다릅니다.
 
 **aerospike-py 가 gather 에서 더 크게 이기는 이유**
 
-공식 client 의 `asyncio.to_thread` hop 이 각 sub-batch 를 thread pool 통해 직렬화; aerospike-py 는 Tokio 안에서 동시 실행. 그래서 gather 의 per-call 오버헤드를 공식은 N× 지불, aerospike-py 는 (대략) 1× 지불.
+공식 client는 각 sub-batch를 `asyncio.to_thread`를 통해 thread pool에 전달합니다. aerospike-py는 Tokio 안에서 sub-batch를 동시에 실행합니다. 따라서 공식 client는 gather의 호출별 overhead를 N번 부담하지만, aerospike-py는 대략 한 번만 부담합니다.
 
 **Smoke (n_groups=4, per_group=30 → total 120 keys)**
 
@@ -152,13 +152,13 @@ zero-copy 검증: numpy 2.x + 64-`<f4` packed dtype 에서 `np_batch.batch_recor
 | `/s4/single` | aerospike-py | 1385.4 | 2.89 | 4.24 |
 | `/s4/single` | **speedup** | **1.39×** | **1.39×** | **1.11×** |
 
-`/s4/single` 이 **양 client 에서 `/s4/gather` 보다 빠름** (round trip 줄어 amortise 잘 됨), 다만 client 간 격차는 **`/s4/single` 에서 더 큼** (1.39× vs 1.25×) — gather path 의 threading penalty 가 진짜 병렬성으로 일부 흡수되는데, single 엔 그 escape valve 없음.
+두 client 모두 **`/s4/single`이 `/s4/gather`보다 빠릅니다.** Round trip이 줄어 고정 비용을 더 잘 분산하기 때문입니다. Client 간 차이는 `/s4/single`에서 더 큽니다(1.39× 대 1.25×). Gather path에서는 실제 병렬 실행이 thread 전환 비용을 일부 상쇄하지만 single path에는 그런 효과가 없습니다.
 
-**Recipe**: key 가 사전에 알려진 경우 `gather(N batch_reads)` 대신 단일 `batch_read(mixed_keys)` 선호. production-benchmark Env C 가 이 패턴으로 p95 추가 −33% 확인.
+**권장 방식**: key를 미리 알고 있다면 `gather(N batch_reads)` 대신 `batch_read(mixed_keys)` 한 번을 사용하세요. Production Benchmark의 Environment C에서 이 변경으로 p95가 추가로 33% 줄었습니다.
 
 **3.14t 예상**
 
-공식의 `asyncio.to_thread` hop 이 cheap 해짐 → 공식에서 gather-vs-single 격차 좁아짐. aerospike-py 의 single-call 우위 (Rust ↔ Python 경계 1회 통과) 는 그대로 유지.
+Python 3.14t에서는 공식 client의 `asyncio.to_thread` 전환 비용이 줄어 gather와 single의 차이도 작아질 것입니다. aerospike-py가 단일 호출로 Rust와 Python의 경계를 한 번만 통과하는 이점은 그대로 유지됩니다.
 
   </TabItem>
 
@@ -166,7 +166,7 @@ zero-copy 검증: numpy 2.x + 64-`<f4` packed dtype 에서 `np_batch.batch_recor
 
 ### s5 — `LazyBatchRecords` 의 부분 materialisation
 
-wire 상의 record 는 64 bin (`f0..f63`). endpoint 는 그중 8개만 소비. 양 client 모두 full payload 수신 — bin projection (`bins=[…]`) 은 server-side 최적화로 의도적으로 skip, 비교 대상은 **client-side materialisation 비용** at 고정 wire size.
+Wire상의 record에는 64개 bin(`f0..f63`)이 있고 endpoint는 그중 8개만 사용합니다. 두 client 모두 전체 payload를 받습니다. Server-side 최적화인 bin projection(`bins=[…]`)은 의도적으로 사용하지 않았으므로, 이 시나리오는 같은 wire size에서 **client-side materialisation 비용**을 비교합니다.
 
 **코드 경로 차이**
 
@@ -183,11 +183,11 @@ wire 상의 record 는 64 bin (`f0..f63`). endpoint 는 그중 8개만 소비. �
 | aerospike-py | 2722.0 | 1.47 | 2.16 |
 | **speedup** | **1.12×** | **1.12×** | — |
 
-s3 보다 격차 작음 — wire payload 가 동일하고 공식 client 의 eager dict build 가 C extension 이라 빠름. aerospike-py 의 우위는 **사용 안 하는 bin 수** 에 비례 — 8-of-64 에선 modest, 1-of-128 이라면 커짐.
+s3보다 차이가 작습니다. Wire payload가 같고 공식 client의 C extension이 dict를 빠르게 생성하기 때문입니다. aerospike-py의 이점은 **사용하지 않는 bin 수**가 늘수록 커집니다. 64개 중 8개를 사용할 때는 차이가 작지만, 128개 중 1개만 사용하면 더 커집니다.
 
 **3.14t 예상**
 
-aerospike-py 의 `to_numpy(subset_dtype)` 는 per-record fill 동안 GIL release → 3.14t 에서 여러 s5 request 가 병렬 materialise 가능. 공식 client 의 per-request dict build 도 C extension 안에선 GIL release 되나, dict ownership 이 Python 으로 넘어가는 시점에 GIL flip. ratio 는 유지될 것.
+aerospike-py의 `to_numpy(subset_dtype)`는 각 record를 채우는 동안 GIL을 해제하므로, Python 3.14t에서는 여러 s5 request를 병렬로 materialise할 수 있습니다. 공식 client도 C extension에서 request별 dict를 만드는 동안 GIL을 해제하지만, 완성된 dict의 소유권을 Python에 넘겨야 합니다. 따라서 비율은 비슷하게 유지될 가능성이 있습니다.
 
   </TabItem>
 </Tabs>
@@ -196,20 +196,20 @@ aerospike-py 의 `to_numpy(subset_dtype)` 는 per-record fill 동안 GIL release
 
 | 제외 | 이유 |
 |---|---|
-| Response body 직렬화 | 각 endpoint 는 `{found: N}` (or `+ pred_sum / subset_sum`) — 레코드에서 파생된 단일 scalar 만 반환. full-record JSON encoding 은 양 client 에 들어가는 비용이지만 key/digest shape 가 달라서 공식 client 쪽을 비대칭으로 부풀리고 client 격차를 묻어버림. |
-| OTel / Prometheus / nelo | 측정 노이즈. 부모 라이브러리는 그 기능을 노출하지만 벤치마크 스위트는 깨끗하게 유지. |
-| Docker image / k8s manifests | client 라이브러리 격리가 목적 — deploy/registry/manifests 경로는 무관 노이즈. |
-| Bin projection (`bins=[…]` on the wire) | server-side 최적화, client 비교와 orthogonal. **s5** 는 동일 wire payload 위에서 client-side materialisation 비용을 측정. |
+| Response body 직렬화 | 각 endpoint는 record에서 계산한 scalar 하나, 즉 `{found: N}` 또는 `pred_sum`/`subset_sum`을 추가한 값만 반환합니다. Full-record JSON encoding은 두 client 모두 부담하지만 key와 digest shape가 달라 공식 client의 비용을 비대칭으로 키우고 client 간 차이를 가릴 수 있습니다. |
+| OTel / Prometheus / nelo | 측정 결과에 변동을 더합니다. Client library는 이 기능을 제공하지만 benchmark suite에서는 비활성화했습니다. |
+| Docker image / k8s manifests | 이 benchmark는 client library만 격리합니다. Deployment, registry, manifest 작업은 관련 없는 변동을 더합니다. |
+| Bin projection (`bins=[…]` on the wire) | Client 비교와 별개인 server-side 최적화입니다. **s5**는 같은 wire payload에서 client-side materialisation 비용을 측정합니다. |
 
-반대편 — 모든 production 비용을 *포함*한 측정 — 은 [Production Benchmark](./production-benchmark) 참조.
+모든 production 비용을 *포함*한 결과는 [Production Benchmark](./production-benchmark)를 참고하세요.
 
 ---
 
 ## Python 3.14t — 같은 스위트 위 런타임 swap
 
-Python 3.14t 는 free-threaded CPython 빌드 (GIL disabled). [Production Benchmark 의 3.14t 섹션](./production-benchmark#python-314t-free-threaded--same-pipeline-gil-removed) 에서 본 `spawn_blocking_delay` (234 ms → 0.12 ms) 와 `event_loop_resume_delay` (39.7 ms → ~0) collapse 가 여기서도 재현될 것이나, isolated 스위트는 `batch_read` 다운스트림의 GIL-bound stage 를 이미 잘라낸 상태이므로 절대 delta 는 더 작을 것.
+Python 3.14t는 GIL을 비활성화한 free-threaded CPython 빌드입니다. [Production Benchmark의 3.14t 섹션](./production-benchmark#python-314t-free-threaded--same-pipeline-gil-removed)에서 `spawn_blocking_delay`는 234 ms에서 0.12 ms로, `event_loop_resume_delay`는 39.7 ms에서 거의 0으로 줄었습니다. 여기서도 같은 현상이 나타날 가능성이 있습니다. 다만 isolated suite는 `batch_read` 이후의 GIL-bound stage를 이미 대부분 제외했으므로 절대 차이는 더 작을 것입니다.
 
-benchmark/ 프로젝트는 단일 인자로 런타임 swap 지원:
+`benchmark/` 프로젝트는 인자 하나로 runtime을 바꿀 수 있습니다.
 
 ```bash
 uv python install 3.14t        # 일회성, ~30 MB 다운로드 (uv 관리)
@@ -218,10 +218,10 @@ PYTHON=3.14t make bench-all CONCURRENCY=10 DURATION=30s BATCH_SIZE=50
 make report                    # report.py 가 python 버전별 그룹화
 ```
 
-per-scenario 예상 효과는 위 시나리오 탭마다 "3.14t 예상" 으로 기재.
+시나리오별 예상 효과는 각 탭의 "3.14t 예상" 절에 정리했습니다.
 
 :::note 3.14t isolated-benchmark 매트릭스는 TODO
-시나리오마다 적힌 "3.14t 예상" 은 production-benchmark stage breakdown 으로부터의 외삽 — 측정값 아님. 하네스는 런타임 swap 을 지원; 매트릭스 측정 published 는 [Bottleneck Analysis](./bottleneck-analysis) 에서 추적.
+각 시나리오의 "3.14t 예상"은 Production Benchmark의 stage breakdown을 바탕으로 추정한 값이며 측정값이 아닙니다. Harness는 runtime 변경을 지원합니다. 공개할 matrix 측정 작업은 [Bottleneck Analysis](./bottleneck-analysis)에서 추적합니다.
 :::
 
 ## 관련 파일

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/overview.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/overview.mdx
@@ -8,7 +8,7 @@ description: aerospike-py vs 공식 C client 의 latency · throughput · Python
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-**aerospike-py** (Rust/PyO3, native async) 와 **공식 `aerospike` Python client** (C extension + `loop.run_in_executor` 래핑) 의 측정 결과를 비교합니다.
+이 문서는 **aerospike-py**(Rust, PyO3, native async)와 **공식 `aerospike` Python client**(C extension을 `loop.run_in_executor`로 실행)를 비교합니다.
 
 :::tip TL;DR — DLRM 서빙 p95 누적 효과
 **324 ms → 97 ms (−70%)** — 세 단계 누적: 클라이언트 교체 → batch_read 통합 → Python 3.14t.
@@ -37,12 +37,12 @@ import TabItem from '@theme/TabItem';
 
 ## 환경별 격차 (Python 3.11 + GIL)
 
-주변 스택이 얇을수록 격차가 큼. 실제 서빙 환경에선 비율이 줄지만 tail latency 우위는 유지.
+Application stack이 단순할수록 client 자체의 차이가 크게 보입니다. 실제 serving workload에서도 비율은 줄지만 tail latency의 이점은 유지됩니다.
 
 <Tabs>
   <TabItem value="dlrm" label="C — uvicorn + DLRM (실 서빙)" default>
 
-HTTP → batch_read → DLRM CPU 추론 → 응답. 실제 recsys 서빙 pod 와 가장 가까움.
+HTTP 요청부터 `batch_read`, DLRM CPU inference, 응답까지 전체 경로를 측정합니다. 실제 recommendation serving pod와 가장 비슷한 환경입니다.
 
 | 지표 | aerospike-py | 공식 | aerospike-py 우위 |
 |---|---:|---:|---:|
@@ -67,7 +67,7 @@ FastAPI + uvicorn + `batch_read`, 모델 추론 없음. "Key-value 조회 앞단
   </TabItem>
   <TabItem value="pure" label="A — 순수 DB client (HTTP/ML 없음)">
 
-Python 루프가 `batch_read` 직접 호출. 주변 스택이 가장 얇아 격차가 가장 큼.
+Python loop가 `batch_read`를 직접 호출합니다. HTTP나 ML layer가 없어 client 자체의 차이가 가장 크게 나타납니다.
 
 | 지표 | aerospike-py | 공식 | 우위 |
 |---|---:|---:|---:|

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/production-benchmark.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/production-benchmark.mdx
@@ -8,11 +8,11 @@ description: FastAPI + DLRM inference + Aerospike CE end-to-end production-shape
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-**production-shaped deployment** 에서의 end-to-end 측정: uvicorn 위 FastAPI, request path 안의 DLRM (CPU inference), 그 뒤의 Aerospike CE, k6 의 실 HTTP 부하, client 로 직렬화되어 돌아가는 response body.
+이 end-to-end benchmark는 **production 형태의 deployment**를 사용합니다. uvicorn 위의 FastAPI, request path의 DLRM CPU inference, Aerospike CE, k6 HTTP load, serialize된 response body를 모두 포함합니다.
 
-실제 recsys 서빙 pod 가 부담하는 모든 비용 (HTTP parse, JSON serialise, model forward) 이 측정에 포함되므로 [Isolated Benchmark](./isolated-benchmark) 대비 headline 숫자는 압축됩니다. 다만 이 수치가 **capacity planning** 용으로 인용하기에 알맞습니다.
+HTTP parsing, JSON serialization, model forward pass처럼 recommendation serving pod가 부담하는 비용이 모두 측정됩니다. 공통 비용 때문에 [Isolated Benchmark](./isolated-benchmark)보다 client 간 차이는 작게 보이지만, **capacity planning**에는 이 수치가 더 적합합니다.
 
-> **Sources**: 2026년 4월 내부 측정 run. raw 산출물은 commit 되어 있지 않음 (`benchmark/` rewrite 이전 git history 의 `benchmark/results/*.md` 파일들). 아래 headline 숫자는 그 산출물에서 재현됨; 새 isolated harness 기반 clean re-measurement 는 [Bottleneck Analysis](./bottleneck-analysis) 에서 추적.
+> **Sources**: 2026년 4월에 내부에서 측정했습니다. Raw 산출물은 저장소에 commit하지 않았으며, `benchmark/`를 다시 작성하기 전 git history의 `benchmark/results/*.md`에서 확인할 수 있습니다. 아래 주요 수치는 해당 산출물에서 가져왔습니다. 새 isolated harness에서 다시 측정하는 작업은 [Bottleneck Analysis](./bottleneck-analysis)에서 추적합니다.
 
 ## 격차가 어디 있는가
 
@@ -23,7 +23,7 @@ A) Pure DB client       ██████████████████�
 B) uvicorn ASGI         █████                 −21%  (290 → 228 ms)
 C) uvicorn + DLRM       ███████████           −42% p95 (324→189 ms)  🔥
 
-mean 이 compress 되어도 p95 우위는 유지 (C): 공식 client 의 result 변환이 tail 에서 GIL 직렬화됨.
+mean 차이가 줄어도 Environment C에서는 p95 우위가 유지됨: 공식 client의 result 변환이 tail에서 GIL 때문에 직렬화됨.
 ```
 
 <Tabs queryString="env">
@@ -31,7 +31,7 @@ mean 이 compress 되어도 p95 우위는 유지 (C): 공식 client 의 result �
 
 ## Environment A — Pure DB Client
 
-**격리하는 것.** FastAPI 없음, model inference 없음, HTTP loadgen 없음. Python 루프가 `batch_read` 를 직접 driver — 주변 스택이 최대한 얇아서 aerospike-py 의 우위가 **가장 큼**.
+**측정 범위.** FastAPI, model inference, HTTP load generator를 제외합니다. Python loop가 `batch_read`를 직접 호출하므로 client 자체의 차이가 **가장 크게** 나타납니다.
 
 ### Setup
 
@@ -62,17 +62,17 @@ Outlier: set_8 (0% found rate) → fast not-found path, 실 read latency 아님.
 ```
 
 :::note `set_8` 은 outlier
-0% found rate — 공식 client 는 success path 보다 error 를 빨리 반환하므로 이 row 는 실 read latency 가 아니라 "fast not-found" 를 반영. **나머지 모든 set 은 4–8× mean speedup.**
+Found rate가 0%입니다. 공식 client는 success path보다 error를 빨리 반환하므로 이 row는 실제 read latency가 아니라 빠른 not-found path를 보여 줍니다. **나머지 모든 set에서는 mean latency가 4~8배 개선되었습니다.**
 :::
 
-**`official-async`** (sync C client 를 `loop.run_in_executor` 로 래핑) 는 모든 set 에서 bare sync client 보다 약간 느림 — 매 request 가 thread-pool hop 을 지불. aerospike-py 의 `official-async` 대비 격차는 `official` 대비 격차보다 *일관되게 큼*.
+**`official-async`**는 sync C client를 `loop.run_in_executor`로 실행합니다. Request마다 thread pool을 거치므로 모든 set에서 bare sync client보다 조금 느립니다. 따라서 aerospike-py와 `official-async`의 차이는 `official`과의 차이보다 일관되게 큽니다.
 
   </TabItem>
   <TabItem value="B" label="B — uvicorn ASGI only">
 
 ## Environment B — uvicorn ASGI Only
 
-**격리하는 것.** `batch_read` 주변에 FastAPI 와 uvicorn 만 추가, model inference 없음. "Key-value 조회 앞단의 REST API" 형태.
+**측정 범위.** `batch_read`에 FastAPI와 uvicorn만 추가하고 model inference는 제외합니다. Key-value 조회 앞에 REST API를 둔 형태입니다.
 
 ### Setup
 
@@ -89,13 +89,13 @@ Outlier: set_8 (0% found rate) → fast not-found path, 실 read latency 아님.
 | **aerospike-py** | **228.49** | **189.56** | 457.42 | 468.03 | 497.09 | **221.12** | 1.46 | **19.4** |
 
 - **Total mean: −21%** (290 → 228 ms)
-- **Aerospike step: −21%** (280 → 221 ms) — 대부분의 wall time 이 DB 호출이라 client gain 이 E2E 로 그대로 전이
+- **Aerospike step: −21%** (280 → 221 ms) — DB 호출이 wall time의 대부분을 차지하므로 client의 개선이 E2E 결과에 그대로 반영됨
 - **TPS: +17%** (16.6 → 19.4 req/s)
-- p99 는 거의 동등 (474 vs 497 ms) — concurrency=5 에선 Tokio 모델이 GIL 을 충분히 stress 해서 tail 을 벌릴 만큼 부하가 강하지 않음
+- p99는 거의 같음(474 대 497 ms) — concurrency=5에서는 GIL 경합이 tail 차이를 만들 만큼 부하가 높지 않음
 
 ### 더 높은 concurrency 에서 backpressure 노출
 
-concurrency=10, 200 iter 두 번째 run (동일 2026년 4월 artifact set):
+Concurrency 10에서 200번 반복한 두 번째 run입니다. 같은 2026년 4월 artifact set을 사용했습니다.
 
 | Client | total mean | p95 | TPS | errors |
 |---|---:|---:|---:|---:|
@@ -103,7 +103,7 @@ concurrency=10, 200 iter 두 번째 run (동일 2026년 4월 artifact set):
 | aerospike-py | 580.70 | 986.93 | 13.9 | **56** |
 
 :::caution Saturation 상황의 backpressure
-이 run 은 테스트 하네스를 saturate 시킴 (공식 client 가 다르게 흡수한 부하에서 56건의 request rejection / timeout). **apples-to-apples 아님** — 적절한 backpressure 튜닝 없이는 native async client 가 server pool 이 흡수 가능한 양 이상의 in-flight 작업을 발행할 수 있다는 증거. [Bottleneck Analysis](./bottleneck-analysis) 의 `gather`→`single` recipe 가 이 문제를 해소.
+이 run에서는 test harness가 포화되어 request rejection 또는 timeout이 56건 발생했습니다. 공식 client는 같은 부하를 다른 방식으로 흡수했으므로 **동등한 조건의 비교가 아닙니다**. 이 결과는 backpressure를 적절히 조정하지 않으면 native async client가 server pool의 처리 한도를 넘는 in-flight 작업을 보낼 수 있음을 보여 줍니다. [Bottleneck Analysis](./bottleneck-analysis)의 `gather`→`single` 방식으로 이 문제를 줄일 수 있습니다.
 :::
 
   </TabItem>
@@ -111,14 +111,14 @@ concurrency=10, 200 iter 두 번째 run (동일 2026년 4월 artifact set):
 
 ## Environment C — uvicorn + DLRM (실 서빙)
 
-**격리하는 것.** Full production-style pipeline:
+**측정 범위.** 다음 production 형태의 전체 pipeline을 측정합니다.
 
 ```
 HTTP request → key extraction → batch_read(9 sets × 200 keys)
             → feature build → DLRM inference (PyTorch CPU) → response
 ```
 
-실 recsys 서빙 pod 와 가장 가까운 측정.
+실제 recommendation serving pod와 가장 가까운 환경입니다.
 
 ### Setup
 
@@ -129,7 +129,7 @@ HTTP request → key extraction → batch_read(9 sets × 200 keys)
 | Loadgen | k6 10 VUs × 60s per scenario, 4 scenarios |
 | Pods | replica 2, 4 CPU / 4 GiB request, 8 CPU / 8 GiB limit |
 
-두 endpoint (`/predict/official/sample` 와 `/predict/py-async/sample`) 가 **같은 pod** 안에 있으며 k6 가 번갈아 호출 — server state 와 네트워크가 완전 동일.
+두 endpoint(`/predict/official/sample`, `/predict/py-async/sample`)는 **같은 pod**에서 실행됩니다. k6가 번갈아 호출하므로 server state와 네트워크 조건이 같습니다.
 
 ### k6 client-side latency
 
@@ -153,7 +153,7 @@ avg     aerospike-py  █████████                    118 ms
 | merge_gather (aero-py only) | 202 | — | — |
 | stress (0→20→50 VUs ramp) | 592 | — | — |
 
-**gather** 격차가 좁아지는 이유는 양 client 모두 result 변환 step 에서 GIL 직렬화에 부딪힘 — [Bottleneck Analysis](./bottleneck-analysis) 참조.
+**gather**에서 차이가 줄어드는 이유는 두 client 모두 result 변환 단계에서 GIL 때문에 직렬화되기 때문입니다. 자세한 내용은 [Bottleneck Analysis](./bottleneck-analysis)를 참고하세요.
 
 ### Server-side Prometheus (동일 run, single mode)
 
@@ -162,7 +162,7 @@ avg     aerospike-py  █████████                    118 ms
 | `predict_duration_seconds` p95 (FastAPI E2E) | **202 ms** | 274 ms |
 | `aerospike_batch_read_all_duration_seconds` p95 | **137 ms** | 252 ms |
 
-server- 와 client-side 수치가 같은 방향으로 움직임 — 둘 사이 ~13 ms 격차는 네트워크 RTT + gateway + connection setup.
+Server-side와 client-side 수치는 같은 방향으로 변합니다. 둘 사이의 약 13 ms 차이는 network RTT, gateway, connection setup에서 발생합니다.
 
   </TabItem>
 </Tabs>
@@ -177,13 +177,13 @@ B) uvicorn ASGI                  mean 1.27×             ≈ noise at C=5
 C) uvicorn + DLRM                mean 1.24×             p95 −42%  🔥
 ```
 
-DB 호출 주위에 layer 가 추가될수록 **ratio 는 압축** (4.8× → 1.24× mean) 되지만 **upper-percentile 우위는 유지** — aerospike-py 는 I/O 동안 GIL 해제, 공식 client 는 `run_in_executor` 통해 GIL 획득을 직렬화하므로 tail 에서 spike.
+Database call 주변에 layer를 추가하면 mean ratio는 4.8×에서 1.24×로 줄어듭니다. 그러나 **upper-percentile 우위는 유지됩니다**. aerospike-py는 I/O 중에 GIL을 해제하지만 공식 client는 `run_in_executor`를 거치며 GIL 획득이 직렬화되어 tail latency가 커집니다.
 
 ---
 
 ## Python 3.14t free-threaded — 같은 pipeline, GIL 제거 {#python-314t-free-threaded--same-pipeline-gil-removed}
 
-Python 3.14t 는 free-threaded CPython 빌드 (GIL disabled, `Py_GIL_DISABLED=1`). 아래 수치는 **동일한** Environment C pipeline (FastAPI + DLRM + k6 10 VUs × 60s) 에서 런타임만 swap 한 결과. **Rust 또는 C source 변경 없음.**
+Python 3.14t는 GIL을 비활성화한 free-threaded CPython 빌드(`Py_GIL_DISABLED=1`)입니다. 아래 수치는 **같은** Environment C pipeline(FastAPI + DLRM + k6 10 VUs × 60s)에서 runtime만 바꿔 측정했습니다. **Rust와 C source는 변경하지 않았습니다.**
 
 ### TL;DR
 
@@ -201,14 +201,14 @@ official (C extension)
 Throughput (aerospike-py): 41.6 → 61.2 iter/s   +47%
 ```
 
-GIL 이 양 client 공통 병목이었음. **aerospike-py 의 gain 은 Rust 를 건드리지 않고 얻음.**
+GIL은 두 client 모두의 병목이었습니다. **aerospike-py는 Rust 코드를 바꾸지 않고도 성능이 개선되었습니다.**
 
 ### 무엇이 빨라지는가 (그리고 왜) {#what-gets-faster-and-why}
 
 <Tabs>
   <TabItem value="aspy" label="aerospike-py: stage breakdown" default>
 
-부하 환경의 internal stage timing. 두 GIL-bound stage 가 거의 0으로 collapse.
+부하를 준 상태에서 측정한 internal stage timing입니다. GIL의 영향을 받는 두 stage가 거의 0으로 줄었습니다.
 
 ```text
 Stage                     3.11 + GIL              3.14t       Change
@@ -222,17 +222,17 @@ tokio_schedule_delay      83.1 μs                49.5 μs      −40%
 limiter_wait              3.56 μs                0.96 μs      −73%
 ```
 
-**두 stage 가 gain 을 지배:**
+**개선 폭의 대부분은 다음 두 stage에서 나옵니다.**
 
-- **`spawn_blocking_delay`** 가 234 ms 에서 0.12 ms 로 drop. GIL 환경에선 Rust async future 가 완료되어 결과를 `Py<...>` 객체로 변환할 때 `spawn_blocking` worker 로 그 작업을 dispatch. 그 worker 가 GIL 을 acquire 해야 하는데, asyncio event loop 와 다른 worker 들과의 contention 하에서 queue 가 수백 ms 까지 늘어남. GIL 없으면 worker 가 즉시 실행.
-- **`event_loop_resume_delay`** 가 거의 0으로 drop. GIL 환경에선 future 가 resolve 되어 event loop 가 깨어난 후에도 coroutine 이 GIL 차례를 기다려야 resume. free-threaded mode 는 여러 coroutine 이 병렬 resume 허용.
+- **`spawn_blocking_delay`**는 234 ms에서 0.12 ms로 줄었습니다. GIL 환경에서는 Rust async future가 끝난 뒤 결과를 `Py<...>` 객체로 바꾸는 작업을 `spawn_blocking` worker에 전달합니다. Worker는 GIL을 얻어야 하므로 asyncio event loop와 다른 worker가 경합하면 queue 대기가 수백 ms까지 늘어납니다. GIL이 없으면 worker가 바로 실행됩니다.
+- **`event_loop_resume_delay`**는 거의 0으로 줄었습니다. GIL 환경에서는 future가 끝나 event loop가 깨어난 뒤에도 coroutine이 GIL을 얻을 때까지 기다립니다. Free-threaded mode에서는 여러 coroutine을 병렬로 재개할 수 있습니다.
 
-`io` 가 8× 작아진 것은 second-order effect: Tokio worker 가 Python 코드와 GIL 경쟁 없이 Aerospike 프로토콜 응답을 parse 할 수 있게 됨.
+`io`가 8배 줄어든 것은 간접 효과입니다. Tokio worker가 Python 코드와 GIL을 두고 경쟁하지 않고 Aerospike protocol response를 parse할 수 있게 되었습니다.
 
   </TabItem>
   <TabItem value="official" label="official C client: 더 큰 ratio">
 
-공식 `aerospike` client 는 synchronous C extension; 앱은 `loop.run_in_executor(ThreadPoolExecutor, ...)` 로 래핑. 각 request:
+공식 `aerospike` client는 synchronous C extension입니다. 애플리케이션에서는 이를 `loop.run_in_executor(ThreadPoolExecutor, ...)`로 감쌉니다. 각 request는 다음 단계를 거칩니다.
 
 ```text
 1. Thread-pool worker dispatch
@@ -241,25 +241,25 @@ limiter_wait              3.56 μs                0.96 μs      −73%
 4. C extension 이 Python dict 빌드 위해 GIL 재획득 ← GIL 하에서 직렬화
 ```
 
-GIL contention 하에서 **2번과 4번이 모든 in-flight request 에 걸쳐 직렬화**.
+GIL 경합이 있으면 **2번과 4번이 모든 in-flight request에서 직렬로 실행됩니다.**
 
-GIL 제거가 이를 병렬화. 공식 client 의 p95 는 **60%** 떨어짐 (324 → 128 ms) — 절대값으로 aerospike-py 의 49% 보다 더 큰 drop, 잃을 게 더 많았기 때문.
+GIL을 제거하면 이 단계들을 병렬로 실행할 수 있습니다. 공식 client의 p95는 **60%** 줄었습니다(324 → 128 ms). 기존 GIL 병목이 더 컸으므로 aerospike-py의 49%보다 감소 폭이 큽니다.
 
   </TabItem>
 </Tabs>
 
 ### 3.14t 의 same-workload 비교
 
-3.14t 에서 양 client 가 **같은 server load** 를 hit (같은 pod 안 endpoint 번갈아 호출, k6 10 VUs):
+Python 3.14t에서 두 client에 **같은 server load**를 적용했습니다. 같은 pod 안의 endpoint를 k6 10 VU가 번갈아 호출했습니다.
 
 | Client | p95 (single mode) | Difference |
 |---|---:|---|
 | aerospike-py | **126 ms** | baseline |
 | official aerospike | 128 ms | +2 ms (~1.5%, noise) |
 
-**3.11 + GIL 하의 42% 격차가 3.14t 에선 ~2ms 로 collapse.**
+**Python 3.11 + GIL에서 42%였던 차이가 Python 3.14t에서는 약 2 ms로 줄었습니다.**
 
-GIL contention 이 — 구조적 차이가 아니라 — 원래 격차 대부분의 원인이었다는 가장 깔끔한 증거.
+이는 client 구조보다 GIL 경합이 기존 차이의 대부분을 만들었다는 점을 보여 줍니다.
 
 ### Throughput (TPS)
 
@@ -279,7 +279,7 @@ GIL contention 이 — 구조적 차이가 아니라 — 원래 격차 대부분
 
 ### 그래도 solo load 에선 aerospike-py 가 여전히 우위 (3.14t)
 
-"126 vs 128 ms" tie 는 각 client 가 ~5 effective VUs 만 보는 configuration 에서 나옴 (10 VUs 가 두 endpoint 로 분산). 부하가 한 client 에 집중되면 격차가 다시 벌어짐.
+126 ms와 128 ms가 나온 측정에서는 10 VU가 두 endpoint로 나뉘어 각 client가 약 5 effective VU만 처리했습니다. 부하를 한 client에 집중하면 차이가 다시 커집니다.
 
 | Metric | aerospike-py solo | official solo | aerospike-py 우위 |
 |---|---:|---:|---|
@@ -289,21 +289,21 @@ GIL contention 이 — 구조적 차이가 아니라 — 원래 격차 대부분
 | Server `batch_read_all` p95 | **64 ms** | 67 ms | −4% |
 | 이론 capacity (Little's Law: 10 VUs / p95) | **~103 req/s** | ~75 req/s | **+37%** |
 
-**3.14t solo load 에서 aerospike-py 가 여전히 leading 하는 이유:**
+**Python 3.14t의 solo load에서도 aerospike-py가 더 빠른 이유는 다음과 같습니다.**
 
-1. **Native async vs threadpool 래핑.** GIL contention 없어도 `run_in_executor` 는 request 당 thread-pool hop 을 추가. aerospike-py 는 asyncio loop 위에서 직접 await.
-2. **Lazy dict conversion.** `batch_read()` 가 `LazyBatchRecords` 핸들 반환. Python-dict materialisation 은 caller 가 `.to_dict()` 호출 시 lazy 하게 일어남; `.to_numpy(dtype)` 는 GIL-released structured-array 경로 제공.
-3. **단일 FFI boundary crossing.** aerospike-py Rust 코드는 1회 PyO3 호출 안에서 full `batch_read` 완료. C extension 은 호출당 Python ↔ C 경계를 여러 번 통과.
+1. **Native async와 thread pool wrapper의 차이.** GIL 경합이 없어도 `run_in_executor`는 request마다 thread pool 전환을 추가합니다. aerospike-py는 asyncio loop에서 직접 await합니다.
+2. **Lazy dict conversion.** `batch_read()`는 `LazyBatchRecords` handle을 반환합니다. Python dict는 caller가 `.to_dict()`를 호출할 때 만들어집니다. `.to_numpy(dtype)`는 GIL을 해제한 structured array 경로를 제공합니다.
+3. **FFI boundary를 한 번만 통과.** aerospike-py의 Rust 코드는 PyO3 호출 한 번 안에서 전체 `batch_read`를 끝냅니다. C extension은 호출할 때마다 Python과 C의 경계를 여러 번 통과합니다.
 
-이 우위들은 concurrency 가 올라갈수록 compound (gather 수치 — 107 vs 253 ms — 가 가장 명확한 예).
+Concurrency가 높아질수록 이 차이들이 누적됩니다. Gather 결과인 107 ms와 253 ms가 이를 가장 잘 보여 줍니다.
 
 ### Migration notes
 
-1. **CI matrix 에 3.14t row 추가.** `python:3.14.2t-slim` 하에서 unit + integration test 실행.
-2. **`gil_used = false` 선언 전 Rust 의 `unsafe` 와 shared mutable state audit.**
-3. **공식 client wheel 기다리거나 build.** PyPI 는 아직 공식 `aerospike` 패키지에 대한 `cp314t` wheel 미배포; source build 는 동작.
+1. **CI matrix에 Python 3.14t를 추가합니다.** `python:3.14.2t-slim`에서 unit test와 integration test를 실행합니다.
+2. **`gil_used = false`를 선언하기 전에 Rust의 `unsafe`와 shared mutable state를 점검합니다.**
+3. **공식 client wheel을 기다리거나 직접 build합니다.** PyPI에는 아직 공식 `aerospike` 패키지의 `cp314t` wheel이 없지만 source build는 동작합니다.
 
-**Side-effect: inference 도 빨라짐.** DLRM inference (PyTorch CPU, control variable) 가 3.14t 에서 **43.5 ms → 20.7 ms (−52%)**. aerospike-py 와 무관 — async I/O 옆에서 도는 GIL-bound inference path 라면 누구든 free 로 얻는 side benefit.
+**부수 효과: inference도 빨라집니다.** Python 3.14t에서 control variable인 DLRM inference(PyTorch CPU)가 **43.5 ms에서 20.7 ms로 52% 줄었습니다.** 이 개선은 aerospike-py와 무관합니다. Async I/O와 함께 실행되는 GIL-bound inference path라면 같은 이점을 얻을 수 있습니다.
 
 ---
 


### PR DESCRIPTION
## Summary

- rewrite authored English README and guide prose with shorter, active sentences
- naturalize Korean documentation while keeping established technical terms and English/Korean meaning aligned
- preserve frontmatter, headings, anchors, code blocks, links, commands, and technical claims
- exclude generated API reference files

## Validation

- `npx docusaurus build --locale en` — passed
- `npx docusaurus build --locale ko` — passed
- frontmatter, heading, fenced-code, and Markdown-link destination comparisons — passed
- `git diff --check` — passed
- `npm run typecheck` — blocked by existing TS5101: TypeScript 6 deprecates `baseUrl` in `docs/tsconfig.json`