### PR TITLE
docs: use the default port in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ High-performance Python client for Aerospike, built with Rust and PyO3 on top of
 pip install aerospike-py
 ```
 
-From a source checkout, start the local Aerospike CE container with
-`make run-aerospike-ce`; it listens on `127.0.0.1:18710`. If you start
-Aerospike manually on the default service port, use `3000` in the examples
-below instead.
+Before running the examples, make sure an Aerospike server is available at
+`127.0.0.1:3000`, or replace the host and port with a seed address for your
+cluster.
 
 ### Sync Client
 
@@ -42,8 +41,7 @@ below instead.
 import aerospike_py as aerospike
 
 with aerospike.client({
-    "hosts": [("127.0.0.1", 18710)],
-    "cluster_name": "docker",
+    "hosts": [("127.0.0.1", 3000)],
 }).connect() as client:
 
     key = ("test", "demo", "user1")
@@ -65,8 +63,7 @@ from aerospike_py import AsyncClient
 
 async def main():
     async with AsyncClient({
-        "hosts": [("127.0.0.1", 18710)],
-        "cluster_name": "docker",
+        "hosts": [("127.0.0.1", 3000)],
     }) as client:
         await client.connect()
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -16,10 +16,9 @@ pip install aerospike-py
 
 **Requirements:** Python 3.10+ (CPython)
 
-If you work from a source checkout, run `make run-aerospike-ce` to start the
-local Aerospike CE container on `127.0.0.1:18710`. If you start Aerospike
-manually on its default service port, replace `18710` with `3000` in the
-examples below.
+Before running the examples, make sure an Aerospike server is available at
+`127.0.0.1:3000`, or replace the host and port with a seed address for your
+cluster.
 
 ## Quick Start
 
@@ -31,7 +30,7 @@ import aerospike_py as aerospike
 from aerospike_py import Record
 
 with aerospike.client({
-    "hosts": [("127.0.0.1", 18710)],
+    "hosts": [("127.0.0.1", 3000)],
 }).connect() as client:
     key: tuple[str, str, str] = ("test", "demo", "user1")
 
@@ -59,7 +58,7 @@ import aerospike_py as aerospike
 from aerospike_py import AsyncClient, Record
 
 async def main() -> None:
-    async with AsyncClient({"hosts": [("127.0.0.1", 18710)]}) as client:
+    async with AsyncClient({"hosts": [("127.0.0.1", 3000)]}) as client:
         await client.connect()
         key: tuple[str, str, str] = ("test", "demo", "user1")
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -16,7 +16,7 @@ pip install aerospike-py
 
 **Requirements:** Python 3.10+ (CPython)
 
-소스 checkout에서 작업한다면 `make run-aerospike-ce`를 실행해 로컬 Aerospike CE 컨테이너를 시작하세요. 컨테이너는 `127.0.0.1:18710`에서 요청을 받습니다. Aerospike를 기본 service port로 직접 실행했다면 아래 예제의 `18710`을 `3000`으로 바꾸세요.
+예제를 실행하기 전에 `127.0.0.1:3000`에서 Aerospike server가 실행 중인지 확인하세요. 다른 환경을 사용한다면 host와 port를 해당 cluster의 seed address로 바꾸세요.
 
 ## Quick Start
 
@@ -28,7 +28,7 @@ import aerospike_py as aerospike
 from aerospike_py import Record
 
 with aerospike.client({
-    "hosts": [("127.0.0.1", 18710)],
+    "hosts": [("127.0.0.1", 3000)],
 }).connect() as client:
     key: tuple[str, str, str] = ("test", "demo", "user1")
 
@@ -56,7 +56,7 @@ import aerospike_py as aerospike
 from aerospike_py import AsyncClient, Record
 
 async def main() -> None:
-    async with AsyncClient({"hosts": [("127.0.0.1", 18710)]}) as client:
+    async with AsyncClient({"hosts": [("127.0.0.1", 3000)]}) as client:
         await client.connect()
         key: tuple[str, str, str] = ("test", "demo", "user1")
 


### PR DESCRIPTION
## Summary

- remove the source-checkout-specific container instructions from Quickstart
- use the standard Aerospike service port 3000 in sync and async examples
- remove the local Docker-only cluster_name setting from the README examples
- keep the English and Korean guides aligned

## Validation

- git diff --check
- English and Korean Docusaurus production build

Documentation-only change; development and benchmark documentation keeps the repository-specific port where it is relevant.