### PR TITLE
docs: improve readability, UX, and accuracy

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,0 @@
-{
-  "url": "https://context7.com/aerospike-ce-ecosystem/aerospike-py",
-  "public_key": "pk_ZxdBn6Jfur93z1Sz19Qfn"
-}

--- a/docs/docs/api/client.md
+++ b/docs/docs/api/client.md
@@ -32,51 +32,23 @@ client = aerospike_py.client({
 }).connect()
 ```
 
-### `set_log_level(level)`
+### `async_client(config)`
 
-Set the aerospike_py log level.
-
-Accepts ``LOG_LEVEL_*`` constants. Controls both Rust-internal
-and Python-side logging.
+Create a new async Aerospike client instance.
 
 | Parameter | Description |
 |-----------|-------------|
-| `level` | One of ``LOG_LEVEL_OFF`` (-1), ``LOG_LEVEL_ERROR`` (0), ``LOG_LEVEL_WARN`` (1), ``LOG_LEVEL_INFO`` (2), ``LOG_LEVEL_DEBUG`` (3), ``LOG_LEVEL_TRACE`` (4). |
+| `config` | [`ClientConfig`](types.md#clientconfig) dictionary. Must contain a ``"hosts"`` key with a list of ``(host, port)`` tuples. |
+
+**Returns:** A new ``AsyncClient`` instance (not yet connected).
 
 ```python
 import aerospike_py
 
-aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)
-```
-
-### `get_metrics()`
-
-Return collected metrics in Prometheus text format.
-
-**Returns:** A string in Prometheus exposition format.
-
-```python
-print(aerospike_py.get_metrics())
-```
-
-### `start_metrics_server(port=9464)`
-
-Start a background HTTP server serving ``/metrics`` for Prometheus.
-
-| Parameter | Description |
-|-----------|-------------|
-| `port` | TCP port to listen on (default ``9464``). |
-
-```python
-aerospike_py.start_metrics_server(port=9464)
-```
-
-### `stop_metrics_server()`
-
-Stop the background metrics HTTP server.
-
-```python
-aerospike_py.stop_metrics_server()
+client = aerospike_py.async_client({
+    "hosts": [("127.0.0.1", 3000)],
+})
+await client.connect()
 ```
 
 ## Connection
@@ -144,6 +116,40 @@ if client.is_connected():
 ```python
 if client.is_connected():
     print("Connected")
+```
+
+  </TabItem>
+</Tabs>
+
+### `ping()`
+
+Lightweight health check that verifies cluster liveness.
+
+Sends an ``info("build")`` command to a random cluster node and
+returns whether the node responded successfully. Unlike
+``is_connected()`` which only checks local state, this method
+performs an actual network round-trip.
+
+Useful for Kubernetes readiness probes, load-balancer health
+checks, and connection-pool validation.
+
+**Returns:** ``True`` if a cluster node responded, ``False`` otherwise
+(including when the client is not connected).
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+if client.ping():
+    print("Cluster is reachable")
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+if await client.ping():
+    print("Cluster is reachable")
 ```
 
   </TabItem>
@@ -400,7 +406,7 @@ Check whether a record exists.
 | `policy` | Optional [`ReadPolicy`](types.md#readpolicy) dict. |
 
 **Returns:** An ``ExistsResult`` NamedTuple with ``key``, ``meta`` fields.
-    ``meta`` is ``None`` if the record does not exist.
+``meta`` is ``None`` if the record does not exist.
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -626,7 +632,7 @@ Execute multiple operations atomically on a single record.
 | Parameter | Description |
 |-----------|-------------|
 | `key` | Record key as ``(namespace, set, primary_key)`` tuple. |
-| `ops` | List of operation dicts with ``"op"``, ``"bin"``, ``"val"`` keys. |
+| `ops` | List of operation dicts with ``"op"``, ``"bin"``, ``"val"`` keys. For an ``OPERATOR_INCR`` op the ``"val"`` must be an ``int`` or ``float`` (a non-numeric ``val`` raises ``TypeError``). |
 | `meta` | Optional [`WriteMeta`](types.md#writemeta) dict. |
 | `policy` | Optional [`WritePolicy`](types.md#writepolicy) dict. |
 
@@ -673,12 +679,12 @@ the operation order.
 | Parameter | Description |
 |-----------|-------------|
 | `key` | Record key as ``(namespace, set, primary_key)`` tuple. |
-| `ops` | List of operation dicts with ``"op"``, ``"bin"``, ``"val"`` keys. |
+| `ops` | List of operation dicts with ``"op"``, ``"bin"``, ``"val"`` keys. For an ``OPERATOR_INCR`` op the ``"val"`` must be an ``int`` or ``float`` (a non-numeric ``val`` raises ``TypeError``). |
 | `meta` | Optional [`WriteMeta`](types.md#writemeta) dict. |
 | `policy` | Optional [`WritePolicy`](types.md#writepolicy) dict. |
 
 **Returns:** An ``OperateOrderedResult`` NamedTuple with ``key``, ``meta``,
-    ``ordered_bins`` fields.
+``ordered_bins`` fields.
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -720,7 +726,7 @@ result = await client.operate_ordered(
 Read multiple records in a single batch call.
 
 Returns a [`LazyBatchRecords`](types.md#lazybatchrecords) — a zero-conversion
-wrapper around the raw Rust results. Call one of its methods
+wrapper around the raw Rust results. Call one of the handle methods
 to materialise the result:
 
 * ``lazy_records.to_dict()`` → ``dict[UserKey, AerospikeRecord]``
@@ -778,7 +784,7 @@ keys), each record can have different bins.
 Write fields can be set at two levels and follow a uniform precedence
 rule — **per-record meta always overrides the batch-level policy**.
 The fields below mirror the corresponding [`WritePolicy`](types.md#writepolicy)
-keys used by :meth:`put`:
+keys used by `put()`:
 
 | Field            | Batch-level (``policy``) | Per-record (``meta``) | Notes                                            |
 |------------------|--------------------------|-----------------------|--------------------------------------------------|
@@ -793,10 +799,10 @@ keys used by :meth:`put`:
 |-----------|-------------|
 | `records` | List of ``(key, bins)`` or ``(key, bins, meta)`` tuples. |
 | `policy` | Optional [`BatchPolicy`](types.md#batchpolicy) dict. Accepts the write fields above plus standard batch transport keys (``socket_timeout``, ``total_timeout``, ``max_retries``, ``filter_expression``, ``allow_inline``, ``allow_inline_ssd``, ``respond_all_keys``). |
-| `retry` | Maximum number of retries for failed records (default ``0``). When > 0, records that fail with transient errors (timeout, device overload, key busy) are automatically retried with exponential backoff (Full Jitter, max 500ms). Retries stop early if the elapsed time approaches ``total_timeout``.  **Note:** If a transport error occurs during retry, retries stop and partial results are returned. Always check each ``BatchRecord.result`` code. Total wall-clock time may exceed ``total_timeout`` by up to one additional timeout window. |
+| `retry` | Maximum number of retries for failed records (default ``0``). When > 0, records that fail with transient errors (timeout, device overload, key busy) are automatically retried with exponential backoff (Full Jitter, max 500ms). Retries stop early if the elapsed time approaches ``total_timeout``. **Note:** If a transport error occurs during retry, retries stop and partial results are returned. Always check each ``BatchRecord.result`` code. Total wall-clock time may exceed ``total_timeout`` by up to one additional timeout window. |
 
 **Returns:** A ``BatchWriteResult`` containing per-record result codes in
-    ``batch_records: list[BatchRecord]``.
+``batch_records: list[BatchRecord]``.
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -868,7 +874,7 @@ results = await client.batch_write(records_with_meta)
   </TabItem>
 </Tabs>
 
-### `batch_write_numpy(data, namespace, set_name, _dtype, key_field=_key, policy=None, retry=0)`
+### `batch_write_numpy(data, namespace, set_name, _dtype, key_field='_key', policy=None, retry=0)`
 
 Write multiple records from a numpy structured array.
 
@@ -884,10 +890,10 @@ Remaining non-underscore-prefixed fields become bins.
 | `_dtype` | numpy dtype describing the array layout. |
 | `key_field` | Name of the dtype field to use as the user key (default ``"_key"``). |
 | `policy` | Optional [`BatchPolicy`](types.md#batchpolicy) dict. |
-| `retry` | Maximum number of retries for failed records (default ``0``). When > 0, records that fail with transient errors (timeout, device overload, key busy) are automatically retried with exponential backoff (Full Jitter, max 500ms). Retries stop early if the elapsed time approaches ``total_timeout``.  **Note:** If a transport error occurs during retry, retries stop and partial results are returned. Always check each ``BatchRecord.result`` code. Total wall-clock time may exceed ``total_timeout`` by up to one additional timeout window. |
+| `retry` | Maximum number of retries for failed records (default ``0``). When > 0, records that fail with transient errors (timeout, device overload, key busy) are automatically retried with exponential backoff (Full Jitter, max 500ms). Retries stop early if the elapsed time approaches ``total_timeout``. **Note:** If a transport error occurs during retry, retries stop and partial results are returned. Always check each ``BatchRecord.result`` code. Total wall-clock time may exceed ``total_timeout`` by up to one additional timeout window. |
 
 **Returns:** A ``BatchWriteResult`` with per-record result codes in
-    ``batch_records: list[BatchRecord]``.
+``batch_records: list[BatchRecord]``.
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -931,9 +937,9 @@ Execute operations on multiple records in a single batch call.
 | `policy` | Optional [`BatchPolicy`](types.md#batchpolicy) dict. |
 
 **Returns:** A ``BatchWriteResult`` with per-record result codes in
-    ``batch_records: list[BatchRecord]``.
-    Each ``BatchRecord`` also includes an ``in_doubt`` flag
-    (see :meth:`batch_write` for details).
+``batch_records: list[BatchRecord]``.
+Each ``BatchRecord`` also includes an ``in_doubt`` flag
+(see `batch_write()` for details).
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -976,9 +982,9 @@ Delete multiple records in a single batch call.
 | `policy` | Optional dict combining a transport-level [`BatchPolicy`](types.md#batchpolicy) with batch-level [`BatchDeletePolicy`](types.md#batchdeletepolicy) defaults: ``gen``, ``key`` (send_key), ``commit_level``, ``durable_delete``, ``filter_expression``. |
 
 **Returns:** A ``BatchWriteResult`` with per-record result codes in
-    ``batch_records: list[BatchRecord]``.
-    Each ``BatchRecord`` also includes an ``in_doubt`` flag
-    (see :meth:`batch_write` for details).
+``batch_records: list[BatchRecord]``.
+Each ``BatchRecord`` also includes an ``in_doubt`` flag
+(see `batch_write()` for details).
 
 ```python
 # Legacy: bare keys.
@@ -1006,9 +1012,21 @@ Execute a UDF on multiple records in a single batch call.
 | `policy` | Optional dict combining a transport-level [`BatchPolicy`](types.md#batchpolicy) with batch-level [`BatchUDFPolicy`](types.md#batchudfpolicy) defaults: ``commit_level``, ``ttl``, ``key`` (send_key), ``durable_delete``, ``filter_expression``. |
 
 **Returns:** A ``BatchWriteResult`` with per-record result codes in
-    ``batch_records: list[BatchRecord]``. UDF return values are
-    stored in the per-record bin map under the Lua-convention
-    ``"SUCCESS"`` key when the call succeeded.
+``batch_records: list[BatchRecord]``. UDF return values are
+stored in the per-record bin map under the Lua-convention
+``"SUCCESS"`` key when the call succeeded.
+
+:::note
+
+``batch_apply`` does **not** accept a ``retry`` parameter
+(unlike `batch_write()`, which accepts ``retry: int = 0``).
+Passing ``retry=`` to this method raises ``TypeError``.
+UDF batches are not idempotent in the general case, so retries
+must be driven by the caller. For per-record control over the
+UDF call shape and policy fields, use ``(key, meta)`` tuples
+with a ``BatchUDFMeta`` payload in ``keys``.
+
+:::
 
 ```python
 # Apply the same UDF to many keys.
@@ -1025,7 +1043,7 @@ results = client.batch_apply(
 )
 ```
 
-## Query & Scan
+## Query
 
 ### `query(namespace, set_name)`
 
@@ -1037,7 +1055,7 @@ Create a Query object for secondary index queries.
 | `set_name` | The set to query. |
 
 **Returns:** A ``Query`` object. Use ``where()`` to set a predicate filter
-    and ``results()`` or ``foreach()`` to execute.
+and ``results()`` or ``foreach()`` to execute.
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -1329,13 +1347,80 @@ result = await client.apply(
   </TabItem>
 </Tabs>
 
-## Query Object
+## User Administration
+
+### `admin_create_user(username, password, roles, policy=None)`
+
+Create a user with the supplied password and roles.
+
+### `admin_drop_user(username, policy=None)`
+
+Delete a user.
+
+### `admin_change_password(username, password, policy=None)`
+
+Change a user's password.
+
+### `admin_grant_roles(username, roles, policy=None)`
+
+Grant roles to a user.
+
+### `admin_revoke_roles(username, roles, policy=None)`
+
+Revoke roles from a user.
+
+### `admin_query_user_info(username, policy=None)`
+
+Return information about one user.
+
+### `admin_query_users_info(policy=None)`
+
+Return information about all users.
+
+## Role Administration
+
+### `admin_create_role(role, privileges, policy=None, whitelist=None, read_quota=0, write_quota=0)`
+
+Create a role with privileges and optional access limits.
+
+### `admin_drop_role(role, policy=None)`
+
+Delete a role.
+
+### `admin_grant_privileges(role, privileges, policy=None)`
+
+Grant privileges to a role.
+
+### `admin_revoke_privileges(role, privileges, policy=None)`
+
+Revoke privileges from a role.
+
+### `admin_query_role(role, policy=None)`
+
+Return information about one role.
+
+### `admin_query_roles(policy=None)`
+
+Return information about all roles.
+
+### `admin_set_whitelist(role, whitelist, policy=None)`
+
+Set the network allowlist for a role.
+
+### `admin_set_quotas(role, read_quota=0, write_quota=0, policy=None)`
+
+Set read and write quotas for a role.
+
+## Query and AsyncQuery Objects
 
 Secondary index query object.
 
 Created via ``Client.query(namespace, set_name)``. Use ``where()``
 to set a predicate filter, ``select()`` to choose bins, then
 ``results()`` or ``foreach()`` to execute.
+
+<Tabs>
+  <TabItem value="query" label="Query" default>
 
 ```python
 from aerospike_py import predicates
@@ -1346,9 +1431,28 @@ query.where(predicates.between("age", 20, 30))
 records = query.results()
 ```
 
-### `select()`
+  </TabItem>
+  <TabItem value="async-query" label="AsyncQuery">
+
+```python
+from aerospike_py import predicates
+
+query = client.query("test", "demo")
+query.select("name", "age")
+query.where(predicates.between("age", 20, 30))
+records = await query.results()
+```
+
+  </TabItem>
+</Tabs>
+
+### `select(*bins)`
 
 Select specific bins to return in query results.
+
+| Parameter | Description |
+|-----------|-------------|
+| `*bins` | Bin names to include in the results. |
 
 ```python
 query = client.query("test", "demo")
@@ -1382,11 +1486,26 @@ Execute the query and return all matching records.
 
 **Returns:** A list of ``Record`` NamedTuples.
 
+<Tabs>
+  <TabItem value="sync" label="Query" default>
+
 ```python
 records = query.results()
 for record in records:
     print(record.bins)
 ```
+
+  </TabItem>
+  <TabItem value="async" label="AsyncQuery">
+
+```python
+records = await query.results()
+for record in records:
+    print(record.bins)
+```
+
+  </TabItem>
+</Tabs>
 
 ### `foreach(callback, policy=None)`
 
@@ -1400,9 +1519,202 @@ from the callback to stop iteration early.
 | `callback` | Function called with each record. Return ``False`` to stop. |
 | `policy` | Optional [`QueryPolicy`](types.md#querypolicy) dict. |
 
+<Tabs>
+  <TabItem value="sync" label="Query" default>
+
 ```python
 def process(record):
     print(record.bins)
 
 query.foreach(process)
+```
+
+  </TabItem>
+  <TabItem value="async" label="AsyncQuery">
+
+```python
+def process(record):
+    print(record.bins)
+
+await query.foreach(process)
+```
+
+  </TabItem>
+</Tabs>
+
+## Partition Filter Helpers
+
+### `partition_filter_all()`
+
+Build a `PartitionFilter` covering all 4096 partitions.
+
+Equivalent to omitting ``partition_filter`` from the policy entirely.
+
+### `partition_filter_by_id(partition_id)`
+
+Build a `PartitionFilter` targeting a single partition.
+
+| Parameter | Description |
+|-----------|-------------|
+| `partition_id` | Partition index in ``[0, 4095]``. |
+
+:::note
+
+Raises `ValueError` If ``partition_id`` is outside the valid range.
+
+:::
+
+### `partition_filter_by_range(begin, count)`
+
+Build a `PartitionFilter` targeting ``count`` partitions from ``begin``.
+
+| Parameter | Description |
+|-----------|-------------|
+| `begin` | First partition (``[0, 4095]``). |
+| `count` | Number of partitions; ``begin + count <= 4096``. ``0`` is allowed and yields an empty filter. |
+
+:::note
+
+Raises `ValueError` If the range overflows 4096.
+
+:::
+
+## Logging
+
+### `set_log_level(level)`
+
+Set the aerospike_py log level.
+
+Accepts ``LOG_LEVEL_*`` constants. Controls both Rust-internal
+and Python-side logging.
+
+| Parameter | Description |
+|-----------|-------------|
+| `level` | One of ``LOG_LEVEL_OFF`` (-1), ``LOG_LEVEL_ERROR`` (0), ``LOG_LEVEL_WARN`` (1), ``LOG_LEVEL_INFO`` (2), ``LOG_LEVEL_DEBUG`` (3), ``LOG_LEVEL_TRACE`` (4). |
+
+```python
+import aerospike_py
+
+aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)
+```
+
+### `dropped_log_count()`
+
+Return the number of log messages dropped because the GIL was unavailable.
+
+When the Rust logging bridge cannot acquire the Python GIL (e.g. during
+interpreter shutdown), log messages are counted as dropped. WARN and ERROR
+level messages are still emitted to stderr as a fallback.
+
+**Returns:** Count of dropped messages since process start.
+
+## Metrics
+
+### `get_metrics()`
+
+Return collected metrics in Prometheus text format.
+
+**Returns:** A string in Prometheus exposition format.
+
+```python
+print(aerospike_py.get_metrics())
+```
+
+### `set_metrics_enabled(enabled)`
+
+Enable or disable Prometheus metrics collection.
+
+When disabled, operation timers are skipped entirely (~1ns atomic check).
+Useful for benchmarking without metrics overhead.
+
+| Parameter | Description |
+|-----------|-------------|
+| `enabled` | ``True`` to enable (default), ``False`` to disable. |
+
+```python
+aerospike_py.set_metrics_enabled(False)   # disable for benchmark
+aerospike_py.set_metrics_enabled(True)     # re-enable
+```
+
+### `is_metrics_enabled()`
+
+Check if Prometheus metrics collection is currently enabled.
+
+**Returns:** ``True`` if metrics are enabled (default), ``False`` otherwise.
+
+```python
+if aerospike_py.is_metrics_enabled():
+    print(aerospike_py.get_metrics())
+```
+
+### `set_internal_stage_metrics_enabled(enabled)`
+
+Enable or disable internal stage profiling metrics.
+
+Controls the ``db_client_internal_stage_seconds`` histogram that captures
+fine-grained timing per batch_read stage. Disabled by default — zero
+overhead when off. Set ``AEROSPIKE_PY_INTERNAL_METRICS=1`` to enable at
+process start.
+
+| Parameter | Description |
+|-----------|-------------|
+| `enabled` | ``True`` to enable, ``False`` to disable (default). |
+
+### `is_internal_stage_metrics_enabled()`
+
+Check if internal stage profiling metrics are currently enabled.
+
+**Returns:** ``True`` if stage profiling is on, ``False`` otherwise (default).
+
+### `internal_stage_profiling()`
+
+Context manager that scopes internal stage profiling to a code block.
+
+Enables profiling on entry and restores the previous state on exit.
+
+```python
+with aerospike_py.internal_stage_profiling():
+    lazy_records = await client.batch_read(keys)
+```
+
+### `start_metrics_server(port=9464)`
+
+Start a background HTTP server serving ``/metrics`` for Prometheus.
+
+| Parameter | Description |
+|-----------|-------------|
+| `port` | TCP port to listen on (default ``9464``). |
+
+```python
+aerospike_py.start_metrics_server(port=9464)
+```
+
+### `stop_metrics_server()`
+
+Stop the background metrics HTTP server.
+
+```python
+aerospike_py.stop_metrics_server()
+```
+
+## Tracing
+
+### `init_tracing()`
+
+Initialize OpenTelemetry tracing.
+
+Reads standard ``OTEL_*`` environment variables for configuration.
+
+```python
+aerospike_py.init_tracing()
+```
+
+### `shutdown_tracing()`
+
+Shut down the tracer provider, flushing pending spans.
+
+Call before process exit to ensure all spans are exported.
+
+```python
+aerospike_py.shutdown_tracing()
 ```

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -32,7 +32,7 @@ Yes. A single `Client` instance can be shared safely across multiple threads. In
 import threading
 import aerospike_py
 
-client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()  # port varies by deployment
+client = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]}).connect()
 
 def worker(thread_id: int) -> None:
     key = ("test", "demo", f"thread_{thread_id}")
@@ -66,7 +66,12 @@ pip install aerospike-py
 pip install aerospike-py[numpy]
 ```
 
-With NumPy installed, call `LazyBatchRecords.to_numpy(dtype)` on the value returned by `batch_read()`. It produces `NumpyBatchRecords` backed by a NumPy structured array. The client fills the buffer with the GIL released, and you can pass the result directly to `torch.from_numpy(...)` without copying it. Use `batch_write_numpy()` for bulk writes from structured arrays. All other features work without NumPy.
+With NumPy installed, call `LazyBatchRecords.to_numpy(dtype)` on the value
+returned by `batch_read()`. It produces `NumpyBatchRecords` backed by a NumPy
+structured array. Select a numeric field before passing it to PyTorch, for
+example `torch.from_numpy(result.batch_records["score"])`; PyTorch does not
+accept the structured array itself. Use `batch_write_numpy()` for bulk writes
+from structured arrays. All other features work without NumPy.
 
 ## Can I migrate from the official C client?
 
@@ -96,7 +101,7 @@ import aerospike_py
 # Initialize before creating the client
 aerospike_py.init_tracing()
 
-client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()  # port varies by deployment
+client = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]}).connect()
 # ... all operations are traced automatically ...
 client.close()
 
@@ -116,7 +121,7 @@ import aerospike_py
 # Start metrics server on port 9464
 aerospike_py.start_metrics_server(9464)
 
-client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()  # port varies by deployment
+client = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]}).connect()
 # ... operations are metered automatically ...
 client.close()
 
@@ -127,7 +132,11 @@ Scrape `http://localhost:9464/metrics` from Prometheus. Operation latency histog
 
 ## What Aerospike server versions are supported?
 
-aerospike-py is tested against **Aerospike Server 6.x and 7.x** (Community and Enterprise). It is built on the Aerospike Rust Client v2.0.0-alpha.9.
+CI runs the integration suite against the current
+`aerospike/aerospike-server:latest` image, while the local Compose examples pin
+Aerospike CE 8.1.0.3. The package uses Aerospike Rust Client 2.0.0. If you need
+to support an older server release, run the integration suite against that
+version before deploying.
 
 ## How do I report a bug or request a feature?
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -2,51 +2,64 @@
 title: Getting Started
 sidebar_label: Getting Started
 sidebar_position: 1
-description: Install aerospike-py and connect to an Aerospike cluster in minutes.
+description: Install aerospike-py, connect to a cluster, and read your first record.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Installation
+This guide takes you from installation to your first successful read. You need an
+Aerospike server or cluster that your machine can already reach. `aerospike-py`
+connects to that server; it does not start one for you.
+
+## 1. Install the client
 
 ```bash
 pip install aerospike-py
 ```
 
-**Requirements:** Python 3.10+ (CPython)
+The package supports CPython 3.10 and later. PyPI provides prebuilt wheels for
+supported macOS, Linux, and Windows x64 platforms, so a normal installation does
+not require a local Rust or C toolchain.
 
-Before running the examples, make sure an Aerospike server is available at
-`127.0.0.1:3000`, or replace the host and port with a seed address for your
-cluster.
+## 2. Choose a seed address
 
-## Quick Start
+Start with the host and service port of any reachable node:
+
+```python
+config = {
+    "hosts": [("127.0.0.1", 3000)],
+}
+```
+
+Port `3000` is Aerospike's default service port. If your container, Kubernetes
+Service, or remote cluster exposes a different address, replace both values with
+the address your application can reach.
+
+:::tip[Why only one address?]
+A seed is the first node the client contacts. After connecting, the client
+discovers the other nodes and keeps the cluster view up to date. Production
+configurations can list more than one seed for startup resilience.
+:::
+
+## 3. Write and read one record
+
+Choose the API that matches your application. Both clients use the same key,
+record, and policy types.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
 
 ```python
-import aerospike_py as aerospike
-from aerospike_py import Record
+from aerospike_py import Client
 
-with aerospike.client({
-    "hosts": [("127.0.0.1", 3000)],
-}).connect() as client:
-    key: tuple[str, str, str] = ("test", "demo", "user1")
+config = {"hosts": [("127.0.0.1", 3000)]}
+key = ("test", "users", "ada")
 
-    # Write
-    client.put(key, {"name": "Alice", "age": 30})
-
-    # Read
-    record: Record = client.get(key)
-    print(record.bins)       # {"name": "Alice", "age": 30}
-    print(record.meta.gen)   # 1
-
-    # Update
-    client.increment(key, "age", 1)
-
-    # Delete
-    client.remove(key)
+with Client(config).connect() as client:
+    client.put(key, {"name": "Ada", "active": True})
+    record = client.get(key)
+    print(record.bins)
 ```
 
   </TabItem>
@@ -54,24 +67,17 @@ with aerospike.client({
 
 ```python
 import asyncio
-import aerospike_py as aerospike
-from aerospike_py import AsyncClient, Record
+from aerospike_py import AsyncClient
+
+config = {"hosts": [("127.0.0.1", 3000)]}
+key = ("test", "users", "ada")
 
 async def main() -> None:
-    async with AsyncClient({"hosts": [("127.0.0.1", 3000)]}) as client:
+    async with AsyncClient(config) as client:
         await client.connect()
-        key: tuple[str, str, str] = ("test", "demo", "user1")
-
-        await client.put(key, {"name": "Bob", "age": 25})
-
-        record: Record = await client.get(key)
-        print(record.bins)  # {"name": "Bob", "age": 25}
-
-        # Concurrent writes
-        keys = [("test", "demo", f"item_{i}") for i in range(10)]
-        await asyncio.gather(*(client.put(k, {"idx": i}) for i, k in enumerate(keys)))
-
-        await client.remove(key)
+        await client.put(key, {"name": "Ada", "active": True})
+        record = await client.get(key)
+        print(record.bins)
 
 asyncio.run(main())
 ```
@@ -79,39 +85,52 @@ asyncio.run(main())
   </TabItem>
 </Tabs>
 
-## Policies & Metadata
+Expected output:
 
-```python
-import aerospike_py as aerospike
-
-key = ("test", "demo", "user1")
-
-# TTL (seconds)
-client.put(key, {"val": 1}, meta={"ttl": 300})
-
-# Create only (fail if exists)
-client.put(key, {"val": 1}, policy={"exists": aerospike.POLICY_EXISTS_CREATE_ONLY})
-
-# Optimistic locking
-record = client.get(key)
-client.put(
-    key,
-    {"val": record.bins["val"] + 1},
-    meta={"gen": record.meta.gen},
-    policy={"gen": aerospike.POLICY_GEN_EQ},
-)
+```text
+{'name': 'Ada', 'active': True}
 ```
 
-## Next Steps
+The key has three parts: namespace (`test`), set (`users`), and user key (`ada`).
+Aerospike stores the values in named bins. `record.bins` contains those values,
+while `record.meta` contains metadata such as generation and TTL.
 
-| Topic | Description |
-|-------|-------------|
-| [Read Operations](guides/crud/read.md) | Get, select, exists, batch read |
-| [Write Operations](guides/crud/write.md) | Put, update, delete, operate, batch operate |
-| [CDT Operations](guides/crud/operations.md) | Atomic list & map operations |
-| [NumPy Batch](guides/crud/numpy-batch.md) | Zero-copy columnar batch reads |
-| [Query](guides/query-scan/query-scan.md) | Secondary index queries |
-| [Expression Filters](guides/query-scan/expression-filters.md) | Server-side filtering |
-| [Configuration](guides/config/client-config.md) | Connection, pool, timeouts |
-| [API Reference](api/client.md) | Full method signatures |
-| [Types](api/types.md) | NamedTuple / TypedDict definitions |
+## 4. Update and clean up
+
+<Tabs>
+  <TabItem value="sync-update" label="Sync" default>
+
+```python
+with Client(config).connect() as client:
+    client.increment(key, "login_count", 1)
+    updated = client.get(key)
+    print(updated.bins)
+    client.remove(key)
+```
+
+  </TabItem>
+  <TabItem value="async-update" label="Async">
+
+```python
+async with AsyncClient(config) as client:
+    await client.connect()
+    await client.increment(key, "login_count", 1)
+    updated = await client.get(key)
+    print(updated.bins)
+    await client.remove(key)
+```
+
+  </TabItem>
+</Tabs>
+
+## Where to go next
+
+| If you want to… | Read… |
+|---|---|
+| Set timeouts, pools, and multiple seeds | [Client configuration](guides/config/client-config.md) |
+| Understand records and read policies | [Read operations](guides/crud/read.md) |
+| Use TTL, generation checks, or batch writes | [Write operations](guides/crud/write.md) |
+| Handle failures by exception type | [Error handling](guides/admin/error-handling.md) |
+| Run secondary-index queries | [Query and scan](guides/query-scan/query-scan.md) |
+| Add the async client to a web service | [FastAPI integration](integrations/fastapi.md) |
+| Check every public method and type | [API reference](api/client.md) |

--- a/docs/docs/guides/architecture.md
+++ b/docs/docs/guides/architecture.md
@@ -133,7 +133,10 @@ record.key.user_key  # "user1"
 
 ### batch_read
 
-Returns a `dict[UserKey, dict]` mapping each user key to its bins. Only successful reads are included — missing or failed keys are absent from the dict.
+Returns a `LazyBatchRecords` handle. Its mapping interface exposes successful
+user-key reads as `user_key → bins`. Call `to_dict()` only when you need a plain
+dictionary, or inspect `batch_records` / `iter_records()` when you need every
+per-record result, including missing and failed reads.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -186,7 +189,10 @@ results = client.batch_write(records, policy={"ttl": 86400})  # default: 1 day
 
 **TTL priority:** per-record `{"ttl": N}` > batch-level `policy={"ttl": N}` > namespace default.
 
-**Retry:** Failed records (timeout, device overload, key busy) are automatically retried with exponential backoff. Retries stop early if the elapsed time approaches `total_timeout`.
+**Retry:** The default `retry=0` does not retry failed records. Set `retry` to a
+value greater than zero to retry eligible failures such as timeout, device
+overload, or key busy with exponential backoff. Retries stop early when the
+elapsed time approaches `total_timeout`.
 
 ```python
 results = client.batch_write(records, retry=3)

--- a/docs/docs/guides/config/client-config.md
+++ b/docs/docs/guides/config/client-config.md
@@ -16,11 +16,13 @@ import aerospike_py as aerospike
 from aerospike_py.types import ClientConfig
 
 config: ClientConfig = {
-    "hosts": [("127.0.0.1", 18710)],
-    "cluster_name": "docker",
+    "hosts": [("127.0.0.1", 3000)],
 }
 client = aerospike.client(config).connect()
 ```
+
+Set `cluster_name` only when you want the client to reject a server whose
+configured cluster name does not match the expected value.
 
 ## All Fields
 

--- a/docs/docs/guides/crud/operations.md
+++ b/docs/docs/guides/crud/operations.md
@@ -381,7 +381,6 @@ from aerospike_py import list_operations as list_ops
 
 with aerospike.client({
     "hosts": [("127.0.0.1", 3000)],
-    "cluster_name": "docker",
 }).connect() as client:
 
     key = ("test", "demo", "player1")
@@ -757,7 +756,6 @@ from aerospike_py import map_operations as map_ops
 
 with aerospike.client({
     "hosts": [("127.0.0.1", 3000)],
-    "cluster_name": "docker",
 }).connect() as client:
 
     key = ("test", "demo", "player1")

--- a/docs/docs/guides/crud/read.md
+++ b/docs/docs/guides/crud/read.md
@@ -64,7 +64,8 @@ if result.meta is not None:
 
 ## Batch Read
 
-Read multiple records in a single network call.
+Read multiple records with one batch API call. The client routes each key to the
+node that owns it, so a multi-node batch may use more than one network request.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -106,4 +107,7 @@ for user_key, bins in batch.items():
 
 - **Batch size**: 100-5,000 keys per batch is optimal. Very large batches may timeout.
 - **Timeouts**: Increase `total_timeout` for large batch operations.
-- **Error handling**: Individual batch records can fail independently. Always check `br.record` for `None`.
+- **Error handling**: The mapping view contains successful records that have a
+  user key. Compare the requested user keys with `batch.keys()` to find misses.
+  Use `batch.iter_records()` and inspect each `br.result` when you need to
+  distinguish a missing record from another per-record error.

--- a/docs/docs/guides/crud/write.md
+++ b/docs/docs/guides/crud/write.md
@@ -291,4 +291,7 @@ except RecordGenerationError:
 
 - **Batch size**: 100-5,000 keys per batch is optimal. Very large batches may timeout.
 - **Timeouts**: Increase `total_timeout` for large batch operations.
-- **Error handling**: Individual batch records can fail independently. Always check `br.record` for `None`.
+- **Error handling**: Individual batch records can fail independently. Check
+  `br.result` first. If it is non-zero, use `br.in_doubt` to decide whether a
+  retry could apply a non-idempotent write twice. `br.record` is optional result
+  data for operations that return a record; it is not the success indicator.

--- a/docs/docs/guides/query-scan/expression-filters.md
+++ b/docs/docs/guides/query-scan/expression-filters.md
@@ -15,7 +15,7 @@ Expression filters require Aerospike Server **5.2+**.
 ## Import
 
 ```python
-from aerospike_py import exp
+from aerospike_py import exp, predicates
 ```
 
 ## Basic Usage

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -45,7 +45,7 @@ aerospike_py.ClusterError: Failed to connect to host(s)
 
 3. If Aerospike runs in a container, verify that the service port is mapped and reachable from the host.
 
-### TimeoutError
+### AerospikeTimeoutError
 
 **Symptoms:**
 
@@ -60,20 +60,18 @@ aerospike_py.AerospikeTimeoutError: Operation timed out
 
 **Solutions:**
 
-1. Increase the timeout in the relevant policy:
+1. Set the operation timeout on the call that needs it:
    ```python
-   # Per-operation timeout
-   record = client.get(key, policy={"timeout": 5000})  # 5 seconds
-
-   # Client-wide default
-   client = aerospike_py.client({
-       "hosts": [("127.0.0.1", 3000)],
-       "policies": {
-           "read": {"timeout": 5000},
-           "write": {"timeout": 5000},
-       },
-   }).connect()
+   read_policy = {
+       "socket_timeout": 5_000,
+       "total_timeout": 5_000,
+   }
+   record = client.get(key, policy=read_policy)
    ```
+
+   `ClientConfig.timeout` controls the initial connection timeout. Read and
+   write timeouts belong to each operation's policy; `ClientConfig` does not
+   accept a global `policies` field.
 
 2. Check server health:
    ```python

--- a/docs/docs/integrations/fastapi.md
+++ b/docs/docs/integrations/fastapi.md
@@ -16,7 +16,6 @@ pip install fastapi uvicorn pydantic-settings aerospike-py
 ```python
 from contextlib import asynccontextmanager
 
-import aerospike_py
 from aerospike_py import AsyncClient
 from fastapi import FastAPI
 
@@ -25,12 +24,13 @@ from fastapi import FastAPI
 async def lifespan(app: FastAPI):
     client = AsyncClient({
         "hosts": [("127.0.0.1", 3000)],
-        "policies": {"key": aerospike_py.POLICY_KEY_SEND},
     })
     await client.connect()
     app.state.aerospike = client
-    yield
-    await client.close()
+    try:
+        yield
+    finally:
+        await client.close()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -55,7 +55,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     aerospike_host: str = "127.0.0.1"
-    aerospike_port: int = 18710
+    aerospike_port: int = 3000
     aerospike_namespace: str = "test"
     aerospike_set: str = "users"
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -102,9 +102,10 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
+      title: 'aerospike-py',
       logo: {
-        alt: 'aerospike-py Logo',
-        src: 'img/logo.svg',
+        alt: 'aerospike-py icon',
+        src: 'img/icon.svg',
       },
       items: [
         {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -29,7 +29,7 @@ const config: Config = {
   markdown: {
     mermaid: true,
     hooks: {
-      onBrokenMarkdownLinks: 'warn',
+      onBrokenMarkdownLinks: 'throw',
     },
   },
   themes: ['@docusaurus/theme-mermaid'],
@@ -51,38 +51,19 @@ const config: Config = {
     },
   },
 
-  plugins: [
-    function context7Widget(): import('@docusaurus/types').Plugin {
-      return {
-        name: 'context7-widget',
-        injectHtmlTags() {
-          return {
-            postBodyTags: [
-              {
-                tagName: 'script',
-                attributes: {
-                  src: 'https://context7.com/widget.js',
-                  async: true,
-                  'data-library': '/kimsoungryoul/aerospike-py',
-                  'data-color': '#E64A19',
-                  'data-position': 'bottom-right',
-                },
-              },
-            ],
-          };
-        },
-      };
-    },
-  ],
-
   presets: [
     [
       'classic',
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          editUrl:
-            'https://github.com/aerospike-ce-ecosystem/aerospike-py/tree/main/docs/',
+          editUrl: ({locale, docPath}) => {
+            const sourcePath =
+              locale === 'ko'
+                ? `docs/i18n/ko/docusaurus-plugin-content-docs/current/${docPath}`
+                : `docs/docs/${docPath}`;
+            return `https://github.com/aerospike-ce-ecosystem/aerospike-py/edit/main/${sourcePath}`;
+          },
           showLastUpdateTime: true,
         },
         blog: false,
@@ -104,7 +85,7 @@ const config: Config = {
     navbar: {
       title: 'aerospike-py',
       logo: {
-        alt: 'aerospike-py icon',
+        alt: '',
         src: 'img/icon.svg',
       },
       items: [
@@ -167,8 +148,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} aerospike-py. Built with Docusaurus.`,
     },
     prism: {
-      theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      theme: prismThemes.oneDark,
+      darkTheme: prismThemes.oneDark,
       additionalLanguages: ['python', 'bash', 'lua', 'toml', 'json'],
     },
   } satisfies Preset.ThemeConfig,

--- a/docs/i18n/ko/code.json
+++ b/docs/i18n/ko/code.json
@@ -44,7 +44,7 @@
     "description": "The label of the link targeting the tag list page"
   },
   "theme.colorToggle.ariaLabel.mode.system": {
-    "message": "system mode",
+    "message": "시스템 모드",
     "description": "The name for the system color mode"
   },
   "theme.colorToggle.ariaLabel.mode.light": {
@@ -179,7 +179,7 @@
     "description": "The ARIA label to collapse the sidebar category"
   },
   "theme.IconExternalLink.ariaLabel": {
-    "message": "(opens in new tab)",
+    "message": "(새 탭에서 열림)",
     "description": "The ARIA label for the external link icon"
   },
   "theme.NavBar.navAriaLabel": {
@@ -259,11 +259,11 @@
     "description": "The ARIA label for hamburger menu button of mobile navigation"
   },
   "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
-    "message": "Expand the dropdown",
+    "message": "드롭다운 펼치기",
     "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
   },
   "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
-    "message": "Collapse the dropdown",
+    "message": "드롭다운 접기",
     "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
   },
   "theme.docs.sidebar.expandButtonTitle": {
@@ -325,5 +325,101 @@
   "theme.tags.tagsPageTitle": {
     "message": "태그",
     "description": "The title of the tag list page"
+  },
+  "homepage.install.copied": {
+    "message": "복사됨"
+  },
+  "homepage.install.copyError": {
+    "message": "복사 실패"
+  },
+  "homepage.install.copy": {
+    "message": "복사"
+  },
+  "homepage.install.copyAriaLabel": {
+    "message": "설치 명령 복사"
+  },
+  "homepage.hero.badge": {
+    "message": "Rust + PyO3 기반"
+  },
+  "homepage.hero.title": {
+    "message": "가장 {fastest} Aerospike Python Client"
+  },
+  "homepage.hero.fastest": {
+    "message": "빠른"
+  },
+  "homepage.hero.subtitle": {
+    "message": "Rust로 구현한 고성능 Aerospike Python client — native 성능, 추가 Python dependency 없음, 완전한 Sync 및 Async 지원."
+  },
+  "homepage.hero.getStarted": {
+    "message": "시작하기"
+  },
+  "homepage.hero.viewBenchmarks": {
+    "message": "벤치마크 보기"
+  },
+  "homepage.stats.faster": {
+    "message": "공식 client 대비 빠름"
+  },
+  "homepage.stats.dependencies": {
+    "message": "Python dependency"
+  },
+  "homepage.stats.apis": {
+    "message": "두 API 지원"
+  },
+  "homepage.stats.binding": {
+    "message": "Native Rust binding"
+  },
+  "homepage.meta.title": {
+    "message": "Aerospike Python client"
+  },
+  "homepage.meta.description": {
+    "message": "PyO3와 Rust로 구현한 고성능 Aerospike Python client — 2배 빠른 성능, 추가 dependency 없음, Sync 및 Async 지원."
+  },
+  "homepage.feature.rust.title": {
+    "message": "Rust 성능"
+  },
+  "homepage.feature.rust.description": {
+    "message": "PyO3 native binary를 사용해 성능이 중요한 경로에서 Python overhead를 없앴습니다."
+  },
+  "homepage.feature.async.title": {
+    "message": "Sync 및 Async"
+  },
+  "homepage.feature.async.description": {
+    "message": "Client와 AsyncClient를 모두 제공합니다. FastAPI, Django, Gunicorn 등에서 사용할 수 있습니다."
+  },
+  "homepage.feature.dependencies.title": {
+    "message": "추가 Python dependency 없음"
+  },
+  "homepage.feature.dependencies.description": {
+    "message": "Compiled wheel로 배포하므로 native C extension을 따로 설치할 필요가 없습니다."
+  },
+  "homepage.feature.types.title": {
+    "message": "완전한 type hints"
+  },
+  "homepage.feature.types.description": {
+    "message": "PEP 561을 준수하는 .pyi stub을 포함해 IDE 자동 완성을 지원합니다."
+  },
+  "homepage.feature.numpy.title": {
+    "message": "NumPy 지원"
+  },
+  "homepage.feature.numpy.description": {
+    "message": "Batch result를 NumPy array로 바로 변환할 수 있어 analytics workload에 적합합니다."
+  },
+  "homepage.feature.title": {
+    "message": "왜 aerospike-py인가?"
+  },
+  "homepage.feature.subtitle": {
+    "message": "매 millisecond가 중요한 production workload를 위해 설계했습니다."
+  },
+  "homepage.api.title": {
+    "message": "Sync 및 Async 지원"
+  },
+  "homepage.api.description": {
+    "message": "동기식 workload에는 Client를, FastAPI, Starlette, Django Channels 같은 async framework에는 AsyncClient를 사용하세요. 두 client는 같은 API를 지원합니다."
+  },
+  "homepage.api.syncTab": {
+    "message": "Sync"
+  },
+  "homepage.api.asyncTab": {
+    "message": "Async"
   }
 }

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current.json
@@ -4,11 +4,59 @@
     "description": "The label for version current"
   },
   "sidebar.docsSidebar.category.API Reference": {
-    "message": "API Reference",
+    "message": "API 레퍼런스",
     "description": "The label for category 'API Reference' in sidebar 'docsSidebar'"
   },
   "sidebar.docsSidebar.category.Guides": {
-    "message": "Guides",
+    "message": "가이드",
     "description": "The label for category 'Guides' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Client Config": {
+    "message": "Client 설정",
+    "description": "The label for category 'Client Config' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Read": {
+    "message": "읽기",
+    "description": "The label for category 'Read' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Write": {
+    "message": "쓰기",
+    "description": "The label for category 'Write' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Admin": {
+    "message": "관리",
+    "description": "The label for category 'Admin' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Integrations": {
+    "message": "통합",
+    "description": "The label for category 'Integrations' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Observability": {
+    "message": "Observability",
+    "description": "The label for category 'Observability' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Performance": {
+    "message": "성능",
+    "description": "The label for category 'Performance' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Connection": {
+    "message": "연결",
+    "description": "The label for category 'Connection' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Records": {
+    "message": "Record",
+    "description": "The label for category 'Records' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Query & Scan": {
+    "message": "Query와 Scan",
+    "description": "The label for category 'Query & Scan' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Batch & NumPy": {
+    "message": "Batch와 NumPy",
+    "description": "The label for category 'Batch & NumPy' in sidebar 'docsSidebar'"
+  },
+  "sidebar.docsSidebar.category.Administration": {
+    "message": "관리",
+    "description": "The label for category 'Administration' in sidebar 'docsSidebar'"
   }
 }

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/client.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/client.md
@@ -1,6 +1,6 @@
 ---
-title: Client
-sidebar_label: Client (Sync & Async)
+title: Client API 레퍼런스
+sidebar_label: Client (동기·비동기)
 sidebar_position: 1
 description: Client 및 AsyncClient 클래스 API 레퍼런스
 ---
@@ -10,51 +10,57 @@ import TabItem from '@theme/TabItem';
 
 aerospike-py는 동일한 기능을 가진 동기(`Client`)와 비동기(`AsyncClient`) API를 제공합니다.
 
-## Creating a Client
+## Factory 함수
 
-<Tabs>
-  <TabItem value="sync" label="Sync Client" default>
+### `client(config)`
+
+새 동기 `Client` 인스턴스를 생성합니다. 생성 직후에는 아직 클러스터에 연결되지 않습니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `config` | [`ClientConfig`](types.md#clientconfig) dict. `(host, port)` 튜플 리스트를 값으로 갖는 `"hosts"` 키가 필요합니다. |
+
+**반환값:** 연결되지 않은 새 `Client` 인스턴스
 
 ```python
 import aerospike_py as aerospike
 
 client = aerospike.client({
     "hosts": [("127.0.0.1", 3000)],
-    "cluster_name": "docker",
 }).connect()
 ```
 
-  </TabItem>
-  <TabItem value="async" label="Async Client">
+### `async_client(config)`
+
+새 비동기 `AsyncClient` 인스턴스를 생성합니다. 생성 후 `await connect()`를 호출해야 합니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `config` | [`ClientConfig`](types.md#clientconfig) dict. `(host, port)` 튜플 리스트를 값으로 갖는 `"hosts"` 키가 필요합니다. |
+
+**반환값:** 연결되지 않은 새 `AsyncClient` 인스턴스
 
 ```python
-import asyncio
-from aerospike_py import AsyncClient
+import aerospike_py as aerospike
 
-async def main():
-    client = AsyncClient({
-        "hosts": [("127.0.0.1", 3000)],
-        "cluster_name": "docker",
-    })
-    await client.connect()
-
-asyncio.run(main())
+client = aerospike.async_client({
+    "hosts": [("127.0.0.1", 3000)],
+})
+await client.connect()
 ```
-
-  </TabItem>
-</Tabs>
 
 ## Context Manager
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
 
-### `__enter__()` / `__exit__()`
+#### `__enter__()` / `__exit__()`
 
 ```python
-with aerospike.client({
+import aerospike_py
+
+with aerospike_py.client({
     "hosts": [("127.0.0.1", 3000)],
-    "cluster_name": "docker",
 }).connect() as client:
     client.put(key, bins)
 # close()가 종료 시 자동으로 호출됩니다
@@ -63,12 +69,13 @@ with aerospike.client({
   </TabItem>
   <TabItem value="async" label="Async Client">
 
-### `async __aenter__()` / `async __aexit__()`
+#### `async __aenter__()` / `async __aexit__()`
 
 ```python
-async with AsyncClient({
+import aerospike_py
+
+async with aerospike_py.async_client({
     "hosts": [("127.0.0.1", 3000)],
-    "cluster_name": "docker",
 }) as client:
     await client.connect()
     await client.put(key, bins)
@@ -99,8 +106,11 @@ client = aerospike.client(config).connect("admin", "admin")
   <TabItem value="async" label="Async Client">
 
 ```python
-await client.connect()
-await client.connect("admin", "admin")
+# 인증 없이 연결
+client = await aerospike.async_client(config).connect()
+
+# 인증 정보로 연결
+client = await aerospike.async_client(config).connect("admin", "admin")
 ```
 
   </TabItem>
@@ -114,6 +124,33 @@ await client.connect("admin", "admin")
 if client.is_connected():
     print("Connected")
 ```
+
+### `ping()`
+
+클러스터가 실제로 응답하는지 확인하는 가벼운 health check입니다. 임의의 노드에 `info("build")`를 보내므로, 로컬 연결 상태만 확인하는 `is_connected()`와 달리 실제 network round-trip이 발생합니다.
+
+Kubernetes readiness probe, load balancer health check, connection pool 검증에 사용할 수 있습니다.
+
+**반환값:** 클러스터 노드가 응답하면 `True`, 연결되지 않았거나 응답하지 않으면 `False`
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+if client.ping():
+    print("Cluster is reachable")
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+if await client.ping():
+    print("Cluster is reachable")
+```
+
+  </TabItem>
+</Tabs>
 
 ### `close()`
 
@@ -157,7 +194,69 @@ nodes = client.get_node_names()  # sync since alpha.10 — no await needed
   </TabItem>
 </Tabs>
 
-## CRUD Operations
+## Info 명령
+
+### `info_all(command, policy=None)`
+
+모든 클러스터 노드에 Info 명령을 보냅니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `command` | Info 명령 문자열. 예: `"namespaces"` |
+| `policy` | 선택적 [`AdminPolicy`](types.md#adminpolicy) dict |
+
+**반환값:** `InfoNodeResult(node_name, error_code, response)` 튜플 리스트
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+results = client.info_all("namespaces")
+for node, error_code, response in results:
+    print(f"{node} (error={error_code}): {response}")
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+results = await client.info_all("namespaces")
+for node, error_code, response in results:
+    print(f"{node} (error={error_code}): {response}")
+```
+
+  </TabItem>
+</Tabs>
+
+### `info_random_node(command, policy=None)`
+
+임의의 클러스터 노드 하나에 Info 명령을 보냅니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `command` | Info 명령 문자열 |
+| `policy` | 선택적 [`AdminPolicy`](types.md#adminpolicy) dict |
+
+**반환값:** 노드가 반환한 Info 응답 문자열
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+build = client.info_random_node("build")
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+build = await client.info_random_node("build")
+```
+
+  </TabItem>
+</Tabs>
+
+## CRUD 작업
 
 ### `put(key, bins, meta=None, policy=None)`
 
@@ -168,7 +267,7 @@ nodes = client.get_node_names()  # sync since alpha.10 — no await needed
 | `key` | `tuple[str, str, str\|int\|bytes]` | `(namespace, set, pk)` |
 | `bins` | `dict[str, Any]` | 빈 이름-값 쌍 |
 | `meta` | [`WriteMeta`](types.md#writemeta) | 선택: `{"ttl": int, "gen": int}` |
-| `policy` | [`WritePolicy`](types.md#writepolicy) | 선택: `{"key", "exists", "gen", "timeout", ...}` |
+| `policy` | [`WritePolicy`](types.md#writepolicy) | 선택: `{"key", "exists", "gen", "socket_timeout", "total_timeout", ...}` |
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -513,6 +612,149 @@ for br in batch.batch_records:
   </TabItem>
 </Tabs>
 
+### `batch_write(records, policy=None, retry=0)`
+
+레코드마다 서로 다른 bin을 한 번의 Batch 호출로 씁니다. 각 항목은 `(key, bins)` 또는 `(key, bins, meta)` 튜플입니다.
+
+- `key`: `(namespace, set_name, primary_key)` 튜플
+- `bins`: bin 이름과 값으로 구성된 dict
+- `meta`: 선택적 [`WriteMeta`](types.md#writemeta) dict. 예: `{"ttl": 300}`
+
+`ttl`, `key`, `exists`, `gen`, `commit_level`, `durable_delete`는 Batch `policy`와 레코드별 `meta`에 모두 지정할 수 있습니다. 같은 필드가 양쪽에 있으면 **레코드별 `meta`가 우선합니다**.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `records` | `(key, bins)` 또는 `(key, bins, meta)` 튜플 리스트 |
+| `policy` | 선택적 [`BatchPolicy`](types.md#batchpolicy) dict. Batch 전송 설정과 쓰기 기본값을 함께 지정합니다. |
+| `retry` | 일시적 오류가 발생한 레코드의 최대 재시도 횟수. 기본값은 `0`이며 자동 재시도하지 않습니다. |
+
+**반환값:** 레코드별 결과를 `batch_records`에 담은 [`BatchWriteResult`](types.md#batchwriteresult). 각 `BatchRecord.result`가 `0`인지 확인하세요.
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+import aerospike_py
+
+records = [
+    (("test", "demo", "user1"), {"name": "Alice", "age": 30}),
+    (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
+]
+
+# 모든 레코드에 적용할 Batch 기본값
+result = client.batch_write(
+    records,
+    policy={
+        "ttl": 3_600,
+        "key": aerospike_py.POLICY_KEY_SEND,
+    },
+    retry=3,
+)
+
+# 레코드별 meta는 Batch 기본값보다 우선합니다.
+result = client.batch_write([
+    (("test", "demo", "user1"), {"name": "Alice"}, {"ttl": 60}),
+    (("test", "demo", "user2"), {"name": "Bob"}),
+])
+
+for batch_record in result.batch_records:
+    if batch_record.result != 0:
+        print(batch_record.key, batch_record.result, batch_record.in_doubt)
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+records = [
+    (("test", "demo", "user1"), {"name": "Alice", "age": 30}),
+    (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
+]
+result = await client.batch_write(records, policy={"ttl": 3_600}, retry=3)
+
+for batch_record in result.batch_records:
+    if batch_record.result != 0:
+        print(batch_record.key, batch_record.result, batch_record.in_doubt)
+```
+
+  </TabItem>
+</Tabs>
+
+:::note
+
+재시도 도중 전송 오류가 발생하면 재시도를 중단하고 부분 결과를 반환할 수 있습니다. `batch_write` 결과를 성공으로 간주하기 전에 모든 `BatchRecord.result`를 확인하세요.
+
+:::
+
+### `batch_write_numpy(data, namespace, set_name, _dtype, key_field='_key', policy=None, retry=0)`
+
+NumPy 구조화 배열의 각 행을 별도 Record로 씁니다. `key_field`로 지정한 field가 Record key가 되고, 이름이 밑줄로 시작하지 않는 나머지 field가 bin이 됩니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `data` | Record 데이터가 들어 있는 NumPy 구조화 배열 |
+| `namespace` | 대상 namespace |
+| `set_name` | 대상 set |
+| `_dtype` | 배열 layout을 설명하는 NumPy dtype |
+| `key_field` | user key로 사용할 dtype field 이름. 기본값은 `"_key"` |
+| `policy` | 선택적 [`BatchPolicy`](types.md#batchpolicy) dict |
+| `retry` | 일시적 오류가 발생한 Record의 최대 재시도 횟수. 기본값은 `0` |
+
+**반환값:** 레코드별 결과를 `batch_records`에 담은 [`BatchWriteResult`](types.md#batchwriteresult)
+
+<Tabs>
+  <TabItem value="sync" label="Sync Client" default>
+
+```python
+import numpy as np
+
+dtype = np.dtype([
+    ("_key", "i4"),
+    ("score", "f8"),
+    ("count", "i4"),
+])
+data = np.array([(1, 0.95, 10), (2, 0.87, 20)], dtype=dtype)
+
+result = client.batch_write_numpy(
+    data,
+    "test",
+    "demo",
+    dtype,
+    retry=3,
+)
+for batch_record in result.batch_records:
+    if batch_record.result != 0:
+        print(batch_record.key, batch_record.result)
+```
+
+  </TabItem>
+  <TabItem value="async" label="Async Client">
+
+```python
+import numpy as np
+
+dtype = np.dtype([
+    ("_key", "i4"),
+    ("score", "f8"),
+    ("count", "i4"),
+])
+data = np.array([(1, 0.95, 10), (2, 0.87, 20)], dtype=dtype)
+
+result = await client.batch_write_numpy(
+    data,
+    "test",
+    "demo",
+    dtype,
+    retry=3,
+)
+for batch_record in result.batch_records:
+    if batch_record.result != 0:
+        print(batch_record.key, batch_record.result)
+```
+
+  </TabItem>
+</Tabs>
+
 ### `batch_operate(keys, ops, policy=None)`
 
 여러 레코드에 연산을 실행합니다.
@@ -802,9 +1044,9 @@ result = await client.apply(key, "my_udf", "my_function", [1, "hello"])
   </TabItem>
 </Tabs>
 
-## Concurrency Patterns (Async)
+## 비동기 동시성 패턴
 
-### `asyncio.gather`를 사용한 병렬 쓰기
+#### `asyncio.gather`를 사용한 병렬 쓰기
 
 ```python
 keys = [("test", "demo", f"item_{i}") for i in range(100)]
@@ -812,7 +1054,7 @@ tasks = [client.put(k, {"idx": i}) for i, k in enumerate(keys)]
 await asyncio.gather(*tasks)
 ```
 
-### 병렬 읽기
+#### 병렬 읽기
 
 ```python
 keys = [("test", "demo", f"item_{i}") for i in range(100)]
@@ -820,7 +1062,7 @@ tasks = [client.get(k) for k in keys]
 results = await asyncio.gather(*tasks, return_exceptions=True)
 ```
 
-### 혼합 연산
+#### 혼합 연산
 
 ```python
 async def process_user(client, user_id):
@@ -836,9 +1078,39 @@ results = await asyncio.gather(*[
 ])
 ```
 
-## Admin Operations
+## 사용자 관리
 
-### User Management
+다음 메서드는 보안이 활성화된 Aerospike 클러스터의 사용자를 관리합니다. `AsyncClient`에서는 각 호출 앞에 `await`를 붙입니다.
+
+### `admin_create_user(username, password, roles, policy=None)`
+
+지정한 비밀번호와 역할로 사용자를 생성합니다.
+
+### `admin_drop_user(username, policy=None)`
+
+사용자를 삭제합니다.
+
+### `admin_change_password(username, password, policy=None)`
+
+사용자의 비밀번호를 변경합니다.
+
+### `admin_grant_roles(username, roles, policy=None)`
+
+사용자에게 역할을 부여합니다.
+
+### `admin_revoke_roles(username, roles, policy=None)`
+
+사용자에게서 역할을 회수합니다.
+
+### `admin_query_user_info(username, policy=None)`
+
+한 사용자의 정보를 반환합니다.
+
+### `admin_query_users_info(policy=None)`
+
+모든 사용자 정보를 반환합니다.
+
+#### 사용자 관리 요약
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -850,8 +1122,8 @@ results = await asyncio.gather(*[
 | `admin_change_password(username, password)` | 비밀번호 변경 |
 | `admin_grant_roles(username, roles)` | 역할 부여 |
 | `admin_revoke_roles(username, roles)` | 역할 회수 |
-| `admin_query_user(username)` | 사용자 정보 조회 |
-| `admin_query_users()` | 전체 사용자 목록 |
+| `admin_query_user_info(username)` | 사용자 정보 조회 |
+| `admin_query_users_info()` | 전체 사용자 목록 |
 
   </TabItem>
   <TabItem value="async" label="Async Client">
@@ -863,13 +1135,49 @@ results = await asyncio.gather(*[
 | `async admin_change_password(username, password)` | 비밀번호 변경 |
 | `async admin_grant_roles(username, roles)` | 역할 부여 |
 | `async admin_revoke_roles(username, roles)` | 역할 회수 |
-| `async admin_query_user(username)` | 사용자 정보 조회 |
-| `async admin_query_users()` | 전체 사용자 목록 |
+| `async admin_query_user_info(username)` | 사용자 정보 조회 |
+| `async admin_query_users_info()` | 전체 사용자 목록 |
 
   </TabItem>
 </Tabs>
 
-### Role Management
+## 역할 관리
+
+역할과 privilege, network allowlist 및 quota를 관리합니다. `AsyncClient`에서는 각 호출 앞에 `await`를 붙입니다.
+
+### `admin_create_role(role, privileges, policy=None, whitelist=None, read_quota=0, write_quota=0)`
+
+privilege와 선택적 접근 제한을 포함한 역할을 생성합니다.
+
+### `admin_drop_role(role, policy=None)`
+
+역할을 삭제합니다.
+
+### `admin_grant_privileges(role, privileges, policy=None)`
+
+역할에 privilege를 부여합니다.
+
+### `admin_revoke_privileges(role, privileges, policy=None)`
+
+역할에서 privilege를 회수합니다.
+
+### `admin_query_role(role, policy=None)`
+
+한 역할의 정보를 반환합니다.
+
+### `admin_query_roles(policy=None)`
+
+모든 역할 정보를 반환합니다.
+
+### `admin_set_whitelist(role, whitelist, policy=None)`
+
+역할의 network allowlist를 설정합니다.
+
+### `admin_set_quotas(role, read_quota=0, write_quota=0, policy=None)`
+
+역할의 읽기 및 쓰기 quota를 설정합니다.
+
+#### 역할 관리 요약
 
 <Tabs>
   <TabItem value="sync" label="Sync Client" default>
@@ -924,6 +1232,299 @@ await client.admin_create_role("custom_role", [
 
   </TabItem>
 </Tabs>
+
+## Query 및 AsyncQuery 객체
+
+`Client.query(namespace, set_name)` 또는 `AsyncClient.query(namespace, set_name)`가 반환하는 Secondary Index Query 객체입니다. `where()`로 predicate를 지정하고, `select()`로 반환할 bin을 선택한 뒤 `results()` 또는 `foreach()`로 실행합니다.
+
+<Tabs>
+  <TabItem value="query" label="Query" default>
+
+```python
+from aerospike_py import predicates
+
+query = client.query("test", "demo")
+query.select("name", "age")
+query.where(predicates.between("age", 20, 30))
+records = query.results()
+```
+
+  </TabItem>
+  <TabItem value="async-query" label="AsyncQuery">
+
+```python
+from aerospike_py import predicates
+
+query = client.query("test", "demo")
+query.select("name", "age")
+query.where(predicates.between("age", 20, 30))
+records = await query.results()
+```
+
+  </TabItem>
+</Tabs>
+
+### `select(*bins)`
+
+Query 결과에 포함할 bin을 선택합니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `*bins` | 결과에 포함할 bin 이름 |
+
+```python
+query = client.query("test", "demo")
+query.select("name", "age")
+```
+
+### `where(predicate)`
+
+Query에 predicate 필터를 지정합니다. 필터 대상 bin에는 일치하는 Secondary Index가 필요합니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `predicate` | `aerospike_py.predicates` helper로 만든 predicate 튜플 |
+
+```python
+from aerospike_py import predicates
+
+query = client.query("test", "demo")
+query.where(predicates.equals("name", "Alice"))
+```
+
+### `results(policy=None)`
+
+Query를 실행하고 일치하는 모든 Record를 반환합니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `policy` | 선택적 [`QueryPolicy`](types.md#querypolicy) dict |
+
+**반환값:** `Record` NamedTuple 리스트
+
+<Tabs>
+  <TabItem value="sync" label="Query" default>
+
+```python
+records = query.results()
+for record in records:
+    print(record.bins)
+```
+
+  </TabItem>
+  <TabItem value="async" label="AsyncQuery">
+
+```python
+records = await query.results()
+for record in records:
+    print(record.bins)
+```
+
+  </TabItem>
+</Tabs>
+
+### `foreach(callback, policy=None)`
+
+Query를 실행해 각 Record마다 callback을 호출합니다. callback이 `False`를 반환하면 순회를 일찍 종료합니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `callback` | 각 Record를 받는 함수. `False`를 반환하면 중단합니다. |
+| `policy` | 선택적 [`QueryPolicy`](types.md#querypolicy) dict |
+
+<Tabs>
+  <TabItem value="sync" label="Query" default>
+
+```python
+def process(record):
+    print(record.bins)
+
+query.foreach(process)
+```
+
+  </TabItem>
+  <TabItem value="async" label="AsyncQuery">
+
+```python
+def process(record):
+    print(record.bins)
+
+await query.foreach(process)
+```
+
+  </TabItem>
+</Tabs>
+
+## Partition Filter helper
+
+### `partition_filter_all()`
+
+4096개 partition 전체를 포함하는 `PartitionFilter`를 만듭니다. policy에서 `partition_filter`를 생략한 것과 같습니다.
+
+```python
+import aerospike_py
+
+partition_filter = aerospike_py.partition_filter_all()
+```
+
+### `partition_filter_by_id(partition_id)`
+
+partition 하나만 대상으로 하는 `PartitionFilter`를 만듭니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `partition_id` | `0` 이상 `4095` 이하의 partition index |
+
+유효 범위를 벗어나면 `ValueError`가 발생합니다.
+
+```python
+partition_filter = aerospike_py.partition_filter_by_id(42)
+```
+
+### `partition_filter_by_range(begin, count)`
+
+`begin`부터 `count`개 partition을 대상으로 하는 `PartitionFilter`를 만듭니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `begin` | 첫 partition. `0` 이상 `4095` 이하 |
+| `count` | partition 수. `begin + count`는 `4096` 이하여야 하며 `0`도 허용됩니다. |
+
+범위가 4096을 넘으면 `ValueError`가 발생합니다.
+
+```python
+partition_filter = aerospike_py.partition_filter_by_range(0, 512)
+```
+
+## 로깅
+
+### `set_log_level(level)`
+
+`aerospike_py`의 Rust 내부 및 Python 측 log level을 함께 설정합니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `level` | `LOG_LEVEL_OFF`, `LOG_LEVEL_ERROR`, `LOG_LEVEL_WARN`, `LOG_LEVEL_INFO`, `LOG_LEVEL_DEBUG`, `LOG_LEVEL_TRACE` 중 하나 |
+
+```python
+import aerospike_py
+
+aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)
+```
+
+### `dropped_log_count()`
+
+Rust logging bridge가 Python GIL을 확보하지 못해 버린 log message 수를 반환합니다. interpreter 종료 중에도 WARN 및 ERROR message는 fallback으로 stderr에 출력됩니다.
+
+**반환값:** process 시작 이후 버려진 message 수
+
+```python
+dropped = aerospike_py.dropped_log_count()
+```
+
+## 메트릭
+
+### `get_metrics()`
+
+수집한 메트릭을 Prometheus exposition format 문자열로 반환합니다.
+
+```python
+import aerospike_py
+
+print(aerospike_py.get_metrics())
+```
+
+### `set_metrics_enabled(enabled)`
+
+Prometheus 메트릭 수집을 켜거나 끕니다. 성능 측정 시 메트릭 오버헤드를 제외하려면 일시적으로 비활성화할 수 있습니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `enabled` | 활성화하려면 `True`, 비활성화하려면 `False`. 기본 상태는 활성화입니다. |
+
+```python
+aerospike_py.set_metrics_enabled(False)
+# benchmark 실행
+aerospike_py.set_metrics_enabled(True)
+```
+
+### `is_metrics_enabled()`
+
+Prometheus 메트릭 수집이 활성화되어 있는지 반환합니다.
+
+```python
+if aerospike_py.is_metrics_enabled():
+    print(aerospike_py.get_metrics())
+```
+
+### `set_internal_stage_metrics_enabled(enabled)`
+
+내부 단계 프로파일링 메트릭을 켜거나 끕니다. 이 설정은 `batch_read` 각 단계의 시간을 기록하는 `db_client_internal_stage_seconds` histogram을 제어합니다. 기본값은 비활성화이며, process 시작 시 `AEROSPIKE_PY_INTERNAL_METRICS=1`로 활성화할 수도 있습니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `enabled` | 활성화하려면 `True`, 비활성화하려면 `False` |
+
+```python
+aerospike_py.set_internal_stage_metrics_enabled(True)
+```
+
+### `is_internal_stage_metrics_enabled()`
+
+내부 단계 프로파일링 메트릭의 활성화 여부를 반환합니다.
+
+```python
+enabled = aerospike_py.is_internal_stage_metrics_enabled()
+```
+
+### `internal_stage_profiling()`
+
+특정 코드 블록에서만 내부 단계 프로파일링을 활성화하는 Context Manager입니다. 블록을 나가면 이전 상태로 복원합니다.
+
+```python
+with aerospike_py.internal_stage_profiling():
+    lazy_records = await client.batch_read(keys)
+```
+
+### `start_metrics_server(port=9464)`
+
+Prometheus가 수집할 `/metrics` endpoint를 제공하는 background HTTP server를 시작합니다.
+
+| 파라미터 | 설명 |
+|-----------|------|
+| `port` | listen할 TCP port. 기본값은 `9464` |
+
+```python
+aerospike_py.start_metrics_server(port=9464)
+```
+
+### `stop_metrics_server()`
+
+background 메트릭 HTTP server를 중지합니다.
+
+```python
+aerospike_py.stop_metrics_server()
+```
+
+## Tracing
+
+### `init_tracing()`
+
+OpenTelemetry tracing을 초기화합니다. 설정은 표준 `OTEL_*` 환경 변수를 읽습니다.
+
+```python
+import aerospike_py
+
+aerospike_py.init_tracing()
+```
+
+### `shutdown_tracing()`
+
+대기 중인 span을 flush하고 tracer provider를 종료합니다. 모든 span이 전송되도록 process 종료 전에 호출하세요.
+
+```python
+aerospike_py.shutdown_tracing()
+```
 
 ## Expression Filters
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/constants.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/constants.md
@@ -1,8 +1,8 @@
 ---
-title: Constants
-sidebar_label: Constants
+title: 상수
+sidebar_label: 상수
 sidebar_position: 4
-description: All constants used across the aerospike-py API.
+description: aerospike-py API에서 사용하는 모든 상수
 ---
 
 ```python

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/exceptions.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/exceptions.md
@@ -1,8 +1,8 @@
 ---
-title: Exceptions
-sidebar_label: Exceptions
+title: 예외
+sidebar_label: 예외
 sidebar_position: 3
-description: Exception hierarchy and error handling patterns.
+description: 예외 계층 구조와 오류 처리 패턴
 ---
 
 ```python

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/query-scan.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/query-scan.md
@@ -1,8 +1,8 @@
 ---
-title: Query API
+title: Query API 레퍼런스
 sidebar_label: Query
 sidebar_position: 5
-description: Query and AsyncQuery class reference with predicates.
+description: predicate를 사용하는 Query 및 AsyncQuery 클래스 레퍼런스
 ---
 
 ## Query / AsyncQuery

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/types.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/types.md
@@ -1,8 +1,8 @@
 ---
-title: Types
-sidebar_label: Types
+title: 타입
+sidebar_label: 타입
 sidebar_position: 2
-description: NamedTuple return types and TypedDict input types.
+description: NamedTuple 반환 타입과 TypedDict 입력 타입
 ---
 
 모든 타입은 `aerospike_py` 또는 `aerospike_py.types` 에서 import 가능.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/contributing.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/contributing.md
@@ -1,8 +1,8 @@
 ---
-title: Contributing
-sidebar_label: Contributing
+title: 기여 가이드
+sidebar_label: 기여 가이드
 sidebar_position: 100
-description: Development setup, build, test, and code style guidelines.
+description: 개발 환경 설정, 빌드, 테스트 및 코드 스타일 가이드
 ---
 
 ## Setup

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/faq.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/faq.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 99
-title: FAQ
-description: Frequently asked questions about aerospike-py.
+title: 자주 묻는 질문(FAQ)
+description: aerospike-py에 대해 자주 묻는 질문
 ---
 
 ## aerospike-py 는 왜 Rust 로 작성되었나요?
@@ -32,7 +32,7 @@ aerospike-py는 모든 database I/O 중에 Python GIL(Global Interpreter Lock)�
 import threading
 import aerospike_py
 
-client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()  # port varies by deployment
+client = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]}).connect()
 
 def worker(thread_id: int) -> None:
     key = ("test", "demo", f"thread_{thread_id}")
@@ -66,7 +66,13 @@ pip install aerospike-py
 pip install aerospike-py[numpy]
 ```
 
-NumPy를 설치하면 `batch_read()`가 반환한 `LazyBatchRecords`에서 `to_numpy(dtype)`를 호출할 수 있습니다. 이 메서드는 NumPy structured array를 사용하는 `NumpyBatchRecords`를 만듭니다. Client가 GIL을 해제한 상태에서 buffer를 채우므로 결과를 복사하지 않고 `torch.from_numpy(...)`에 바로 전달할 수 있습니다. Structured array를 bulk write할 때는 `batch_write_numpy()`를 사용합니다. 그 밖의 기능은 NumPy 없이도 동일하게 동작합니다.
+NumPy를 설치하면 `batch_read()`가 반환한 `LazyBatchRecords`에서
+`to_numpy(dtype)`를 호출할 수 있습니다. 이 메서드는 NumPy structured array를
+사용하는 `NumpyBatchRecords`를 만듭니다. PyTorch에는 structured array 전체가
+아니라 `torch.from_numpy(result.batch_records["score"])`처럼 numeric field를
+선택해 전달해야 합니다. Structured array를 bulk write할 때는
+`batch_write_numpy()`를 사용합니다. 그 밖의 기능은 NumPy 없이도 동일하게
+동작합니다.
 
 ## 공식 C client 에서 migrate 가능한가요?
 
@@ -96,7 +102,7 @@ import aerospike_py
 # client 생성 전 초기화
 aerospike_py.init_tracing()
 
-client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()  # port varies by deployment
+client = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]}).connect()
 # ... 모든 operation 이 자동으로 traced ...
 client.close()
 
@@ -116,7 +122,7 @@ import aerospike_py
 # port 9464 에서 metrics server 시작
 aerospike_py.start_metrics_server(9464)
 
-client = aerospike_py.client({"hosts": [("127.0.0.1", 18710)]}).connect()  # port varies by deployment
+client = aerospike_py.client({"hosts": [("127.0.0.1", 3000)]}).connect()
 # ... operation 이 자동으로 metered ...
 client.close()
 
@@ -127,7 +133,11 @@ Prometheus에서 `http://localhost:9464/metrics`를 scrape하세요. Operation t
 
 ## 어떤 Aerospike server 버전을 지원하나요?
 
-aerospike-py는 **Aerospike Server 6.x와 7.x**의 Community 및 Enterprise edition을 대상으로 테스트합니다. 내부적으로 Aerospike Rust Client v2.0.0-alpha.9를 사용합니다.
+CI는 현재 `aerospike/aerospike-server:latest` image를 대상으로 integration
+suite를 실행하고, 로컬 Compose 예제는 Aerospike CE 8.1.0.3을 고정해서
+사용합니다. Package는 Aerospike Rust Client 2.0.0을 사용합니다. 더 오래된
+server release를 지원해야 한다면 배포 전에 해당 version으로 integration suite를
+실행하세요.
 
 ## bug 신고 또는 기능 요청은 어떻게 하나요?
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/getting-started.md
@@ -1,50 +1,65 @@
 ---
-title: Getting Started
-sidebar_label: Getting Started
+title: 시작하기
+sidebar_label: 시작하기
 sidebar_position: 1
-description: Install aerospike-py and connect to an Aerospike cluster in minutes.
+description: aerospike-py를 설치하고 cluster에 연결해 첫 record를 조회합니다.
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Installation
+이 문서는 설치부터 첫 record 조회까지 안내합니다. 먼저 현재 machine에서 접근할 수
+있는 Aerospike server 또는 cluster가 필요합니다. `aerospike-py`는 실행 중인
+server에 연결하는 client이며 server를 함께 시작하지 않습니다.
+
+## 1. Client 설치
 
 ```bash
 pip install aerospike-py
 ```
 
-**Requirements:** Python 3.10+ (CPython)
+CPython 3.10 이상을 지원합니다. 지원하는 macOS, Linux, Windows x64 환경에서는
+PyPI가 prebuilt wheel을 제공하므로, 일반적인 설치 과정에 로컬 Rust 또는 C
+toolchain이 필요하지 않습니다.
 
-예제를 실행하기 전에 `127.0.0.1:3000`에서 Aerospike server가 실행 중인지 확인하세요. 다른 환경을 사용한다면 host와 port를 해당 cluster의 seed address로 바꾸세요.
+## 2. Seed address 설정
 
-## Quick Start
+접근할 수 있는 node 하나의 host와 service port로 시작합니다.
+
+```python
+config = {
+    "hosts": [("127.0.0.1", 3000)],
+}
+```
+
+`3000`은 Aerospike의 기본 service port입니다. Container, Kubernetes Service,
+remote cluster가 다른 address를 노출한다면 두 값을 application에서 접근할 수
+있는 address로 바꾸세요.
+
+:::tip[Address가 하나만 있어도 되는 이유]
+Seed는 client가 처음 연결하는 node입니다. 연결이 끝나면 client가 나머지 node를
+찾고 cluster 정보를 계속 갱신합니다. Production 환경에서는 시작 시 가용성을 높이기
+위해 seed를 여러 개 지정할 수 있습니다.
+:::
+
+## 3. 첫 record 쓰기와 읽기
+
+Application에 맞는 API를 선택하세요. Sync와 async client는 같은 key, record,
+policy type을 사용합니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
 
 ```python
-import aerospike_py as aerospike
-from aerospike_py import Record
+from aerospike_py import Client
 
-with aerospike.client({
-    "hosts": [("127.0.0.1", 3000)],
-}).connect() as client:
-    key: tuple[str, str, str] = ("test", "demo", "user1")
+config = {"hosts": [("127.0.0.1", 3000)]}
+key = ("test", "users", "ada")
 
-    # Write
-    client.put(key, {"name": "Alice", "age": 30})
-
-    # Read
-    record: Record = client.get(key)
-    print(record.bins)       # {"name": "Alice", "age": 30}
-    print(record.meta.gen)   # 1
-
-    # Update
-    client.increment(key, "age", 1)
-
-    # Delete
-    client.remove(key)
+with Client(config).connect() as client:
+    client.put(key, {"name": "Ada", "active": True})
+    record = client.get(key)
+    print(record.bins)
 ```
 
   </TabItem>
@@ -52,24 +67,17 @@ with aerospike.client({
 
 ```python
 import asyncio
-import aerospike_py as aerospike
-from aerospike_py import AsyncClient, Record
+from aerospike_py import AsyncClient
+
+config = {"hosts": [("127.0.0.1", 3000)]}
+key = ("test", "users", "ada")
 
 async def main() -> None:
-    async with AsyncClient({"hosts": [("127.0.0.1", 3000)]}) as client:
+    async with AsyncClient(config) as client:
         await client.connect()
-        key: tuple[str, str, str] = ("test", "demo", "user1")
-
-        await client.put(key, {"name": "Bob", "age": 25})
-
-        record: Record = await client.get(key)
-        print(record.bins)  # {"name": "Bob", "age": 25}
-
-        # Concurrent writes
-        keys = [("test", "demo", f"item_{i}") for i in range(10)]
-        await asyncio.gather(*(client.put(k, {"idx": i}) for i, k in enumerate(keys)))
-
-        await client.remove(key)
+        await client.put(key, {"name": "Ada", "active": True})
+        record = await client.get(key)
+        print(record.bins)
 
 asyncio.run(main())
 ```
@@ -77,39 +85,52 @@ asyncio.run(main())
   </TabItem>
 </Tabs>
 
-## Policy 와 Metadata
+예상 출력:
 
-```python
-import aerospike_py as aerospike
-
-key = ("test", "demo", "user1")
-
-# TTL (초)
-client.put(key, {"val": 1}, meta={"ttl": 300})
-
-# Create only (이미 존재하면 실패)
-client.put(key, {"val": 1}, policy={"exists": aerospike.POLICY_EXISTS_CREATE_ONLY})
-
-# Optimistic locking
-record = client.get(key)
-client.put(
-    key,
-    {"val": record.bins["val"] + 1},
-    meta={"gen": record.meta.gen},
-    policy={"gen": aerospike.POLICY_GEN_EQ},
-)
+```text
+{'name': 'Ada', 'active': True}
 ```
 
-## 다음 단계
+Key는 namespace(`test`), set(`users`), user key(`ada`)로 구성됩니다. Aerospike는
+값을 이름이 있는 bin에 저장합니다. `record.bins`에는 bin 값이, `record.meta`에는
+generation과 TTL 같은 metadata가 들어 있습니다.
 
-| Topic | 설명 |
-|-------|-------------|
-| [Read Operations](guides/crud/read.md) | get, select, exists, batch read |
-| [Write Operations](guides/crud/write.md) | put, update, delete, operate, batch operate |
-| [CDT Operations](guides/crud/operations.md) | atomic list 와 map operation |
-| [NumPy Batch](guides/crud/numpy-batch.md) | zero-copy columnar batch read |
-| [Query](guides/query-scan/query-scan.md) | secondary index 기반 query |
-| [Expression Filters](guides/query-scan/expression-filters.md) | server-side filtering |
-| [Configuration](guides/config/client-config.md) | connection, pool, timeout |
-| [API Reference](api/client.md) | 전체 method signature |
-| [Types](api/types.md) | NamedTuple / TypedDict 정의 |
+## 4. Update와 정리
+
+<Tabs>
+  <TabItem value="sync-update" label="Sync" default>
+
+```python
+with Client(config).connect() as client:
+    client.increment(key, "login_count", 1)
+    updated = client.get(key)
+    print(updated.bins)
+    client.remove(key)
+```
+
+  </TabItem>
+  <TabItem value="async-update" label="Async">
+
+```python
+async with AsyncClient(config) as client:
+    await client.connect()
+    await client.increment(key, "login_count", 1)
+    updated = await client.get(key)
+    print(updated.bins)
+    await client.remove(key)
+```
+
+  </TabItem>
+</Tabs>
+
+## 다음 문서
+
+| 필요한 작업 | 참고 문서 |
+|---|---|
+| Timeout, connection pool, 여러 seed 설정 | [Client configuration](guides/config/client-config.md) |
+| Record와 read policy 이해 | [Read operations](guides/crud/read.md) |
+| TTL, generation check, batch write 사용 | [Write operations](guides/crud/write.md) |
+| Exception type별 오류 처리 | [Error handling](guides/admin/error-handling.md) |
+| Secondary index query 실행 | [Query and scan](guides/query-scan/query-scan.md) |
+| Web service에 async client 연결 | [FastAPI integration](integrations/fastapi.md) |
+| Public method와 type 확인 | [API reference](api/client.md) |

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/admin.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/admin.md
@@ -1,9 +1,9 @@
 ---
-title: Admin Guide
-sidebar_label: User & Role Management
+title: 사용자 및 역할 관리 가이드
+sidebar_label: 사용자 및 역할 관리
 sidebar_position: 1
 slug: /guides/admin
-description: User and role management for security-enabled Aerospike clusters.
+description: 보안이 활성화된 Aerospike 클러스터의 사용자 및 역할 관리
 ---
 
 이 기능을 사용하려면 security가 활성화된 Aerospike server가 필요합니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/error-handling.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/error-handling.md
@@ -1,9 +1,9 @@
 ---
-title: Error Handling
-sidebar_label: Error Handling
+title: 오류 처리
+sidebar_label: 오류 처리
 sidebar_position: 3
 slug: /guides/error-handling
-description: Production error handling patterns for aerospike-py.
+description: aerospike-py를 위한 운영 환경 오류 처리 패턴
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/udf.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/admin/udf.md
@@ -1,9 +1,9 @@
 ---
-title: UDF Guide
+title: UDF 가이드
 sidebar_label: UDF (Lua)
 sidebar_position: 2
 slug: /guides/udf
-description: Register, execute, and remove Lua UDFs on the Aerospike server.
+description: Aerospike 서버에서 Lua UDF를 등록·실행·제거하는 방법
 ---
 
 User-Defined Function(UDF)은 Lua 스크립트입니다. Aerospike는 대상 record를 소유한 server node에서 스크립트를 실행합니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/api-comparison.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/api-comparison.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 8
-title: API Comparison
-sidebar_label: API Comparison
+title: API 비교
+sidebar_label: API 비교
 slug: /guides/api-comparison
-description: Side-by-side API comparison between the official C-based client and aerospike-py.
+description: 공식 C 기반 Client와 aerospike-py의 API를 나란히 비교
 ---
 
 이 문서는 **공식 C 기반 client**(PyPI의 `aerospike`)와 Rust 기반 **aerospike-py**를 비교합니다. 단계별 이전 방법은 [Migration Guide](/docs/guides/migration)를 참고하세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/architecture.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/architecture.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 1
-title: Architecture
-description: How aerospike-py works under the hood — layers, GIL handling, data flow, and batch operations.
+title: 아키텍처
+description: aerospike-py의 내부 동작 구조 — 계층, GIL 처리, 데이터 흐름 및 Batch 작업
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Architecture
+# 아키텍처
 
 aerospike-py는 [PyO3](https://pyo3.rs)를 사용해 [Aerospike Rust Client](https://github.com/aerospike/aerospike-client-rust)를 native Python extension으로 제공합니다. Python application은 type annotation을 갖춘 익숙한 API를 사용하고, Rust core가 Aerospike I/O를 처리합니다.
 
@@ -133,7 +133,10 @@ record.key.user_key  # "user1"
 
 ### batch_read
 
-각 user key 를 그 bin 으로 매핑하는 `dict[UserKey, dict]` 반환. 성공한 read 만 포함 — missing 또는 failed key 는 dict 에 없음.
+`LazyBatchRecords` handle을 반환합니다. Mapping interface는 성공한 user-key read를
+`user_key → bins` 형태로 제공합니다. Plain dictionary가 필요할 때만 `to_dict()`를
+호출하세요. Missing과 failed read를 포함한 모든 per-record result가 필요하다면
+`batch_records` 또는 `iter_records()`를 확인합니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -186,7 +189,10 @@ results = client.batch_write(records, policy={"ttl": 86400})  # default: 1일
 
 **TTL 우선순위:** per-record `{"ttl": N}` > batch-level `policy={"ttl": N}` > namespace default.
 
-**Retry:** 실패한 record (timeout, device overload, key busy) 는 exponential backoff 로 자동 재시도. elapsed time 이 `total_timeout` 에 근접하면 retry 조기 종료.
+**Retry:** 기본값 `retry=0`은 실패한 record를 재시도하지 않습니다. Timeout, device
+overload, key busy 같은 eligible failure를 exponential backoff로 재시도하려면
+`retry`를 0보다 크게 지정하세요. Elapsed time이 `total_timeout`에 가까워지면
+retry를 일찍 중단합니다.
 
 ```python
 results = client.batch_write(records, retry=3)

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/client-config.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/client-config.md
@@ -1,9 +1,9 @@
 ---
-title: Client Configuration
-sidebar_label: Connection & Config
+title: Client 설정
+sidebar_label: 연결 및 설정
 sidebar_position: 1
 slug: /guides/client-config
-description: Configure connections, timeouts, auth, and connection pools.
+description: 연결, 타임아웃, 인증 및 connection pool 설정
 ---
 
 import Tabs from '@theme/Tabs';
@@ -16,11 +16,13 @@ import aerospike_py as aerospike
 from aerospike_py.types import ClientConfig
 
 config: ClientConfig = {
-    "hosts": [("127.0.0.1", 18710)],
-    "cluster_name": "docker",
+    "hosts": [("127.0.0.1", 3000)],
 }
 client = aerospike.client(config).connect()
 ```
+
+Client가 예상과 다른 cluster name을 가진 server를 거부해야 할 때만
+`cluster_name`을 지정하세요.
 
 ## 모든 필드
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/migration.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/config/migration.md
@@ -1,9 +1,9 @@
 ---
-title: Migration from Official Client
-sidebar_label: Migration Guide
+title: 공식 Client에서 마이그레이션
+sidebar_label: 마이그레이션 가이드
 sidebar_position: 3
 slug: /guides/migration
-description: Migrate from aerospike-client-python (C-based) to aerospike-py (Rust-based).
+description: C 기반 aerospike-client-python에서 Rust 기반 aerospike-py로 마이그레이션하는 방법
 ---
 
 ## Installation

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch-write.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch-write.md
@@ -1,9 +1,9 @@
 ---
-title: NumPy Batch Write Guide
-sidebar_label: NumPy Batch Write
+title: NumPy Batch 쓰기 가이드
+sidebar_label: NumPy Batch 쓰기
 sidebar_position: 5
 slug: /guides/numpy-batch-write
-description: Use batch_write_numpy to write records directly from numpy structured arrays for high-performance bulk ingestion into Aerospike.
+description: batch_write_numpy를 사용해 NumPy 구조화 배열의 Record를 Aerospike에 직접 대량 적재하는 방법
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-batch.md
@@ -1,9 +1,9 @@
 ---
-title: NumPy Batch Read Guide
-sidebar_label: NumPy Batch Read
+title: NumPy Batch 읽기 가이드
+sidebar_label: NumPy Batch 읽기
 sidebar_position: 4
 slug: /guides/numpy-batch
-description: Use batch_read with numpy structured arrays for high-performance columnar analytics directly from Aerospike.
+description: NumPy 구조화 배열과 batch_read를 사용해 Aerospike 데이터를 고성능 열 기반 분석에 활용하는 방법
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-guide.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/numpy-guide.md
@@ -1,9 +1,9 @@
 ---
-title: NumPy Integration Guide
-sidebar_label: NumPy Integration
+title: NumPy 연동 가이드
+sidebar_label: NumPy 연동
 sidebar_position: 6
 slug: /guides/numpy-integration
-description: High-performance batch operations using NumPy structured arrays.
+description: NumPy 구조화 배열을 사용하는 고성능 Batch 작업
 ---
 
 NumPy structured array로 batch read와 write의 성능을 높일 수 있습니다. Rust client는 Aerospike와 NumPy buffer 사이에서 데이터를 직접 옮기므로 element마다 Python object를 만들지 않습니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/operations.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/operations.md
@@ -1,9 +1,9 @@
 ---
-title: List & Map CDT Operations
-sidebar_label: Operations
+title: List 및 Map CDT 작업
+sidebar_label: List·Map CDT
 sidebar_position: 3
 slug: /guides/operations
-description: Atomic server-side List (31 ops) and Map (27 ops) collection data type operations via client.operate().
+description: client.operate()를 통한 서버 측 원자적 List(31개) 및 Map(27개) CDT 작업
 ---
 
 import Tabs from '@theme/Tabs';
@@ -381,7 +381,6 @@ from aerospike_py import list_operations as list_ops
 
 with aerospike.client({
     "hosts": [("127.0.0.1", 3000)],
-    "cluster_name": "docker",
 }).connect() as client:
 
     key = ("test", "demo", "player1")
@@ -757,7 +756,6 @@ from aerospike_py import map_operations as map_ops
 
 with aerospike.client({
     "hosts": [("127.0.0.1", 3000)],
-    "cluster_name": "docker",
 }).connect() as client:
 
     key = ("test", "demo", "player1")

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/read.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/read.md
@@ -1,9 +1,9 @@
 ---
-title: Read Operations
-sidebar_label: Read
+title: 읽기 작업
+sidebar_label: 읽기
 sidebar_position: 1
 slug: /guides/read
-description: Get, select, exists, and batch read operations.
+description: get, select, exists 및 batch read 작업
 ---
 
 import Tabs from '@theme/Tabs';
@@ -64,7 +64,8 @@ if result.meta is not None:
 
 ## Batch Read
 
-여러 record를 한 번의 network call로 읽습니다.
+여러 record를 하나의 batch API call로 읽습니다. Client는 각 key를 소유한 node로
+요청을 보내므로 multi-node batch에서는 network request가 여러 번 발생할 수 있습니다.
 
 <Tabs>
   <TabItem value="sync" label="Sync" default>
@@ -106,4 +107,7 @@ for user_key, bins in batch.items():
 
 - **Batch size**: batch당 100–5,000개 key를 권장합니다. Batch가 너무 크면 timeout이 발생할 수 있습니다.
 - **Timeout**: 큰 batch operation에는 더 긴 `total_timeout`을 사용하세요.
-- **Error handling**: 각 batch record는 독립적으로 실패할 수 있습니다. 항상 `br.record`가 `None`인지 확인하세요.
+- **Error handling**: Mapping view에는 user key가 있는 성공한 record만 들어 있습니다.
+  요청한 user key와 `batch.keys()`를 비교하면 누락된 key를 찾을 수 있습니다.
+  RecordNotFound와 다른 per-record error를 구분해야 한다면 `batch.iter_records()`를
+  순회하며 각 `br.result`를 확인하세요.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/write.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/crud/write.md
@@ -1,9 +1,9 @@
 ---
-title: Write Operations
-sidebar_label: Write
+title: 쓰기 작업
+sidebar_label: 쓰기
 sidebar_position: 2
 slug: /guides/write
-description: Put, update, delete, operate, batch operate, and optimistic locking.
+description: put, update, delete, operate, batch operate 및 낙관적 잠금 사용법
 ---
 
 import Tabs from '@theme/Tabs';
@@ -291,4 +291,7 @@ except RecordGenerationError:
 
 - **Batch size**: batch 당 100-5,000 key 가 최적. 너무 크면 timeout 가능.
 - **Timeout**: 큰 batch operation 의 경우 `total_timeout` 증가.
-- **Error handling**: Batch 안의 record는 각각 독립적으로 실패할 수 있습니다. 항상 `br.record`가 `None`인지 확인하세요.
+- **Error handling**: Batch 안의 record는 각각 독립적으로 실패할 수 있습니다. 먼저
+  `br.result`를 확인하세요. 값이 0이 아니라면 `br.in_doubt`를 확인해 non-idempotent
+  write를 retry할 때 두 번 적용될 가능성이 있는지 판단합니다. `br.record`는 record를
+  반환하는 operation의 선택적 결과이며 성공 여부를 나타내지 않습니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/expression-filters.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/expression-filters.md
@@ -1,9 +1,9 @@
 ---
-title: Expression Filters
-sidebar_label: Expression Filters
+title: Expression 필터
+sidebar_label: Expression 필터
 sidebar_position: 2
 slug: /guides/expression-filters
-description: Server-side record filtering with 104+ composable expression functions.
+description: 조합 가능한 104개 이상의 expression 함수로 서버에서 Record를 필터링하는 방법
 ---
 
 Expression filter는 read, write, query operation에 적용할 수 있습니다. Server가 expression을 평가해 조건에 맞는 record만 반환하거나 수정합니다.
@@ -15,7 +15,7 @@ Expression filter를 사용하려면 Aerospike Server **5.2 이상**이 필요�
 ## Import
 
 ```python
-from aerospike_py import exp
+from aerospike_py import exp, predicates
 ```
 
 ## 기본 사용

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/query-scan.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/query-scan/query-scan.md
@@ -1,9 +1,9 @@
 ---
-title: Query Guide
+title: Query 가이드
 sidebar_label: Query
 sidebar_position: 1
 slug: /guides/query-scan
-description: Secondary index queries with predicates.
+description: 보조 인덱스 Query에 predicate를 적용하는 방법
 ---
 
 ## Secondary Index Query

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/troubleshooting.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/guides/troubleshooting.md
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 10
-title: Troubleshooting
-description: Common problems and solutions when using aerospike-py.
+title: 문제 해결
+description: aerospike-py 사용 중 발생하는 일반적인 문제와 해결 방법
 ---
 
-# Troubleshooting
+# 문제 해결
 
 이 문서에서는 자주 발생하는 aerospike-py error의 원인을 확인하고 해결 방법을 안내합니다.
 
@@ -45,7 +45,7 @@ aerospike_py.ClusterError: Failed to connect to host(s)
 
 3. Aerospike를 container에서 실행한다면 service port가 올바르게 mapping되었고 host에서 접근할 수 있는지 확인하세요.
 
-### TimeoutError
+### AerospikeTimeoutError
 
 **증상:**
 
@@ -60,20 +60,18 @@ aerospike_py.AerospikeTimeoutError: Operation timed out
 
 **해결책:**
 
-1. 관련 policy 에서 timeout 증가:
+1. Timeout이 필요한 호출에 operation policy를 지정합니다.
    ```python
-   # Per-operation timeout
-   record = client.get(key, policy={"timeout": 5000})  # 5초
-
-   # Client-wide default
-   client = aerospike_py.client({
-       "hosts": [("127.0.0.1", 3000)],
-       "policies": {
-           "read": {"timeout": 5000},
-           "write": {"timeout": 5000},
-       },
-   }).connect()
+   read_policy = {
+       "socket_timeout": 5_000,
+       "total_timeout": 5_000,
+   }
+   record = client.get(key, policy=read_policy)
    ```
+
+   `ClientConfig.timeout`은 최초 connection timeout을 제어합니다. Read와 write
+   timeout은 각 operation의 policy에 지정해야 하며, `ClientConfig`에는 전역
+   `policies` field가 없습니다.
 
 2. server 상태 확인:
    ```python

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/fastapi.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/fastapi.md
@@ -1,8 +1,8 @@
 ---
-title: FastAPI Integration
-sidebar_label: FastAPI
+title: FastAPI 연동
+sidebar_label: FastAPI 연동
 sidebar_position: 1
-description: AsyncClient with FastAPI lifespan and dependency injection.
+description: FastAPI lifespan과 의존성 주입에서 AsyncClient를 사용하는 방법
 ---
 
 ## Prerequisites
@@ -16,7 +16,6 @@ pip install fastapi uvicorn pydantic-settings aerospike-py
 ```python
 from contextlib import asynccontextmanager
 
-import aerospike_py
 from aerospike_py import AsyncClient
 from fastapi import FastAPI
 
@@ -25,12 +24,13 @@ from fastapi import FastAPI
 async def lifespan(app: FastAPI):
     client = AsyncClient({
         "hosts": [("127.0.0.1", 3000)],
-        "policies": {"key": aerospike_py.POLICY_KEY_SEND},
     })
     await client.connect()
     app.state.aerospike = client
-    yield
-    await client.close()
+    try:
+        yield
+    finally:
+        await client.close()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -132,8 +132,8 @@ async def delete_user(user_id: str, request: Request):
 
 ```bash
 cd examples/sample-fastapi
-docker compose up -d
-pip install -r requirements.txt
+docker compose -f ../../compose.sample-fastapi.yaml up -d aerospike
+uv sync --all-extras
 uvicorn app.main:app --reload
 # http://localhost:8000/docs 방문
 ```

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/internal-stage-metrics.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/internal-stage-metrics.md
@@ -1,8 +1,8 @@
 ---
-title: Internal Stage Profiling
-sidebar_label: Internal Stage Profiling
+title: 내부 단계 프로파일링
+sidebar_label: 내부 단계 프로파일링
 sidebar_position: 4
-description: Fine-grained per-stage timing for debugging aerospike-py latency, with zero production overhead when disabled.
+description: aerospike-py 지연 시간을 디버깅하는 단계별 정밀 시간 측정. 비활성화하면 운영 오버헤드가 없습니다.
 ---
 
 `db_client_operation_duration_seconds`와 함께 더 세밀한 timing을 제공하는 두 번째 histogram도 사용할 수 있습니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/logging.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/logging.md
@@ -1,8 +1,8 @@
 ---
-title: Logging
-sidebar_label: Logging
+title: 로깅
+sidebar_label: 로깅
 sidebar_position: 1
-description: Rust-to-Python logging bridge for observing Aerospike client internals.
+description: Aerospike Client 내부를 관찰하기 위한 Rust-Python 로깅 브리지
 ---
 
 aerospike-py에는 **Rust-to-Python logging bridge**가 내장되어 있습니다. 내부 Rust log를 Python `logging` module로 전달하며 package를 import할 때 자동으로 초기화됩니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/metrics.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/metrics.md
@@ -1,8 +1,8 @@
 ---
-title: Prometheus Metrics
-sidebar_label: Metrics
+title: Prometheus 메트릭
+sidebar_label: 메트릭
 sidebar_position: 2
-description: Prometheus metrics for monitoring Aerospike operations.
+description: Aerospike 작업을 모니터링하는 Prometheus 메트릭
 ---
 
 aerospike-py는 operation-level metric을 Rust에서 기록하고 **Prometheus text format**으로 제공합니다. Metric 이름은 [OpenTelemetry DB Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/)를 따릅니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/tracing.md
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/integrations/observability/tracing.md
@@ -1,8 +1,8 @@
 ---
-title: Distributed Tracing
-sidebar_label: Tracing
+title: 분산 추적
+sidebar_label: 추적
 sidebar_position: 3
-description: OpenTelemetry distributed tracing for Aerospike operations.
+description: Aerospike 작업을 위한 OpenTelemetry 분산 추적
 ---
 
 aerospike-py는 모든 data operation을 위한 **OpenTelemetry tracing**을 제공합니다. Span은 [Database Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/)를 따르며 **OTLP gRPC**로 export됩니다.

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/_category_.json
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/_category_.json
@@ -1,10 +1,10 @@
 {
-  "label": "Performance",
+  "label": "성능",
   "position": 5,
   "collapsed": false,
   "link": {
     "type": "generated-index",
-    "title": "Performance",
+    "title": "성능",
     "description": "aerospike-py 벤치마크 결과 및 성능 분석"
   }
 }

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/bottleneck-analysis.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/bottleneck-analysis.mdx
@@ -1,6 +1,6 @@
 ---
-title: Bottleneck Analysis
-sidebar_label: Bottleneck Analysis
+title: 병목 분석
+sidebar_label: 병목 분석
 sidebar_position: 4
 description: aerospike-py 의 stage-별 profiling 및 최적화 recipe. 새 isolated 하네스 기반 재측정 대기 중.
 ---

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/isolated-benchmark.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/isolated-benchmark.mdx
@@ -1,6 +1,6 @@
 ---
-title: Isolated Benchmark
-sidebar_label: Isolated Benchmark
+title: 격리 벤치마크
+sidebar_label: 격리 벤치마크
 sidebar_position: 2
 description: 5-시나리오 uvicorn ASGI 벤치마크 스위트 (benchmark/) — FastAPI 직렬화·추론 비용을 가능한 한 제거해서 client 자체의 격차를 드러냄. Python 3.14t 계획 포함.
 ---

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/overview.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Performance Overview
-sidebar_label: Overview
+title: 성능 개요
+sidebar_label: 개요
 sidebar_position: 1
 description: aerospike-py vs 공식 C client 의 latency · throughput · Python 3.14t 효과 요약
 ---

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/production-benchmark.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/performance/production-benchmark.mdx
@@ -1,6 +1,6 @@
 ---
-title: Production Benchmark
-sidebar_label: Production Benchmark
+title: 운영 환경 벤치마크
+sidebar_label: 운영 환경 벤치마크
 sidebar_position: 3
 description: FastAPI + DLRM inference + Aerospike CE end-to-end production-shape 벤치마크. k6 부하, Python 3.14t free-threaded 결과 포함.
 ---

--- a/docs/i18n/ko/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/ko/docusaurus-theme-classic/footer.json
@@ -1,30 +1,34 @@
 {
   "link.title.Docs": {
-    "message": "Docs",
+    "message": "문서",
     "description": "The title of the footer links column with title=Docs in the footer"
   },
   "link.title.More": {
-    "message": "More",
+    "message": "더 보기",
     "description": "The title of the footer links column with title=More in the footer"
   },
   "link.item.label.Getting Started": {
-    "message": "Getting Started",
+    "message": "시작하기",
     "description": "The label of footer link with label=Getting Started linking to /docs/getting-started"
   },
   "link.item.label.API Reference": {
-    "message": "API Reference",
+    "message": "API 레퍼런스",
     "description": "The label of footer link with label=API Reference linking to /docs/api/client"
   },
   "link.item.label.Guides": {
-    "message": "Guides",
+    "message": "가이드",
     "description": "The label of footer link with label=Guides linking to /docs/guides/write"
+  },
+  "link.item.label.Performance": {
+    "message": "성능",
+    "description": "The label of footer link with label=Performance linking to /docs/performance/overview"
   },
   "link.item.label.Blog": {
     "message": "Blog",
     "description": "The label of footer link with label=Blog linking to /blog"
   },
   "link.item.label.Releases": {
-    "message": "Release Notes",
+    "message": "릴리스",
     "description": "The label of footer link with label=Releases linking to /releases"
   },
   "link.item.label.GitHub": {

--- a/docs/i18n/ko/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/ko/docusaurus-theme-classic/navbar.json
@@ -4,7 +4,7 @@
     "description": "The title in the navbar"
   },
   "item.label.Docs": {
-    "message": "Docs",
+    "message": "문서",
     "description": "Navbar item with label Docs"
   },
   "item.label.Blog": {
@@ -12,7 +12,7 @@
     "description": "Navbar item with label Blog"
   },
   "item.label.Releases": {
-    "message": "Release Notes",
+    "message": "릴리스",
     "description": "Navbar item with label Releases"
   },
   "item.label.GitHub": {

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -8,46 +8,53 @@ const sidebars: SidebarsConfig = {
       label: 'Guides',
       collapsed: false,
       items: [
-        'guides/architecture',
         {
           type: 'category',
-          label: 'Client Config',
+          label: 'Connection',
           items: [
             'guides/config/client-config',
             'guides/config/performance-tuning',
-            'guides/config/migration',
           ],
         },
         {
           type: 'category',
-          label: 'Read',
-          items: [
-            'guides/crud/read',
-            'guides/query-scan/query-scan',
-            'guides/query-scan/expression-filters',
-            'guides/crud/numpy-batch',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Write',
+          label: 'Records',
           items: [
             'guides/crud/write',
+            'guides/crud/read',
             'guides/crud/operations',
-            'guides/crud/numpy-batch-write',
           ],
         },
         {
           type: 'category',
-          label: 'Admin',
+          label: 'Query & Scan',
+          items: [
+            'guides/query-scan/query-scan',
+            'guides/query-scan/expression-filters',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Batch & NumPy',
+          items: [
+            'guides/crud/numpy-batch',
+            'guides/crud/numpy-batch-write',
+            'guides/crud/numpy-guide',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Administration',
           items: [
             'guides/admin/admin',
             'guides/admin/udf',
-            'guides/admin/error-handling',
           ],
         },
-        'guides/api-comparison',
         'guides/troubleshooting',
+        'guides/admin/error-handling',
+        'guides/config/migration',
+        'guides/api-comparison',
+        'guides/architecture',
       ],
     },
     {

--- a/docs/src/components/ArchitectureComparison/index.tsx
+++ b/docs/src/components/ArchitectureComparison/index.tsx
@@ -237,7 +237,7 @@ export function RequestFlow(): React.ReactElement {
             <div className={styles.flowArrow}>&darr;</div>
             <FlowStep num={4} variant="good" label={<>Return Pending &rarr; <b>pyo3 Auto Convert</b></>} />
           </div>
-          <div className={styles.flowFooter} style={{ color: 'var(--arch-green)' }}>
+          <div className={styles.flowFooter} style={{ color: 'var(--arch-good)' }}>
             GIL 1x &middot; 1 Boundary Crossing &middot; No Thread Creation
           </div>
         </div>
@@ -319,7 +319,7 @@ export function GilTimeline(): React.ReactElement {
             </div>
           </div>
           <div className={styles.gilFooter}>
-            GIL <span style={{ color: 'var(--arch-green)' }}>1x</span> &middot; No handoff
+            GIL <span style={{ color: 'var(--arch-good)' }}>1x</span> &middot; No handoff
           </div>
         </div>
       </div>
@@ -416,13 +416,13 @@ export function ConcurrencyViz(): React.ReactElement {
               </div>
             </div>
             <div className={styles.threadRow}>
-              <span className={styles.threadLabel} style={{ color: 'var(--arch-green)' }}>Status</span>
+              <span className={styles.threadLabel} style={{ color: 'var(--arch-good)' }}>Status</span>
               <div className={styles.threadBarCt}>
                 <div className={`${styles.threadBar} ${styles.barStatusGood}`} style={{ left: 0, width: '100%' }}>&#x2713; All 1,000 processed concurrently</div>
               </div>
             </div>
           </div>
-          <div className={styles.panelFooter} style={{ color: 'var(--arch-green)' }}>
+          <div className={styles.panelFooter} style={{ color: 'var(--arch-good)' }}>
             All concurrent with 4 workers &middot; No queue
           </div>
         </div>
@@ -641,7 +641,7 @@ export function ThroughputSim(): React.ReactElement {
             </div>
             <div className={styles.duoRow}>
               <span className={styles.duoRowLabel}>Queued</span>
-              <span className={styles.duoRowValue} style={{ color: 'var(--arch-green)' }}>0</span>
+              <span className={styles.duoRowValue} style={{ color: 'var(--arch-good)' }}>0</span>
             </div>
           </div>
         </div>
@@ -799,49 +799,51 @@ export function GilChart(): React.ReactElement {
     x.fillText('OOM @64', oomX + 3, P.t + 10);
 
     // Area fills
+    // Keep the narrowed context in a non-null binding for the nested draw helpers.
+    const ctx = x;
     function fillArea(pts: number[], color: string) {
-      x.fillStyle = color;
-      x.beginPath();
+      ctx.fillStyle = color;
+      ctx.beginPath();
       pts.forEach((v, i) => {
         const px = xPos(xs[i]), py = yPos(v);
-        i === 0 ? x.moveTo(px, py) : x.lineTo(px, py);
+        i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
       });
-      x.lineTo(xPos(xs[pts.length - 1]), yPos(0));
-      x.lineTo(xPos(xs[0]), yPos(0));
-      x.closePath();
-      x.fill();
+      ctx.lineTo(xPos(xs[pts.length - 1]), yPos(0));
+      ctx.lineTo(xPos(xs[0]), yPos(0));
+      ctx.closePath();
+      ctx.fill();
     }
-    fillArea(oP, 'rgba(99,102,241,.06)');
-    fillArea(rP, 'rgba(249,115,22,.06)');
+    fillArea(oP, 'rgba(37,99,235,.06)');
+    fillArea(rP, 'rgba(255,199,44,.08)');
 
     // Lines
     function drawLine(pts: number[], color: string) {
-      x.strokeStyle = color;
-      x.lineWidth = 2.5;
-      x.lineJoin = 'round';
-      x.beginPath();
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2.5;
+      ctx.lineJoin = 'round';
+      ctx.beginPath();
       pts.forEach((v, i) => {
         const px = xPos(xs[i]), py = yPos(v);
-        i === 0 ? x.moveTo(px, py) : x.lineTo(px, py);
+        i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
       });
-      x.stroke();
-      x.fillStyle = color;
+      ctx.stroke();
+      ctx.fillStyle = color;
       pts.forEach((v, i) => {
         const px = xPos(xs[i]), py = yPos(v);
-        x.beginPath();
-        x.arc(px, py, 3, 0, Math.PI * 2);
-        x.fill();
+        ctx.beginPath();
+        ctx.arc(px, py, 3, 0, Math.PI * 2);
+        ctx.fill();
       });
     }
-    drawLine(oP, '#6366f1');
-    drawLine(rP, '#f97316');
+    drawLine(oP, '#2563eb');
+    drawLine(rP, '#b98200');
 
     // End labels
     x.font = 'bold 10px sans-serif';
     x.textAlign = 'left';
-    x.fillStyle = '#6366f1';
+    x.fillStyle = '#2563eb';
     x.fillText(`${oP[oP.length - 1].toFixed(1)}ms`, xPos(xs[xs.length - 1]) + 6, yPos(oP[oP.length - 1]) + 4);
-    x.fillStyle = '#f97316';
+    x.fillStyle = '#b98200';
     x.fillText(`${rP[rP.length - 1].toFixed(1)}ms`, xPos(xs[xs.length - 1]) + 6, yPos(rP[rP.length - 1]) + 4);
   }, []);
 

--- a/docs/src/components/ArchitectureComparison/styles.module.css
+++ b/docs/src/components/ArchitectureComparison/styles.module.css
@@ -6,14 +6,14 @@
   --arch-text: #1e293b;
   --arch-text-dim: #64748b;
   --arch-text-muted: #94a3b8;
-  --arch-rust: #f97316;
-  --arch-rust-dim: rgba(249, 115, 22, 0.1);
-  --arch-c-async: #6366f1;
-  --arch-c-async-dim: rgba(99, 102, 241, 0.1);
-  --arch-c-sync: #8b5cf6;
-  --arch-c-sync-dim: rgba(139, 92, 246, 0.1);
-  --arch-green: #10b981;
-  --arch-green-dim: rgba(16, 185, 129, 0.1);
+  --arch-rust: #b98200;
+  --arch-rust-dim: rgba(255, 199, 44, 0.14);
+  --arch-c-async: #2563eb;
+  --arch-c-async-dim: rgba(37, 99, 235, 0.1);
+  --arch-c-sync: #7c3aed;
+  --arch-c-sync-dim: rgba(124, 58, 237, 0.1);
+  --arch-good: #0b5cab;
+  --arch-good-dim: rgba(11, 92, 171, 0.1);
   --arch-red: #ef4444;
   --arch-red-dim: rgba(239, 68, 68, 0.1);
   --arch-yellow: #eab308;
@@ -29,6 +29,8 @@
   --arch-text: #e2e8f0;
   --arch-text-dim: #8892a8;
   --arch-text-muted: #5a6580;
+  --arch-rust: #ffc72c;
+  --arch-good: #60a5fa;
 }
 
 /* ── 3-column grid ───────────────────────────────── */
@@ -95,7 +97,7 @@
   font-weight: 500;
 }
 
-.tagFast { background: var(--arch-green-dim); color: var(--arch-green); }
+.tagFast { background: var(--arch-good-dim); color: var(--arch-good); }
 .tagMid { background: var(--arch-yellow-dim); color: var(--arch-yellow); }
 .tagSlow { background: var(--arch-red-dim); color: var(--arch-red); }
 
@@ -142,7 +144,7 @@
 }
 
 .stepBad { background: var(--arch-red-dim); }
-.stepGood { background: var(--arch-green-dim); }
+.stepGood { background: var(--arch-good-dim); }
 .stepNeutral { background: var(--arch-surface-2); }
 
 .flowArrow {
@@ -204,7 +206,7 @@
 }
 
 .gilHeld { background: var(--arch-red); color: white; }
-.gilFree { background: var(--arch-green-dim); color: var(--arch-green); }
+.gilFree { background: var(--arch-good-dim); color: var(--arch-good); }
 .gilIo { background: var(--arch-surface); color: var(--arch-text-muted); border: 1px dashed var(--arch-border); }
 .gilEmpty { background: transparent; }
 .gilTokio { background: var(--arch-rust-dim); color: var(--arch-rust); border: 1px solid var(--arch-rust); }
@@ -263,7 +265,7 @@
 .barTask { background: var(--arch-rust); }
 .barIdle { background: rgba(90, 101, 128, 0.15); color: var(--arch-text-muted); }
 .barBlocked { background: rgba(239, 68, 68, 0.25); color: var(--arch-red); }
-.barStatusGood { background: var(--arch-green-dim); color: var(--arch-green); }
+.barStatusGood { background: var(--arch-good-dim); color: var(--arch-good); }
 
 /* ── Concurrency slider section ───────────────────── */
 .concurrencyViz {
@@ -468,7 +470,7 @@
 }
 
 .condHeadBench { color: var(--arch-yellow); }
-.condHeadProd { color: var(--arch-green); }
+.condHeadProd { color: var(--arch-good); }
 
 .condCell {
   padding: 7px 12px;
@@ -482,7 +484,7 @@
   color: var(--arch-text);
 }
 
-.condCellHl { color: var(--arch-green); font-weight: 500; }
+.condCellHl { color: var(--arch-good); font-weight: 500; }
 
 /* ── Duo cards (throughput sim) ──────────────────── */
 .duoGrid {

--- a/docs/src/components/BenchmarkDashboard/constants.ts
+++ b/docs/src/components/BenchmarkDashboard/constants.ts
@@ -20,26 +20,26 @@ export const CROSS_OP_BASELINE: Record<string, string> = {
 
 // ── Chart Colors (4-client) ─────────────────────────────────
 
-export const COLOR_APY_SYNC = '#E64A19';       // aerospike orange-red
-export const COLOR_OFFICIAL_SYNC = '#78909c';   // gray
-export const COLOR_OFFICIAL_ASYNC = '#ff9800';  // orange
-export const COLOR_APY_ASYNC = '#4caf50';       // green
+export const COLOR_APY_SYNC = 'var(--apy-chart-sync)';
+export const COLOR_OFFICIAL_SYNC = '#78909c';  // slate
+export const COLOR_OFFICIAL_ASYNC = '#3B82F6'; // blue
+export const COLOR_APY_ASYNC = 'var(--apy-chart-async)';
 
-export const COLOR_PUT_P50 = '#E64A19';
-export const COLOR_PUT_P99 = '#FF8A65';
-export const COLOR_GET_P50 = '#43a047';
-export const COLOR_GET_P99 = '#a5d6a7';
+export const COLOR_PUT_P50 = '#B98200';
+export const COLOR_PUT_P99 = '#FFC72C';
+export const COLOR_GET_P50 = '#2563EB';
+export const COLOR_GET_P99 = '#93C5FD';
 export const COLOR_MEM_PUT = '#ef5350';
 export const COLOR_MEM_GET = '#42a5f5';
-export const COLOR_MEM_BATCH = '#FF6D00';
+export const COLOR_MEM_BATCH = '#7C3AED';
 export const COLOR_MEM_C_GET = '#78909c';
 export const COLOR_MEM_C_BATCH = '#b0bec5';
-export const COLOR_READ = '#4caf50';
+export const COLOR_READ = '#2563EB';
 export const COLOR_WRITE = '#f44336';
-export const COLOR_THROUGHPUT = '#E64A19';
+export const COLOR_THROUGHPUT = '#FFC72C';
 
 // NumPy chart colors
-export const COLOR_DICT_SYNC = '#E64A19';
-export const COLOR_NUMPY_SYNC = '#e91e63';
-export const COLOR_DICT_ASYNC = '#4caf50';
-export const COLOR_NUMPY_ASYNC = '#2196f3';
+export const COLOR_DICT_SYNC = 'var(--apy-chart-sync)';
+export const COLOR_NUMPY_SYNC = '#7C3AED';
+export const COLOR_DICT_ASYNC = 'var(--apy-chart-async)';
+export const COLOR_NUMPY_ASYNC = '#2563EB';

--- a/docs/src/components/BenchmarkDashboard/styles/Cards.module.css
+++ b/docs/src/components/BenchmarkDashboard/styles/Cards.module.css
@@ -11,7 +11,7 @@
 
 .metricCard:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(230, 74, 25, 0.12);
+  box-shadow: 0 4px 12px rgba(11, 31, 51, 0.12);
 }
 
 [data-theme='dark'] .metricCard {
@@ -19,7 +19,7 @@
 }
 
 [data-theme='dark'] .metricCard:hover {
-  box-shadow: 0 4px 12px rgba(230, 74, 25, 0.25);
+  box-shadow: 0 4px 12px rgba(255, 199, 44, 0.2);
 }
 
 .metricValue {
@@ -33,7 +33,7 @@
 }
 
 .metricValueSuccess {
-  color: var(--ifm-color-success-darkest, #2e7d32);
+  color: var(--ifm-color-primary);
 }
 
 .metricValueWarning {
@@ -136,8 +136,8 @@
 }
 
 .speedupFaster {
-  background: rgba(46, 125, 50, 0.12);
-  color: var(--ifm-color-success-darkest, #2e7d32);
+  background: var(--apy-color-yellow-soft);
+  color: var(--ifm-color-primary);
 }
 
 .speedupSlower {
@@ -170,5 +170,11 @@
 @media (max-width: 768px) {
   .comparisonGrid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .metricCard:hover {
+    transform: none;
   }
 }

--- a/docs/src/components/BenchmarkDashboard/styles/Charts.module.css
+++ b/docs/src/components/BenchmarkDashboard/styles/Charts.module.css
@@ -39,7 +39,7 @@
 
 .dateSelect:focus {
   border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 2px rgba(230, 74, 25, 0.15);
+  box-shadow: 0 0 0 2px rgba(255, 199, 44, 0.28);
 }
 
 [data-theme='dark'] .dateSelect {

--- a/docs/src/components/BenchmarkDashboard/styles/HeroBanner.module.css
+++ b/docs/src/components/BenchmarkDashboard/styles/HeroBanner.module.css
@@ -1,5 +1,5 @@
 .heroBanner {
-  background: linear-gradient(135deg, rgba(230, 74, 25, 0.08) 0%, transparent 60%);
+  background: linear-gradient(135deg, rgba(255, 199, 44, 0.13) 0%, transparent 60%);
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 12px;
   padding: 1.5rem;
@@ -7,7 +7,7 @@
 }
 
 [data-theme='dark'] .heroBanner {
-  background: linear-gradient(135deg, rgba(230, 74, 25, 0.15) 0%, transparent 60%);
+  background: linear-gradient(135deg, rgba(255, 199, 44, 0.1) 0%, transparent 60%);
 }
 
 .heroHeader {

--- a/docs/src/components/BenchmarkDashboard/styles/Tables.module.css
+++ b/docs/src/components/BenchmarkDashboard/styles/Tables.module.css
@@ -34,7 +34,7 @@
 }
 
 .faster {
-  color: var(--ifm-color-success-darkest, #2e7d32);
+  color: var(--ifm-color-primary);
   font-weight: 700;
 }
 

--- a/docs/src/components/HomepageFeatures.module.css
+++ b/docs/src/components/HomepageFeatures.module.css
@@ -1,91 +1,67 @@
-/* ============================================================
-   Feature Cards Section
-   ============================================================ */
 .featureCardsSection {
-  padding: 4rem 0 2rem;
+  padding: 4rem 0 2.5rem;
   background: var(--ifm-background-color);
+}
+
+.sectionHeader {
+  max-width: 720px;
+  margin: 0 auto 2rem;
+  text-align: center;
+}
+
+.sectionTitle {
+  margin-bottom: 0.6rem;
+  font-size: 1.85rem;
+  line-height: 1.25;
+}
+
+.sectionSubtitle {
+  margin: 0;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
 .featureCardsGrid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-  margin-top: 2.5rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
 }
 
 .featureCard {
   padding: 1.5rem;
-  border-radius: 10px;
-  border: 1px solid var(--ifm-color-emphasis-200);
+  border: 1px solid var(--apy-color-line);
+  border-radius: 0.65rem;
   background: var(--ifm-background-color);
-  transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+  transition: border-color 150ms ease, background-color 150ms ease;
 }
 
 .featureCard:hover {
   border-color: var(--ifm-color-primary);
-  box-shadow: 0 4px 20px rgba(230, 74, 25, 0.1);
-  transform: translateY(-2px);
-}
-
-[data-theme='dark'] .featureCard {
-  background: var(--ifm-background-surface-color);
-}
-
-[data-theme='dark'] .featureCard:hover {
-  box-shadow: 0 4px 20px rgba(255, 138, 101, 0.12);
-}
-
-.featureCardIcon {
-  font-size: 2rem;
-  margin-bottom: 0.75rem;
-  display: block;
+  background: var(--apy-color-yellow-soft);
 }
 
 .featureCardTitle {
-  font-size: 1rem;
-  font-weight: 700;
-  margin-bottom: 0.4rem;
-  font-family: var(--ifm-heading-font-family);
+  margin-bottom: 0.45rem;
+  font-size: 1.05rem;
+  line-height: 1.35;
 }
 
 .featureCardDesc {
-  font-size: 0.875rem;
+  margin: 0;
   color: var(--ifm-color-emphasis-700);
-  line-height: 1.6;
-  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.65;
 }
 
-/* ============================================================
-   2-Column Sections (Drop-in + Sync/Async)
-   ============================================================ */
 .section {
-  padding: 3rem 0;
-}
-
-.section + .section {
-  padding-top: 0;
-}
-
-.sectionHeader {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.sectionTitle {
-  font-size: 1.8rem;
-  margin-bottom: 0.5rem;
-  font-family: var(--ifm-heading-font-family);
-}
-
-.sectionSubtitle {
-  color: var(--ifm-color-emphasis-600);
-  font-size: 1.05rem;
-  margin: 0;
+  padding: 3rem 0 4.5rem;
+  background: var(--ifm-background-color);
 }
 
 .twoColLayout {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(260px, 0.8fr) minmax(0, 1.2fr);
   gap: 2.5rem;
   align-items: start;
 }
@@ -95,44 +71,62 @@
 }
 
 .twoColText h2 {
-  font-size: 1.7rem;
-  font-family: var(--ifm-heading-font-family);
   margin-bottom: 0.75rem;
+  font-size: 1.75rem;
+  line-height: 1.25;
 }
 
-.twoColText p {
+.twoColText > p:last-child {
+  margin: 0;
   color: var(--ifm-color-emphasis-700);
   line-height: 1.7;
-  margin-bottom: 0;
 }
 
-/* Single-column fallbacks */
-.dropInBlock {
-  max-width: 720px;
-  margin: 0 auto;
+.codeTabs {
+  min-width: 0;
 }
 
-.tabsSection {
-  max-width: 720px;
-  margin: 0 auto;
+.codeTabs :global(.tabs) {
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--apy-color-line);
 }
 
-/* ============================================================
-   Responsive
-   ============================================================ */
+.codeTabs :global(.tabs__item) {
+  min-width: 6rem;
+  text-align: center;
+}
+
 @media screen and (max-width: 996px) {
   .featureCardsGrid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .twoColLayout {
     grid-template-columns: 1fr;
     gap: 1.5rem;
   }
+
+  .twoColText {
+    max-width: 700px;
+  }
 }
 
 @media screen and (max-width: 640px) {
+  .featureCardsSection {
+    padding: 3rem 0 2rem;
+  }
+
   .featureCardsGrid {
     grid-template-columns: 1fr;
+  }
+
+  .section {
+    padding: 2.5rem 0 3.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .featureCard {
+    transition: none;
   }
 }

--- a/docs/src/components/HomepageFeatures.tsx
+++ b/docs/src/components/HomepageFeatures.tsx
@@ -1,86 +1,96 @@
 import type {ReactNode} from 'react';
-import Heading from '@theme/Heading';
+import {translate} from '@docusaurus/Translate';
 import CodeBlock from '@theme/CodeBlock';
-import Tabs from '@theme/Tabs';
+import Heading from '@theme/Heading';
 import TabItem from '@theme/TabItem';
+import Tabs from '@theme/Tabs';
 import styles from './HomepageFeatures.module.css';
 
-/* ── Feature Card Data ───────────────────────────────────── */
-const FEATURE_CARDS = [
-  {
-    icon: '🦀',
-    title: 'Rust Performance',
-    desc: 'Native binary via PyO3 — zero Python overhead on the hot path.',
-  },
-  {
-    icon: '⚡',
-    title: 'Sync & Async',
-    desc: 'Both Client and AsyncClient. Works with FastAPI, Django, Gunicorn, and more.',
-  },
-  {
-    icon: '📦',
-    title: 'Zero Python Deps',
-    desc: 'Ships as a compiled wheel. No native C extensions to install separately.',
-  },
-  {
-    icon: '🔍',
-    title: 'Full Type Hints',
-    desc: 'PEP 561 compliant with bundled .pyi stubs. First-class IDE auto-complete.',
-  },
-  {
-    icon: '🔢',
-    title: 'NumPy Support',
-    desc: 'Batch results directly as NumPy arrays — ideal for analytics workloads.',
-  },
-];
-
-/* ── Code Snippets ───────────────────────────────────────── */
 const CODE_SYNC = `from aerospike_py import Client
 
-client = Client({'hosts': [('localhost', 3000)]})
-client.connect()
-
-client.put(('test','demo','key1'), {'name': 'Alice', 'age': 30})
-_, _, bins = client.get(('test','demo','key1'))
-print(bins)  # {'name': 'Alice', 'age': 30}
-
-client.close()`;
+with Client({"hosts": [("127.0.0.1", 3000)]}).connect() as client:
+    key = ("test", "users", "ada")
+    client.put(key, {"name": "Ada", "active": True})
+    record = client.get(key)
+    print(record.bins)`;
 
 const CODE_ASYNC = `import asyncio
 from aerospike_py import AsyncClient
 
-async def main():
-    client = AsyncClient({'hosts': [('localhost', 3000)]})
-    await client.connect()
-
-    await client.put(('test','demo','key1'), {'name': 'Alice', 'age': 30})
-    _, _, bins = await client.get(('test','demo','key1'))
-    print(bins)  # {'name': 'Alice', 'age': 30}
-
-    await client.close()
+async def main() -> None:
+    async with AsyncClient({"hosts": [("127.0.0.1", 3000)]}) as client:
+        await client.connect()
+        key = ("test", "users", "ada")
+        await client.put(key, {"name": "Ada", "active": True})
+        record = await client.get(key)
+        print(record.bins)
 
 asyncio.run(main())`;
 
-/* ── Feature Cards Section ───────────────────────────────── */
 function FeatureCardsSection() {
+  const cards = [
+    {
+      key: 'rust',
+      title: translate({id: 'homepage.feature.rust.title', message: 'Rust Performance'}),
+      description: translate({
+        id: 'homepage.feature.rust.description',
+        message: 'Native binary via PyO3 — zero Python overhead on the hot path.',
+      }),
+    },
+    {
+      key: 'sync-async',
+      title: translate({id: 'homepage.feature.async.title', message: 'Sync & Async'}),
+      description: translate({
+        id: 'homepage.feature.async.description',
+        message: 'Both Client and AsyncClient. Works with FastAPI, Django, Gunicorn, and more.',
+      }),
+    },
+    {
+      key: 'dependencies',
+      title: translate({id: 'homepage.feature.dependencies.title', message: 'Zero Python Deps'}),
+      description: translate({
+        id: 'homepage.feature.dependencies.description',
+        message: 'Ships as a compiled wheel. No native C extensions to install separately.',
+      }),
+    },
+    {
+      key: 'types',
+      title: translate({id: 'homepage.feature.types.title', message: 'Full Type Hints'}),
+      description: translate({
+        id: 'homepage.feature.types.description',
+        message: 'PEP 561 compliant with bundled .pyi stubs. First-class IDE auto-complete.',
+      }),
+    },
+    {
+      key: 'numpy',
+      title: translate({id: 'homepage.feature.numpy.title', message: 'NumPy Support'}),
+      description: translate({
+        id: 'homepage.feature.numpy.description',
+        message: 'Batch results directly as NumPy arrays — ideal for analytics workloads.',
+      }),
+    },
+  ];
+
   return (
     <section className={styles.featureCardsSection}>
       <div className="container">
         <div className={styles.sectionHeader}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Why aerospike-py?
+            {translate({id: 'homepage.feature.title', message: 'Why aerospike-py?'})}
           </Heading>
           <p className={styles.sectionSubtitle}>
-            Built for production workloads where every millisecond counts
+            {translate({
+              id: 'homepage.feature.subtitle',
+              message: 'Built for production workloads where every millisecond counts',
+            })}
           </p>
         </div>
         <div className={styles.featureCardsGrid}>
-          {FEATURE_CARDS.map((card) => (
-            <div key={card.title} className={styles.featureCard}>
-              <span className={styles.featureCardIcon}>{card.icon}</span>
-              <div className={styles.featureCardTitle}>{card.title}</div>
-              <p className={styles.featureCardDesc}>{card.desc}</p>
-            </div>
+          {cards.map((card) => (
+            <article key={card.key} className={styles.featureCard}>
+              <Heading as="h3" className={styles.featureCardTitle}>{card.title}</Heading>
+              <p className={styles.featureCardDesc}>{card.description}</p>
+            </article>
           ))}
         </div>
       </div>
@@ -88,7 +98,6 @@ function FeatureCardsSection() {
   );
 }
 
-/* ── Sync & Async Section ────────────────────────────────── */
 function SyncAsyncSection() {
   return (
     <section className={styles.section}>
@@ -96,25 +105,22 @@ function SyncAsyncSection() {
         <div className={styles.twoColLayout}>
           <div className={styles.twoColText}>
             <Heading as="h2">
-              Sync &amp; Async Support
+              {translate({id: 'homepage.api.title', message: 'Sync & Async Support'})}
             </Heading>
             <p>
-              Use <code>Client</code> for synchronous workloads or{' '}
-              <code>AsyncClient</code> for async frameworks like FastAPI,
-              Starlette, and Django Channels — same API, both fully supported.
+              {translate({
+                id: 'homepage.api.description',
+                message: 'Use Client for synchronous workloads or AsyncClient for async frameworks like FastAPI, Starlette, and Django Channels — same API, both fully supported.',
+              })}
             </p>
           </div>
-          <div>
+          <div className={styles.codeTabs}>
             <Tabs>
-              <TabItem value="sync" label="SyncClient" default>
-                <CodeBlock language="python">
-                  {CODE_SYNC}
-                </CodeBlock>
+              <TabItem value="sync" label={translate({id: 'homepage.api.syncTab', message: 'Sync'})} default>
+                <CodeBlock language="python">{CODE_SYNC}</CodeBlock>
               </TabItem>
-              <TabItem value="async" label="AsyncClient">
-                <CodeBlock language="python">
-                  {CODE_ASYNC}
-                </CodeBlock>
+              <TabItem value="async" label={translate({id: 'homepage.api.asyncTab', message: 'Async'})}>
+                <CodeBlock language="python">{CODE_ASYNC}</CodeBlock>
               </TabItem>
             </Tabs>
           </div>
@@ -124,7 +130,6 @@ function SyncAsyncSection() {
   );
 }
 
-/* ── Main Export ─────────────────────────────────────────── */
 export default function HomepageFeatures(): ReactNode {
   return (
     <>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,202 +1,381 @@
-/* ============================================================
-   Color Theme — aerospike-py Navy / Yellow
-   ============================================================ */
+/* aerospike-py — Aerospike yellow, Python navy, documentation-first layout */
 :root {
-  --ifm-color-primary:          #0B1F33;
-  --ifm-color-primary-dark:     #091C2E;
-  --ifm-color-primary-darker:   #081A2B;
-  --ifm-color-primary-darkest:  #071624;
-  --ifm-color-primary-light:    #23364A;
-  --ifm-color-primary-lighter:  #304357;
-  --ifm-color-primary-lightest: #647283;
-
+  --ifm-color-primary: #0b1f33;
+  --ifm-color-primary-dark: #081b2d;
+  --ifm-color-primary-darker: #071927;
+  --ifm-color-primary-darkest: #05131f;
+  --ifm-color-primary-light: #17334f;
+  --ifm-color-primary-lighter: #21415f;
+  --ifm-color-primary-lightest: #48657e;
+  --ifm-background-color: #ffffff;
+  --ifm-background-surface-color: #f6f8fb;
+  --ifm-navbar-height: 4rem;
   --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
-
-  /* Custom brand variables */
-  --apy-color-yellow: #FFC72C;
-  --apy-color-navy:   #0B1F33;
-  --apy-color-white:  #FFFFFF;
-  --apy-color-muted:  #647283;
-  --apy-color-code:   #102A43;
-
-  /* Typography */
   --ifm-font-family-base: 'Inter', system-ui, -apple-system, sans-serif;
   --ifm-heading-font-family: 'Plus Jakarta Sans', var(--ifm-font-family-base);
   --ifm-font-family-monospace: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
   --ifm-line-height-base: 1.75;
+  --ifm-menu-color-background-active: #fff7d6;
+  --docusaurus-highlighted-code-line-bg: rgba(255, 199, 44, 0.18);
+
+  --apy-color-yellow: #ffc72c;
+  --apy-color-yellow-soft: #fff8df;
+  --apy-color-navy: #0b1f33;
+  --apy-color-ink: #17283a;
+  --apy-color-muted: #5f7183;
+  --apy-color-paper: #f6f8fb;
+  --apy-color-line: #dfe6ed;
+  --apy-color-line-strong: #b9c6d2;
+  --apy-focus-ring: #0b1f33;
+  --apy-chart-sync: #0b1f33;
+  --apy-chart-async: #7a5700;
 }
 
 [data-theme='dark'] {
-  --ifm-color-primary:          #FFC72C;
-  --ifm-color-primary-dark:     #F2B800;
-  --ifm-color-primary-darker:   #E8AE00;
-  --ifm-color-primary-darkest:  #C28F00;
-  --ifm-color-primary-light:    #FFD154;
-  --ifm-color-primary-lighter:  #FFD866;
-  --ifm-color-primary-lightest: #FFE79D;
+  --ifm-color-primary: #ffc72c;
+  --ifm-color-primary-dark: #f2b800;
+  --ifm-color-primary-darker: #e8ae00;
+  --ifm-color-primary-darkest: #c28f00;
+  --ifm-color-primary-light: #ffd154;
+  --ifm-color-primary-lighter: #ffd866;
+  --ifm-color-primary-lightest: #ffe79d;
+  --ifm-background-color: #091827;
+  --ifm-background-surface-color: #102438;
+  --ifm-menu-color-background-active: rgba(255, 199, 44, 0.12);
+  --docusaurus-highlighted-code-line-bg: rgba(255, 199, 44, 0.13);
 
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --apy-color-yellow-soft: rgba(255, 199, 44, 0.09);
+  --apy-color-ink: #e6edf3;
+  --apy-color-muted: #9fb0c0;
+  --apy-color-paper: #0d1d2d;
+  --apy-color-line: #263b4f;
+  --apy-color-line-strong: #3f566c;
+  --apy-focus-ring: #ffc72c;
+  --apy-chart-sync: #7db7ff;
+  --apy-chart-async: #ffc72c;
 }
 
-/* ============================================================
-   Navbar
-   ============================================================ */
+html {
+  scroll-padding-top: calc(var(--ifm-navbar-height) + 1.25rem);
+}
+
+body {
+  color: var(--apy-color-ink);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  background: var(--apy-color-yellow);
+  color: var(--apy-color-navy);
+}
+
+/* Navigation */
 .navbar {
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
   border-bottom: 2px solid var(--apy-color-yellow);
+  box-shadow: 0 1px 8px rgba(11, 31, 51, 0.08);
 }
 
 [data-theme='dark'] .navbar {
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.34);
 }
 
-/* ============================================================
-   Footer
-   ============================================================ */
+.navbar__brand {
+  gap: 0.55rem;
+  margin-right: 1.5rem;
+}
+
+.navbar__logo {
+  height: 2rem;
+}
+
+.navbar__title {
+  font-family: var(--ifm-heading-font-family);
+  font-size: 0.98rem;
+  font-weight: 700;
+}
+
+.navbar__link {
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.navbar__link:hover,
+.navbar__link--active {
+  color: var(--ifm-color-primary);
+}
+
+/* Documentation canvas */
+.theme-doc-markdown {
+  max-width: 75ch;
+  line-height: 1.75;
+}
+
+.theme-doc-markdown > h1:first-child,
+.theme-doc-markdown header h1 {
+  margin-bottom: 1.4rem;
+  font-size: clamp(2.15rem, 4vw, 2.8rem);
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  text-wrap: balance;
+}
+
+.theme-doc-markdown h2 {
+  margin-top: 2.75rem;
+  margin-bottom: 1.1rem;
+  padding-bottom: 0.55rem;
+  border-bottom: 1px solid var(--apy-color-line);
+  font-size: clamp(1.5rem, 2.5vw, 1.8rem);
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+.theme-doc-markdown h3 {
+  margin-top: 2rem;
+  margin-bottom: 0.8rem;
+  font-size: clamp(1.2rem, 2vw, 1.35rem);
+}
+
+.theme-doc-markdown h4 {
+  margin-top: 1.8rem;
+}
+
+.theme-doc-markdown p,
+.theme-doc-markdown li {
+  text-wrap: pretty;
+}
+
+.theme-doc-markdown p {
+  margin-bottom: 1.25rem;
+}
+
+.theme-doc-markdown li + li {
+  margin-top: 0.35rem;
+}
+
+.theme-doc-markdown :where(p, li, td) > a {
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 35%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+
+.theme-doc-markdown :where(p, li, td) > a:hover {
+  text-decoration-color: var(--apy-color-yellow);
+  text-decoration-thickness: 2px;
+}
+
+.theme-doc-breadcrumbs {
+  margin-bottom: 1.4rem;
+  font-size: 0.8rem;
+}
+
+.theme-doc-sidebar-container {
+  background: var(--apy-color-paper);
+}
+
+.menu {
+  padding: 1.25rem 0.75rem 2rem;
+  font-size: 0.9rem;
+}
+
+.menu__list-item-collapsible {
+  border-radius: 0.5rem;
+}
+
+.menu__link {
+  border-radius: 0.45rem;
+  line-height: 1.35;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.menu__link--active:not(.menu__link--sublist) {
+  position: relative;
+  background: var(--ifm-menu-color-background-active);
+  color: var(--apy-color-navy);
+  font-weight: 700;
+}
+
+.menu__link--active:not(.menu__link--sublist)::before {
+  position: absolute;
+  top: 0.45rem;
+  bottom: 0.45rem;
+  left: 0;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--apy-color-yellow);
+  content: '';
+}
+
+[data-theme='dark'] .menu__link--active:not(.menu__link--sublist) {
+  color: var(--apy-color-yellow);
+}
+
+.table-of-contents {
+  border-left-color: var(--apy-color-line);
+  font-size: 0.82rem;
+}
+
+.table-of-contents__link {
+  line-height: 1.45;
+}
+
+.table-of-contents__link--active {
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+}
+
+/* Code and data */
+.theme-code-block,
+.prism-code {
+  border: 1px solid var(--apy-color-line);
+  border-radius: 0.7rem;
+  box-shadow: none;
+}
+
+.prism-code {
+  font-size: 0.86rem;
+  line-height: 1.7;
+}
+
+:not(pre) > code {
+  padding: 0.12rem 0.35rem;
+  border: 1px solid var(--apy-color-line);
+  border-radius: 0.3rem;
+  background: var(--apy-color-paper);
+  color: inherit;
+  font-size: 0.88em;
+}
+
+.theme-doc-markdown table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--apy-color-line);
+  border-radius: 0.65rem;
+}
+
+.theme-doc-markdown table th,
+.theme-doc-markdown table td {
+  padding: 0.75rem 0.85rem;
+  border-color: var(--apy-color-line);
+  vertical-align: top;
+}
+
+.theme-doc-markdown table th {
+  background: var(--apy-color-paper);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.theme-doc-markdown table td code {
+  white-space: nowrap;
+}
+
+.tabs {
+  gap: 0.25rem;
+  border-bottom-color: var(--apy-color-line);
+}
+
+.tabs__item {
+  padding: 0.6rem 1rem;
+  border-radius: 0.45rem 0.45rem 0 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.tabs__item--active {
+  border-bottom-color: var(--apy-color-yellow);
+}
+
+.alert,
+.admonition {
+  margin: 1.75rem 0;
+  border-radius: 0.65rem;
+  box-shadow: none;
+}
+
+/* Keep tip admonitions in the Aerospike brand palette. */
+.alert--success {
+  --ifm-alert-background-color: var(--apy-color-yellow-soft);
+  --ifm-alert-background-color-highlight: rgba(255, 199, 44, 0.18);
+  --ifm-alert-foreground-color: var(--apy-color-ink);
+  --ifm-alert-border-color: #b98200;
+}
+
+[data-theme='dark'] .alert--success {
+  --ifm-alert-background-color: rgba(255, 199, 44, 0.09);
+  --ifm-alert-background-color-highlight: rgba(255, 199, 44, 0.16);
+  --ifm-alert-foreground-color: var(--apy-color-ink);
+  --ifm-alert-border-color: var(--apy-color-yellow);
+}
+
+.pagination-nav__link {
+  border-color: var(--apy-color-line);
+  border-radius: 0.7rem;
+  transition: border-color 140ms ease, background-color 140ms ease;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--apy-color-yellow);
+  background: var(--apy-color-yellow-soft);
+}
+
 .footer--dark {
   background: var(--apy-color-navy);
 }
 
-/* ============================================================
-   Hero
-   ============================================================ */
-.hero--primary {
-  --ifm-hero-background-color: var(--ifm-color-primary);
-  --ifm-hero-text-color: #ffffff;
+/* Keyboard and motion */
+:where(a, button, [tabindex]):focus-visible {
+  outline: 3px solid var(--apy-focus-ring);
+  outline-offset: 3px;
 }
 
-/* ============================================================
-   Typography
-   ============================================================ */
-.markdown {
-  line-height: 1.75;
-  max-width: 75ch;
+@media screen and (max-width: 996px) {
+  .navbar__brand {
+    margin-right: 0.5rem;
+  }
+
+  .navbar-sidebar .menu {
+    padding-top: 0.75rem;
+  }
+
+  .theme-doc-markdown {
+    max-width: none;
+  }
 }
 
-.markdown p {
-  margin-bottom: 1.25rem;
+@media screen and (max-width: 640px) {
+  .theme-doc-markdown > h1:first-child,
+  .theme-doc-markdown header h1 {
+    font-size: clamp(2rem, 9vw, 2.4rem);
+  }
+
+  .theme-doc-markdown h2 {
+    margin-top: 2.65rem;
+  }
+
+  .prism-code {
+    font-size: 0.78rem;
+  }
+
+  .theme-doc-markdown table th,
+  .theme-doc-markdown table td {
+    padding: 0.65rem 0.7rem;
+  }
 }
 
-.markdown h2 {
-  margin-top: 2.5rem;
-  padding-bottom: 0.4rem;
-  border-bottom: 1px solid var(--ifm-toc-border-color);
-  font-family: var(--ifm-heading-font-family);
-}
-
-.markdown h3 {
-  margin-top: 2rem;
-  font-family: var(--ifm-heading-font-family);
-}
-
-/* ============================================================
-   Code Blocks
-   ============================================================ */
-.prism-code {
-  border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  font-size: 0.9rem;
-}
-
-[data-theme='dark'] .prism-code {
-  border-color: rgba(255, 255, 255, 0.1);
-  background-color: var(--apy-color-code) !important;
-}
-
-/* Inline code */
-:not(pre) > code {
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
-  padding: 2px 6px;
-}
-
-[data-theme='dark'] :not(pre) > code {
-  border-color: rgba(255, 255, 255, 0.15);
-}
-
-/* ============================================================
-   Tables
-   ============================================================ */
-table {
-  display: block;
-  overflow-x: auto;
-  width: 100%;
-}
-
-table th {
-  background-color: var(--ifm-color-emphasis-100);
-  font-weight: 600;
-}
-
-[data-theme='dark'] table th {
-  background-color: var(--ifm-color-emphasis-200);
-}
-
-table td code {
-  white-space: nowrap;
-}
-
-/* ============================================================
-   Sidebar
-   ============================================================ */
-.menu__link--active:not(.menu__link--sublist) {
-  border-left: 3px solid var(--ifm-color-primary);
-  padding-left: calc(var(--ifm-menu-link-padding-horizontal) - 3px);
-}
-
-.menu__link {
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-/* ============================================================
-   Admonitions
-   ============================================================ */
-.admonition {
-  border-radius: 8px;
-  margin-bottom: 1.5rem;
-}
-
-/* ============================================================
-   Tabs (Sync / Async)
-   ============================================================ */
-.tabs__item {
-  font-size: 0.95rem;
-  padding: 0.6rem 1.2rem;
-}
-
-/* ============================================================
-   Table of Contents
-   ============================================================ */
-.table-of-contents__link--active {
-  font-weight: 600;
-  color: var(--ifm-color-primary);
-}
-
-.table-of-contents {
-  font-size: 0.85rem;
-}
-
-/* ============================================================
-   Feature Cards (Homepage)
-   ============================================================ */
-.feature-card {
-  padding: 1.5rem;
-  border-radius: 8px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  margin-bottom: 1rem;
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.feature-card:hover {
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 2px 12px rgba(11, 31, 51, 0.12);
-}
-
-[data-theme='dark'] .feature-card:hover {
-  box-shadow: 0 2px 12px rgba(255, 199, 44, 0.15);
-}
-
-.feature-card h3 {
-  margin-bottom: 0.5rem;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -1,255 +1,270 @@
-/* ============================================================
-   Hero Section
-   ============================================================ */
 .heroBanner {
-  padding: 6rem 0 5rem;
-  text-align: center;
   position: relative;
   overflow: hidden;
-  background: var(--apy-color-navy, #0B1F33);
+  padding: 5rem 1.5rem 4.5rem;
+  background: var(--apy-color-navy, #0b1f33);
   color: #fff;
+  text-align: center;
 }
 
-/* Single data-line motif */
 .heroBanner::before {
-  content: '';
   position: absolute;
   inset: 0;
   background-image: repeating-linear-gradient(
     0deg,
     transparent 0,
     transparent 39px,
-    rgba(255, 199, 44, 0.07) 39px,
-    rgba(255, 199, 44, 0.07) 40px
+    rgba(255, 199, 44, 0.055) 39px,
+    rgba(255, 199, 44, 0.055) 40px
   );
-  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.72), transparent 78%);
+  content: '';
+  mask-image: linear-gradient(to bottom, #000, transparent 82%);
   pointer-events: none;
 }
 
 .heroContent {
   position: relative;
   z-index: 1;
+  max-width: 760px;
+  margin: 0 auto;
 }
 
 .heroLogo {
   display: block;
-  width: 5.5rem;
-  height: 5.5rem;
-  margin: 0 auto 1.25rem;
-  border-radius: 1.15rem;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+  width: 4.75rem;
+  height: 4.75rem;
+  margin: 0 auto 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
 }
 
-/* ============================================================
-   Badge
-   ============================================================ */
 .heroBadge {
   display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  background: rgba(255, 199, 44, 0.1);
-  border: 1px solid rgba(255, 199, 44, 0.42);
-  border-radius: 100px;
-  padding: 0.3rem 0.9rem;
+  margin-bottom: 1.25rem;
+  padding: 0.3rem 0.85rem;
+  border: 1px solid rgba(255, 199, 44, 0.4);
+  border-radius: 999px;
+  background: rgba(255, 199, 44, 0.09);
+  color: var(--apy-color-yellow, #ffc72c);
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--apy-color-yellow, #FFC72C);
-  letter-spacing: 0.03em;
-  margin-bottom: 1.5rem;
 }
 
-/* ============================================================
-   Title
-   ============================================================ */
 .heroTitle {
-  font-size: clamp(2.2rem, 5vw, 3.5rem);
-  font-weight: 800;
-  line-height: 1.15;
+  margin: 0 0 1rem;
   color: #fff;
-  margin-bottom: 1rem;
-  font-family: 'Plus Jakarta Sans', var(--ifm-heading-font-family, sans-serif);
-}
-
-.heroTitleAccent {
-  color: var(--apy-color-yellow, #FFC72C);
-  position: relative;
+  font-family: var(--ifm-heading-font-family);
+  font-size: clamp(2.25rem, 5vw, 3.5rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
 }
 
 .heroSubtitle {
-  font-size: 1.15rem;
-  color: rgba(255, 255, 255, 0.7);
-  max-width: 560px;
-  margin: 0 auto 2.5rem;
-  line-height: 1.6;
+  max-width: 620px;
+  margin: 0 auto 2rem;
+  color: rgba(255, 255, 255, 0.74);
+  font-size: 1.1rem;
+  line-height: 1.65;
 }
 
-/* ============================================================
-   CTA Buttons
-   ============================================================ */
+.heroTitleAccent {
+  color: var(--apy-color-yellow, #ffc72c);
+}
+
 .buttons {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.ctaPrimary,
+.ctaSecondary {
+  min-height: 3rem;
+  border-radius: 0.5rem !important;
+  font-weight: 600;
+  transition: background-color 150ms ease, border-color 150ms ease !important;
 }
 
 .ctaPrimary {
-  background: var(--apy-color-yellow, #FFC72C) !important;
-  border-color: var(--apy-color-yellow, #FFC72C) !important;
-  color: var(--apy-color-navy, #0B1F33) !important;
-  font-weight: 600;
-  transition: background 0.2s, transform 0.15s, box-shadow 0.2s !important;
+  border-color: var(--apy-color-yellow, #ffc72c) !important;
+  background: var(--apy-color-yellow, #ffc72c) !important;
+  color: var(--apy-color-navy, #0b1f33) !important;
 }
 
 .ctaPrimary:hover {
-  background: #FFD154 !important;
-  border-color: #FFD154 !important;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 16px rgba(255, 199, 44, 0.28) !important;
+  border-color: #ffd154 !important;
+  background: #ffd154 !important;
 }
 
 .ctaSecondary {
+  border: 1px solid rgba(255, 255, 255, 0.4) !important;
   background: transparent !important;
-  border-color: rgba(255, 255, 255, 0.4) !important;
-  color: rgba(255, 255, 255, 0.85) !important;
-  font-weight: 600;
-  transition: border-color 0.2s, color 0.2s, transform 0.15s !important;
+  color: #fff !important;
 }
 
 .ctaSecondary:hover {
-  border-color: rgba(255, 255, 255, 0.8) !important;
-  color: #fff !important;
-  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.75) !important;
+  background: rgba(255, 255, 255, 0.06) !important;
 }
 
-/* ============================================================
-   Install Command
-   ============================================================ */
 .installCommand {
   display: inline-flex;
+  max-width: 100%;
+  min-height: 2.75rem;
+  gap: 0.65rem;
   align-items: center;
-  gap: 0.75rem;
-  background: rgba(0, 0, 0, 0.4);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
-  padding: 0.6rem 1.5rem;
-  backdrop-filter: blur(4px);
+  padding: 0.35rem 0.4rem 0.35rem 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.prompt {
+  color: var(--apy-color-yellow, #ffc72c);
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 700;
 }
 
 .installCommand code {
-  color: var(--apy-color-yellow, #FFC72C);
-  font-size: 1rem;
-  font-family: var(--ifm-font-family-monospace, monospace);
-  background: none;
-  border: none;
+  overflow: hidden;
   padding: 0;
+  border: 0;
+  background: transparent;
+  color: #f6f8fa;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.9rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .copyButton {
-  background: none;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 4px;
-  color: rgba(255, 255, 255, 0.7);
+  min-width: 4.8rem;
+  align-self: stretch;
+  padding: 0.25rem 0.7rem;
+  border: 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0 0.35rem 0.35rem 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.76);
   cursor: pointer;
-  font-size: 1rem;
-  padding: 0.15rem 0.4rem;
-  line-height: 1;
-  transition: all 0.2s;
+  font-size: 0.76rem;
+  font-weight: 600;
 }
 
 .copyButton:hover {
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
   color: #fff;
-  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.statsBar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-color);
+}
+
+.statItem {
+  display: flex;
+  min-width: 180px;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.35rem 2.5rem;
+  border-right: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.statItem:last-child {
+  border-right: 0;
+}
+
+.statValue {
+  color: var(--ifm-color-primary);
+  font-family: var(--ifm-heading-font-family);
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.statLabel {
+  margin-top: 0.15rem;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.78rem;
+  font-weight: 500;
 }
 
 .ctaPrimary:focus-visible,
 .ctaSecondary:focus-visible,
 .copyButton:focus-visible {
-  outline: 3px solid var(--apy-color-yellow, #FFC72C);
+  outline: 3px solid var(--apy-color-yellow, #ffc72c);
   outline-offset: 3px;
 }
 
-/* ============================================================
-   Stats Bar
-   ============================================================ */
-.statsBar {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0;
-  background: var(--ifm-background-color);
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-}
-
-.statItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 1.5rem 3rem;
-  border-right: 1px solid var(--ifm-color-emphasis-200);
-}
-
-.statItem:last-child {
-  border-right: none;
-}
-
-.statValue {
-  font-size: 1.75rem;
-  font-weight: 800;
-  color: var(--ifm-color-primary);
-  font-family: 'Plus Jakarta Sans', var(--ifm-heading-font-family, sans-serif);
-  line-height: 1.2;
-}
-
-.statLabel {
-  font-size: 0.8rem;
-  color: var(--ifm-color-emphasis-600);
-  font-weight: 500;
-  margin-top: 0.2rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 640px) {
   .heroBanner {
-    padding: 4rem 1.5rem 3.5rem;
+    padding: 3.5rem 1rem 3rem;
   }
 
   .heroLogo {
-    width: 4.75rem;
-    height: 4.75rem;
+    width: 4rem;
+    height: 4rem;
+  }
+
+  .heroTitle {
+    font-size: clamp(2.1rem, 10vw, 2.7rem);
+    line-height: 1.18;
+  }
+
+  .heroSubtitle {
+    font-size: 1rem;
+  }
+
+  .buttons {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .buttons a,
+  .installCommand {
+    width: 100%;
+  }
+
+  .installCommand code {
+    flex: 1;
+    font-size: 0.78rem;
   }
 
   .statsBar {
-    flex-direction: column;
-    align-items: stretch;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .statItem {
-    border-right: none;
+    min-width: 0;
+    padding: 1rem 0.5rem;
+    border-right: 1px solid var(--ifm-color-emphasis-200);
     border-bottom: 1px solid var(--ifm-color-emphasis-200);
-    padding: 1rem 2rem;
-    flex-direction: row;
-    justify-content: space-between;
   }
 
-  .statItem:last-child {
-    border-bottom: none;
+  .statItem:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .statItem:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+
+  .statValue {
+    font-size: 1.25rem;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .ctaPrimary,
-  .ctaSecondary,
-  .copyButton {
+  .ctaSecondary {
     transition: none !important;
-  }
-
-  .ctaPrimary:hover,
-  .ctaSecondary:hover {
-    transform: none;
   }
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,39 +1,55 @@
-import {type ReactNode, useState, useCallback} from 'react';
+import {type ReactNode, useCallback, useState} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
+import Translate, {translate} from '@docusaurus/Translate';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import styles from './index.module.css';
 
+type CopyState = 'idle' | 'copied' | 'error';
+
 function CopyBlock({text, className}: {text: string; className?: string}) {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (!navigator.clipboard) {
+        throw new Error('Clipboard API is unavailable');
+      }
+      await navigator.clipboard.writeText(text);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+
+    window.setTimeout(() => setCopyState('idle'), 2000);
   }, [text]);
+
+  const copyLabel =
+    copyState === 'copied'
+      ? translate({id: 'homepage.install.copied', message: 'Copied'})
+      : copyState === 'error'
+        ? translate({id: 'homepage.install.copyError', message: 'Copy failed'})
+        : translate({id: 'homepage.install.copy', message: 'Copy'});
+
   return (
     <div className={clsx(styles.installCommand, className)}>
+      <span className={styles.prompt} aria-hidden="true">$</span>
       <code>{text}</code>
       <button
         className={styles.copyButton}
         onClick={handleCopy}
-        aria-label="Copy to clipboard"
-        title="Copy to clipboard">
-        {copied ? '✓' : '⧉'}
+        aria-label={translate({
+          id: 'homepage.install.copyAriaLabel',
+          message: 'Copy the install command',
+        })}
+        title={copyLabel}>
+        <span aria-live="polite">{copyLabel}</span>
       </button>
     </div>
   );
 }
-
-const STATS = [
-  {value: '2×', label: 'Faster than Official'},
-  {value: '0', label: 'Python Dependencies'},
-  {value: 'Sync + Async', label: 'Both APIs'},
-  {value: 'PyO3', label: 'Native Rust Binding'},
-];
 
 function HeroSection() {
   const iconSrc = useBaseUrl('/img/icon.svg');
@@ -43,27 +59,34 @@ function HeroSection() {
       <div className={clsx('container', styles.heroContent)}>
         <img className={styles.heroLogo} src={iconSrc} alt="" aria-hidden="true" />
         <div className={styles.heroBadge}>
-          <span>⚡</span>
-          <span>Built with Rust + PyO3</span>
+          <Translate id="homepage.hero.badge">Built with Rust + PyO3</Translate>
         </div>
         <h1 className={styles.heroTitle}>
-          The <span className={styles.heroTitleAccent}>Fastest</span>{' '}
-          Aerospike Python Client
+          <Translate
+            id="homepage.hero.title"
+            values={{
+              fastest: (
+                <span className={styles.heroTitleAccent}>
+                  <Translate id="homepage.hero.fastest">Fastest</Translate>
+                </span>
+              ),
+            }}>
+            {'The {fastest} Aerospike Python Client'}
+          </Translate>
         </h1>
         <p className={styles.heroSubtitle}>
-          High-performance Aerospike Python client built in Rust —
-          native performance, zero extra dependencies, full Sync &amp; Async support.
+          <Translate id="homepage.hero.subtitle">
+            High-performance Aerospike Python client built in Rust — native performance,
+            zero extra dependencies, full Sync &amp; Async support.
+          </Translate>
         </p>
         <div className={styles.buttons}>
-          <Link
-            className={clsx('button button--lg', styles.ctaPrimary)}
-            to="/docs/getting-started">
-            Get Started →
+          <Link className={clsx('button button--lg', styles.ctaPrimary)} to="/docs/getting-started">
+            <Translate id="homepage.hero.getStarted">Get Started</Translate>
+            <span aria-hidden="true"> →</span>
           </Link>
-          <Link
-            className={clsx('button button--outline button--lg', styles.ctaSecondary)}
-            to="/docs/performance/overview">
-            View Benchmarks
+          <Link className={clsx('button button--lg', styles.ctaSecondary)} to="/docs/performance/overview">
+            <Translate id="homepage.hero.viewBenchmarks">View Benchmarks</Translate>
           </Link>
         </div>
         <CopyBlock text="pip install aerospike-py" />
@@ -73,9 +96,16 @@ function HeroSection() {
 }
 
 function StatsBar() {
+  const stats = [
+    {value: '2×', label: translate({id: 'homepage.stats.faster', message: 'Faster than Official'})},
+    {value: '0', label: translate({id: 'homepage.stats.dependencies', message: 'Python Dependencies'})},
+    {value: 'Sync + Async', label: translate({id: 'homepage.stats.apis', message: 'Both APIs'})},
+    {value: 'PyO3', label: translate({id: 'homepage.stats.binding', message: 'Native Rust Binding'})},
+  ];
+
   return (
     <div className={styles.statsBar}>
-      {STATS.map((stat) => (
+      {stats.map((stat) => (
         <div key={stat.label} className={styles.statItem}>
           <span className={styles.statValue}>{stat.value}</span>
           <span className={styles.statLabel}>{stat.label}</span>
@@ -88,8 +118,11 @@ function StatsBar() {
 export default function Home(): ReactNode {
   return (
     <Layout
-      title="Home"
-      description="High-performance Aerospike Python Client built with PyO3 + Rust — 2× faster, zero dependencies, Sync &amp; Async">
+      title={translate({id: 'homepage.meta.title', message: 'Aerospike Python client'})}
+      description={translate({
+        id: 'homepage.meta.description',
+        message: 'High-performance Aerospike Python Client built with PyO3 and Rust — 2× faster, zero dependencies, Sync and Async.',
+      })}>
       <HeroSection />
       <StatsBar />
       <main>

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true
   },
   "exclude": [".docusaurus", "build"]

--- a/examples/sample-fastapi/app/main.py
+++ b/examples/sample-fastapi/app/main.py
@@ -43,7 +43,6 @@ async def lifespan(app: FastAPI):
     # Aerospike client with backpressure config
     config: dict = {
         "hosts": [(settings.aerospike_host, settings.aerospike_port)],
-        "policies": {"key": aerospike_py.POLICY_KEY_SEND},
     }
     if settings.max_concurrent_ops > 0:
         config["max_concurrent_operations"] = settings.max_concurrent_ops
@@ -52,12 +51,12 @@ async def lifespan(app: FastAPI):
     client = AsyncClient(config)
     await client.connect()
     app.state.aerospike = client
-
-    yield
-
-    await client.close()
-    aerospike_py.shutdown_tracing()
-    app.state.tracing_enabled = False
+    try:
+        yield
+    finally:
+        await client.close()
+        aerospike_py.shutdown_tracing()
+        app.state.tracing_enabled = False
 
 
 app = FastAPI(

--- a/examples/sample-fastapi/tests/conftest.py
+++ b/examples/sample-fastapi/tests/conftest.py
@@ -171,7 +171,6 @@ def aerospike_client(aerospike_container):
     container, port = aerospike_container
     config = {
         "hosts": [("127.0.0.1", port)],
-        "policies": {"key": aerospike_py.POLICY_KEY_SEND},
     }
     # Only set cluster_name when using the managed container (cluster-name "docker").
     if container is not None:
@@ -198,7 +197,6 @@ def client(aerospike_container):
 
         ac_config = {
             "hosts": [("127.0.0.1", port)],
-            "policies": {"key": aerospike_py.POLICY_KEY_SEND},
         }
         # Only set cluster_name when using the managed container.
         if container is not None:
@@ -206,10 +204,12 @@ def client(aerospike_container):
         ac = aerospike_py.AsyncClient(ac_config)
         await ac.connect()
         a.state.aerospike = ac
-        yield
-        await ac.close()
-        aerospike_py.shutdown_tracing()
-        a.state.tracing_enabled = False
+        try:
+            yield
+        finally:
+            await ac.close()
+            aerospike_py.shutdown_tracing()
+            a.state.tracing_enabled = False
 
     original_lifespan = app.router.lifespan_context
     app.router.lifespan_context = _test_lifespan

--- a/examples/sample-fastapi/tests/test_observability.py
+++ b/examples/sample-fastapi/tests/test_observability.py
@@ -135,15 +135,16 @@ def test_tracing_spans_sent_to_jaeger(aerospike_container, jaeger_container, aer
             {
                 "hosts": [("127.0.0.1", as_port)],
                 "cluster_name": "docker",
-                "policies": {"key": aerospike_py.POLICY_KEY_SEND},
             }
         )
         await ac.connect()
         a.state.aerospike = ac
-        yield
-        await ac.close()
-        aerospike_py.shutdown_tracing()
-        a.state.tracing_enabled = False
+        try:
+            yield
+        finally:
+            await ac.close()
+            aerospike_py.shutdown_tracing()
+            a.state.tracing_enabled = False
 
     original_lifespan = app.router.lifespan_context
     original_aerospike = getattr(app.state, "aerospike", None)

--- a/scripts/generate-api-docs.py
+++ b/scripts/generate-api-docs.py
@@ -39,6 +39,23 @@ class ParsedDocstring:
     returns: str = ""
     raises: list[tuple[str, str]] = field(default_factory=list)
     example: str = ""
+    notes: list[str] = field(default_factory=list)
+
+
+_SPHINX_ROLE_RE = re.compile(r":(?P<role>meth|func|class|attr):`(?P<short>~?)(?P<target>[^`]+)`")
+
+
+def _normalize_sphinx_roles(text: str) -> str:
+    """Convert common Sphinx cross-references into readable Markdown code."""
+
+    def _replace(match: re.Match[str]) -> str:
+        target = match.group("target")
+        display = target.rsplit(".", 1)[-1] if match.group("short") else target
+        if match.group("role") in ("meth", "func") and not display.endswith("()"):
+            display += "()"
+        return f"`{display}`"
+
+    return _SPHINX_ROLE_RE.sub(_replace, text)
 
 
 def _parse_google_docstring(doc: str | None) -> ParsedDocstring:
@@ -58,7 +75,7 @@ def _parse_google_docstring(doc: str | None) -> ParsedDocstring:
     def _flush_item():
         nonlocal current_item_name, current_item_lines
         if current_item_name:
-            desc = " ".join(current_item_lines).strip()
+            desc = _normalize_sphinx_roles(" ".join(part for part in current_item_lines if part).strip())
             if section == "args":
                 result.args.append((current_item_name, desc))
             elif section == "raises":
@@ -72,26 +89,32 @@ def _parse_google_docstring(doc: str | None) -> ParsedDocstring:
             # Dedent before stripping to preserve relative indentation
             result.example = textwrap.dedent("\n".join(section_lines)).strip()
         else:
-            text = "\n".join(section_lines).strip()
+            text = _normalize_sphinx_roles(textwrap.dedent("\n".join(section_lines)).strip())
             if section == "summary":
                 result.summary = text
             elif section == "returns":
                 result.returns = text
+            elif section == "notes" and text:
+                result.notes.append(text)
         section_lines.clear()
 
-    section_headers = {"Args:", "Returns:", "Raises:", "Example:"}
+    section_headers = {"Args:", "Returns:", "Raises:", "Example:", "Note:", "Notes:"}
     section_map = {
         "Args:": "args",
         "Returns:": "returns",
         "Raises:": "raises",
         "Example:": "example",
+        "Note:": "notes",
+        "Notes:": "notes",
     }
 
     for line in lines:
         stripped = line.strip()
 
         # Check for section header
-        if stripped in section_headers:
+        # Google-style section headers are top-level after dedenting. An
+        # indented ``Note:`` can still be ordinary parameter prose.
+        if not line[:1].isspace() and stripped in section_headers:
             # Flush previous state
             _flush_item()
             _flush_section()
@@ -100,7 +123,9 @@ def _parse_google_docstring(doc: str | None) -> ParsedDocstring:
 
         if section in ("args", "raises"):
             # Check for new item: "name: description" or "Name: description"
-            m = re.match(r"^\s{4,8}(\w+):\s*(.*)", line)
+            # Requiring whitespace (or EOL) after the colon prevents Markdown
+            # labels such as ``**Note:**`` from becoming fake parameters.
+            m = re.match(r"^\s{4,8}([*]{0,2}\w+):(?:\s+(.*)|\s*$)", line)
             if m:
                 _flush_item()
                 current_item_name = m.group(1)
@@ -130,20 +155,33 @@ def _get_method_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
     args = node.args
     parts: list[str] = []
 
-    # Positional args (skip 'self')
-    all_args = args.args[:]
-    defaults = list(args.defaults)
-    # Pad defaults to align with args
-    while len(defaults) < len(all_args):
-        defaults.insert(0, None)  # type: ignore[arg-type]
+    def _format_arg(arg: ast.arg, default: ast.expr | None = None) -> str:
+        rendered = arg.arg
+        if default is not None:
+            rendered += f"={ast.unparse(default)}"
+        return rendered
 
-    for arg, default in zip(all_args, defaults, strict=False):
+    # Defaults align to the right across positional-only and positional args.
+    positional_args = [*args.posonlyargs, *args.args]
+    default_offset = len(positional_args) - len(args.defaults)
+    for index, arg in enumerate(positional_args):
         if arg.arg == "self":
             continue
-        s = arg.arg
-        if default is not None:
-            s += f"={ast.literal_eval(default)}" if isinstance(default, ast.Constant) else "=..."
-        parts.append(s)
+        default = args.defaults[index - default_offset] if index >= default_offset else None
+        parts.append(_format_arg(arg, default))
+        if args.posonlyargs and index == len(args.posonlyargs) - 1:
+            parts.append("/")
+
+    if args.vararg:
+        parts.append(f"*{args.vararg.arg}")
+    elif args.kwonlyargs:
+        parts.append("*")
+
+    for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=True):
+        parts.append(_format_arg(arg, default))
+
+    if args.kwarg:
+        parts.append(f"**{args.kwarg.arg}")
 
     return ", ".join(parts)
 
@@ -236,9 +274,22 @@ def _extract_functions(
 # ---------------------------------------------------------------------------
 
 
+def _render_notes(notes: list[str]) -> list[str]:
+    """Render parsed Note/Notes sections as Docusaurus admonitions."""
+    lines: list[str] = []
+    for note in notes:
+        lines.append(":::note\n")
+        lines.append(f"{note}\n")
+        lines.append(":::\n")
+    return lines
+
+
 def _render_method_section(
     sync_method: MethodInfo | None,
     async_method: MethodInfo | None,
+    *,
+    sync_label: str = "Sync Client",
+    async_label: str = "Async Client",
 ) -> str:
     """Render a Markdown section for a method with Sync/Async tabs."""
     method = sync_method or async_method
@@ -254,8 +305,9 @@ def _render_method_section(
     lines.append(f"### `{name}({sig})`\n")
 
     # Summary
-    if ds.summary:
-        lines.append(ds.summary)
+    summary = ds.summary or METHOD_FALLBACK_SUMMARIES.get(name, "")
+    if summary:
+        lines.append(summary)
         lines.append("")
 
     # Args table
@@ -280,14 +332,16 @@ def _render_method_section(
             lines.append(f"Raises `{exc_name}` {desc}\n")
             lines.append(":::\n")
 
+    lines.extend(_render_notes(ds.notes))
+
     # Examples with tabs
     if sync_method and async_method and sync_method.docstring.example and async_method.docstring.example:
         lines.append("<Tabs>")
-        lines.append('  <TabItem value="sync" label="Sync Client" default>\n')
+        lines.append(f'  <TabItem value="sync" label="{sync_label}" default>\n')
         lines.append(sync_method.docstring.example)
         lines.append("")
         lines.append("  </TabItem>")
-        lines.append('  <TabItem value="async" label="Async Client">\n')
+        lines.append(f'  <TabItem value="async" label="{async_label}">\n')
         lines.append(async_method.docstring.example)
         lines.append("")
         lines.append("  </TabItem>")
@@ -323,6 +377,14 @@ def _render_standalone_section(method: MethodInfo) -> str:
         lines.append(f"**Returns:** {ds.returns}")
         lines.append("")
 
+    if ds.raises:
+        for exc_name, desc in ds.raises:
+            lines.append(":::note\n")
+            lines.append(f"Raises `{exc_name}` {desc}\n")
+            lines.append(":::\n")
+
+    lines.extend(_render_notes(ds.notes))
+
     if ds.example:
         lines.append(ds.example)
         lines.append("")
@@ -337,7 +399,7 @@ def _render_standalone_section(method: MethodInfo) -> str:
 
 # Methods to include in the generated client doc, grouped by section
 CLIENT_METHOD_SECTIONS = [
-    ("Connection", ["connect", "is_connected", "close", "get_node_names"]),
+    ("Connection", ["connect", "is_connected", "ping", "close", "get_node_names"]),
     ("Info", ["info_all", "info_random_node"]),
     ("CRUD Operations", ["put", "get", "select", "exists", "remove", "touch"]),
     ("String / Numeric Operations", ["append", "prepend", "increment", "remove_bin"]),
@@ -346,19 +408,165 @@ CLIENT_METHOD_SECTIONS = [
         "Batch Operations",
         ["batch_read", "batch_write", "batch_write_numpy", "batch_operate", "batch_remove", "batch_apply"],
     ),
-    ("Query & Scan", ["query", "scan"]),
+    ("Query", ["query"]),
     ("Index Management", ["index_integer_create", "index_string_create", "index_geo2dsphere_create", "index_remove"]),
     ("Truncate", ["truncate"]),
     ("UDF", ["udf_put", "udf_remove", "apply"]),
+    (
+        "User Administration",
+        [
+            "admin_create_user",
+            "admin_drop_user",
+            "admin_change_password",
+            "admin_grant_roles",
+            "admin_revoke_roles",
+            "admin_query_user_info",
+            "admin_query_users_info",
+        ],
+    ),
+    (
+        "Role Administration",
+        [
+            "admin_create_role",
+            "admin_drop_role",
+            "admin_grant_privileges",
+            "admin_revoke_privileges",
+            "admin_query_role",
+            "admin_query_roles",
+            "admin_set_whitelist",
+            "admin_set_quotas",
+        ],
+    ),
 ]
+
+
+MODULE_FUNCTION_SECTIONS = [
+    ("Factory Functions", ["client", "async_client"]),
+    (
+        "Partition Filter Helpers",
+        ["partition_filter_all", "partition_filter_by_id", "partition_filter_by_range"],
+    ),
+    ("Logging", ["set_log_level", "dropped_log_count"]),
+    (
+        "Metrics",
+        [
+            "get_metrics",
+            "set_metrics_enabled",
+            "is_metrics_enabled",
+            "set_internal_stage_metrics_enabled",
+            "is_internal_stage_metrics_enabled",
+            "internal_stage_profiling",
+            "start_metrics_server",
+            "stop_metrics_server",
+        ],
+    ),
+    ("Tracing", ["init_tracing", "shutdown_tracing"]),
+]
+
+
+# The admin methods currently have signatures but no docstrings in the public
+# stub. Keep their generated reference useful until those docstrings are added.
+METHOD_FALLBACK_SUMMARIES = {
+    "admin_create_user": "Create a user with the supplied password and roles.",
+    "admin_drop_user": "Delete a user.",
+    "admin_change_password": "Change a user's password.",
+    "admin_grant_roles": "Grant roles to a user.",
+    "admin_revoke_roles": "Revoke roles from a user.",
+    "admin_query_user_info": "Return information about one user.",
+    "admin_query_users_info": "Return information about all users.",
+    "admin_create_role": "Create a role with privileges and optional access limits.",
+    "admin_drop_role": "Delete a role.",
+    "admin_grant_privileges": "Grant privileges to a role.",
+    "admin_revoke_privileges": "Revoke privileges from a role.",
+    "admin_query_role": "Return information about one role.",
+    "admin_query_roles": "Return information about all roles.",
+    "admin_set_whitelist": "Set the network allowlist for a role.",
+    "admin_set_quotas": "Set read and write quotas for a role.",
+}
+
+
+def _ordered_method_names(*method_lists: list[MethodInfo]) -> list[str]:
+    """Return the public method-name union while preserving stub order."""
+    names: list[str] = []
+    for methods in method_lists:
+        for method in methods:
+            if method.name not in names:
+                names.append(method.name)
+    return names
+
+
+def _append_grouped_methods(
+    lines: list[str],
+    sections: list[tuple[str, list[str]]],
+    sync_methods: dict[str, MethodInfo],
+    async_methods: dict[str, MethodInfo],
+    ordered_names: list[str],
+) -> set[str]:
+    """Render configured sections and a fallback section for new stub methods."""
+    rendered: set[str] = set()
+    for section_title, method_names in sections:
+        available = [name for name in method_names if name in sync_methods or name in async_methods]
+        if not available:
+            continue
+        lines.append(f"## {section_title}\n")
+        for name in available:
+            lines.append(_render_method_section(sync_methods.get(name), async_methods.get(name)))
+            rendered.add(name)
+
+    # A new public method must never disappear merely because the curated
+    # section list has not been updated yet.
+    ungrouped = [name for name in ordered_names if name not in rendered]
+    if ungrouped:
+        lines.append("## Other Client Methods\n")
+        for name in ungrouped:
+            lines.append(_render_method_section(sync_methods.get(name), async_methods.get(name)))
+            rendered.add(name)
+
+    return rendered
+
+
+def _append_grouped_functions(
+    lines: list[str],
+    functions: list[MethodInfo],
+    sections: list[tuple[str, list[str]]],
+) -> set[str]:
+    """Render every public module function, grouped for navigation."""
+    functions_by_name = {function.name: function for function in functions}
+    rendered: set[str] = set()
+    for section_title, function_names in sections:
+        available = [name for name in function_names if name in functions_by_name]
+        if not available:
+            continue
+        lines.append(f"## {section_title}\n")
+        for name in available:
+            lines.append(_render_standalone_section(functions_by_name[name]))
+            rendered.add(name)
+
+    ungrouped = [function for function in functions if function.name not in rendered]
+    if ungrouped:
+        lines.append("## Other Module Helpers\n")
+        for function in ungrouped:
+            lines.append(_render_standalone_section(function))
+            rendered.add(function.name)
+
+    return rendered
+
+
+def _validate_inventory(category: str, expected: set[str], rendered: set[str]) -> None:
+    """Fail generation rather than silently dropping a public API symbol."""
+    missing = expected - rendered
+    if missing:
+        missing_names = ", ".join(sorted(missing))
+        raise RuntimeError(f"Generated {category} reference is missing: {missing_names}")
 
 
 def generate_client_doc(tree: ast.Module) -> str:
     """Generate the client.md API documentation."""
-    # Find Client and AsyncClient classes
+    # Types and exceptions have dedicated API pages and are intentionally
+    # outside this generator's inventory.
     classes: dict[str, ast.ClassDef] = {}
     for node in tree.body:
-        if isinstance(node, ast.ClassDef) and node.name in ("Client", "AsyncClient"):
+        if isinstance(node, ast.ClassDef) and node.name in ("Client", "AsyncClient", "Query", "AsyncQuery"):
             classes[node.name] = node
 
     sync_cls = classes.get("Client")
@@ -374,21 +582,19 @@ def generate_client_doc(tree: ast.Module) -> str:
     sync_methods = {m.name: m for m in sync_methods_list}
     async_methods = {m.name: m for m in async_methods_list}
 
-    # Extract Query and Scan classes
-    query_cls = None
-    scan_cls = None
-    for node in tree.body:
-        if isinstance(node, ast.ClassDef):
-            if node.name == "Query":
-                query_cls = node
-            elif node.name == "Scan":
-                scan_cls = node
+    query_cls = classes.get("Query")
+    async_query_cls = classes.get("AsyncQuery")
+    query_methods_list = _extract_methods(query_cls) if query_cls else []
+    async_query_methods_list = _extract_methods(async_query_cls) if async_query_cls else []
+    query_methods = {m.name: m for m in query_methods_list}
+    async_query_methods = {m.name: m for m in async_query_methods_list}
 
-    # Extract factory functions
-    factory_functions = _extract_functions(
-        tree,
-        {"client", "set_log_level", "get_metrics", "start_metrics_server", "stop_metrics_server"},
-    )
+    # Extract every public module function. Curated groups control placement;
+    # the fallback group keeps future stub additions visible.
+    module_functions = _extract_functions(tree)
+    factory_names = set(MODULE_FUNCTION_SECTIONS[0][1])
+    factory_functions = [function for function in module_functions if function.name in factory_names]
+    helper_functions = [function for function in module_functions if function.name not in factory_names]
 
     # Build document
     lines: list[str] = [
@@ -404,53 +610,76 @@ def generate_client_doc(tree: ast.Module) -> str:
         "aerospike-py provides both synchronous (`Client`) and asynchronous (`AsyncClient`) APIs with identical functionality.\n",
     ]
 
-    # Factory functions
-    lines.append("## Factory Functions\n")
-    for func in factory_functions:
-        lines.append(_render_standalone_section(func))
+    rendered_functions = _append_grouped_functions(lines, factory_functions, MODULE_FUNCTION_SECTIONS[:1])
 
     # Client methods grouped by section
-    for section_title, method_names in CLIENT_METHOD_SECTIONS:
-        lines.append(f"## {section_title}\n")
-        for name in method_names:
-            sm = sync_methods.get(name)
-            am = async_methods.get(name)
-            if sm or am:
-                lines.append(_render_method_section(sm, am))
+    rendered_client_methods = _append_grouped_methods(
+        lines,
+        CLIENT_METHOD_SECTIONS,
+        sync_methods,
+        async_methods,
+        _ordered_method_names(sync_methods_list, async_methods_list),
+    )
 
-    # Query class
-    if query_cls:
-        query_methods = _extract_methods(query_cls)
-        lines.append("## Query Object\n")
-        query_doc = ast.get_docstring(query_cls)
-        if query_doc:
-            parsed = _parse_google_docstring(query_doc)
-            if parsed.summary:
-                lines.append(parsed.summary)
-                lines.append("")
-            if parsed.example:
-                lines.append(parsed.example)
-                lines.append("")
+    # Pair Query and AsyncQuery so shared semantics stay together while their
+    # sync/await examples remain explicit.
+    rendered_query_methods: set[str] = set()
+    if query_cls or async_query_cls:
+        lines.append("## Query and AsyncQuery Objects\n")
+        primary_query_cls = query_cls or async_query_cls
+        assert primary_query_cls is not None
+        parsed_class_doc = _parse_google_docstring(ast.get_docstring(primary_query_cls))
+        if parsed_class_doc.summary:
+            lines.append(parsed_class_doc.summary)
+            lines.append("")
 
-        for m in query_methods:
-            lines.append(_render_standalone_section(m))
+        sync_class_doc = _parse_google_docstring(ast.get_docstring(query_cls)) if query_cls else ParsedDocstring()
+        async_class_doc = (
+            _parse_google_docstring(ast.get_docstring(async_query_cls)) if async_query_cls else ParsedDocstring()
+        )
+        if sync_class_doc.example and async_class_doc.example:
+            lines.append("<Tabs>")
+            lines.append('  <TabItem value="query" label="Query" default>\n')
+            lines.append(sync_class_doc.example)
+            lines.append("")
+            lines.append("  </TabItem>")
+            lines.append('  <TabItem value="async-query" label="AsyncQuery">\n')
+            lines.append(async_class_doc.example)
+            lines.append("")
+            lines.append("  </TabItem>")
+            lines.append("</Tabs>\n")
+        elif parsed_class_doc.example:
+            lines.append(parsed_class_doc.example)
+            lines.append("")
 
-    # Scan class
-    if scan_cls:
-        scan_methods = _extract_methods(scan_cls)
-        lines.append("## Scan Object\n")
-        scan_doc = ast.get_docstring(scan_cls)
-        if scan_doc:
-            parsed = _parse_google_docstring(scan_doc)
-            if parsed.summary:
-                lines.append(parsed.summary)
-                lines.append("")
-            if parsed.example:
-                lines.append(parsed.example)
-                lines.append("")
+        for name in _ordered_method_names(query_methods_list, async_query_methods_list):
+            lines.append(
+                _render_method_section(
+                    query_methods.get(name),
+                    async_query_methods.get(name),
+                    sync_label="Query",
+                    async_label="AsyncQuery",
+                )
+            )
+            rendered_query_methods.add(name)
 
-        for m in scan_methods:
-            lines.append(_render_standalone_section(m))
+    rendered_functions.update(_append_grouped_functions(lines, helper_functions, MODULE_FUNCTION_SECTIONS[1:]))
+
+    _validate_inventory(
+        "module function",
+        {function.name for function in module_functions},
+        rendered_functions,
+    )
+    _validate_inventory(
+        "Client/AsyncClient method",
+        set(sync_methods) | set(async_methods),
+        rendered_client_methods,
+    )
+    _validate_inventory(
+        "Query/AsyncQuery method",
+        set(query_methods) | set(async_query_methods),
+        rendered_query_methods,
+    )
 
     return "\n".join(lines)
 

--- a/tests/unit/test_api_docs_generator.py
+++ b/tests/unit/test_api_docs_generator.py
@@ -8,7 +8,10 @@ import re
 import sys
 from collections import Counter
 from pathlib import Path
-from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 STUB_PATH = ROOT / "src" / "aerospike_py" / "__init__.pyi"

--- a/tests/unit/test_api_docs_generator.py
+++ b/tests/unit/test_api_docs_generator.py
@@ -1,0 +1,118 @@
+"""Regression tests for the public-stub API documentation generator."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+STUB_PATH = ROOT / "src" / "aerospike_py" / "__init__.pyi"
+GENERATOR_PATH = ROOT / "scripts" / "generate-api-docs.py"
+
+
+def _load_generator() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("generate_api_docs", GENERATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load API docs generator: {GENERATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+GENERATOR = _load_generator()
+TREE = ast.parse(STUB_PATH.read_text(encoding="utf-8"), filename=str(STUB_PATH))
+
+
+def _public_methods(class_name: str) -> set[str]:
+    for node in TREE.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return {
+                child.name
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and not child.name.startswith("_")
+            }
+    return set()
+
+
+def test_generated_reference_covers_public_stub_inventory() -> None:
+    """Every public function and relevant class method gets an API heading."""
+    rendered = GENERATOR.generate_client_doc(TREE)
+
+    expected = Counter(
+        node.name
+        for node in TREE.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and not node.name.startswith("_")
+    )
+    expected.update(_public_methods("Client") | _public_methods("AsyncClient"))
+    expected.update(_public_methods("Query") | _public_methods("AsyncQuery"))
+
+    headings = Counter(re.findall(r"^### `([A-Za-z_]\w*)\(", rendered, flags=re.MULTILINE))
+    assert headings == expected
+
+
+def test_previously_omitted_api_groups_are_explicit() -> None:
+    """Guard the client, async query, observability, and partition regressions."""
+    rendered = GENERATOR.generate_client_doc(TREE)
+
+    required_markers = [
+        "### `ping()`",
+        "### `admin_create_user(username, password, roles, policy=None)`",
+        "### `admin_set_quotas(role, read_quota=0, write_quota=0, policy=None)`",
+        "### `async_client(config)`",
+        "## Query and AsyncQuery Objects",
+        'label="AsyncQuery"',
+        "### `set_metrics_enabled(enabled)`",
+        "### `internal_stage_profiling()`",
+        "### `init_tracing()`",
+        "### `partition_filter_by_range(begin, count)`",
+    ]
+    for marker in required_markers:
+        assert marker in rendered
+
+
+def test_varargs_and_raises_render_without_losing_stub_details() -> None:
+    """Signatures and Google-style sections retain useful call details."""
+    rendered = GENERATOR.generate_client_doc(TREE)
+
+    assert "### `select(*bins)`" in rendered
+    assert "| `*bins` | Bin names to include in the results. |" in rendered
+    assert "Raises `ValueError` If ``partition_id`` is outside the valid range." in rendered
+
+
+def test_markdown_note_inside_argument_is_not_a_fake_parameter() -> None:
+    """A bold ``**Note:**`` inside retry's prose stays in the retry cell."""
+    rendered = GENERATOR.generate_client_doc(TREE)
+
+    assert "| `**Note` |" not in rendered
+    assert rendered.count("**Note:** If a transport error occurs during retry") == 2
+    assert "| `retry` | Maximum number of retries" in rendered
+
+
+def test_note_section_ends_example_and_normalizes_sphinx_method_reference() -> None:
+    """batch_apply's trailing Note renders separately from its fenced example."""
+    rendered = GENERATOR.generate_client_doc(TREE)
+    start = rendered.index("### `batch_apply(")
+    end = rendered.index("\n## Query", start)
+    batch_apply = rendered[start:end]
+
+    assert "\n:::note\n" in batch_apply
+    assert "(unlike `batch_write()`, which accepts ``retry: int = 0``)." in batch_apply
+    assert "\n```python\n# Apply the same UDF" in batch_apply
+    assert "\n    Note:" not in batch_apply
+    assert ":meth:" not in rendered
+
+
+def test_plural_notes_section_is_supported() -> None:
+    """Google-style ``Notes:`` receives the same handling as ``Note:``."""
+    parsed = GENERATOR._parse_google_docstring(
+        "Summary.\n\nNotes:\n    Reuse :meth:`~Client.batch_write` only for idempotent writes."
+    )
+
+    assert parsed.summary == "Summary."
+    assert parsed.notes == ["Reuse `batch_write()` only for idempotent writes."]


### PR DESCRIPTION
## Summary

- keep the established homepage messaging and font stacks while simplifying the responsive layout
- use logo-only navigation branding, One Dark source blocks, Aerospike yellow/navy UI, and no green UI accents
- rewrite EN/KO Getting Started and improve navigation, Korean labels, readable prose, and locale-correct edit links
- fix invalid policy, batch, FastAPI, troubleshooting, port, and API examples
- complete EN/KO public API coverage and harden the API documentation generator with regression tests
- remove Context7 completely, including its widget plugin and repository configuration

## Verification

- npm run typecheck
- Docusaurus production build for EN and KO
- 6 API generator regression tests
- Python 3.14 compile checks for changed Python files
- desktop and 390px mobile browser checks in light and dark modes
- clean browser console; no horizontal overflow; no Context7 script or DOM

## Review

Ready for visual and content review. Do not merge until the requested manual review is complete.